### PR TITLE
Prefer per-release track title over recording title when tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Re-tagging from MusicBrainz now writes the per-release track title, not the
+  underlying recording title. Track titles edited on a release (e.g. cleaning up a
+  featured-artist credit) are picked up on re-tag instead of silently keeping the
+  old name.
+
 ## [1.0.0] - 2026-07-10
 
 - Initial release.

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -296,9 +296,19 @@ def _flatten_tracks(release: Release) -> Iterator[_FlatTrack]:
 
 
 def _track_title(track: Track) -> str:
-    if (recording := track.get("recording")) and (title := recording.get("title")):
+    """The track's title, preferring the per-release **track** title over the
+    underlying recording title.
+
+    This matches Picard: `track_to_metadata` seeds the title from the recording
+    and then overrides it with the track title when present. The track title is
+    what appears on *this* release — e.g. after applying MusicBrainz's featured-
+    artist style, the editor moves the guest out of the track title into the
+    artist credit, while the recording title often keeps its original form.
+    Reading the recording title instead would silently re-tag with the stale
+    name (see issue #27)."""
+    if title := track.get("title"):
         return str(title)
-    return str(track.get("title", ""))
+    return str((track.get("recording") or {}).get("title", ""))
 
 
 def _isrcs(track: Track) -> list[str]:

--- a/test/test_match.py
+++ b/test/test_match.py
@@ -179,7 +179,12 @@ def test_candidate_records_proposed_at(tmp_path):
 def test_track_comparison_has_file_and_mb_titles(tmp_path):
     album_dir = _album_with(tmp_path, 1)
     rel = _release([FIXTURE_DURATION_MS])
-    rel["medium-list"][0]["track-list"][0]["recording"]["title"] = "Song A"
+    track = rel["medium-list"][0]["track-list"][0]
+    # The per-release track title is authoritative and must win over a differing
+    # recording title (issue #27) — the assessment display would otherwise show
+    # the stale recording name.
+    track["title"] = "Song A"
+    track["recording"]["title"] = "Song A /w Someone"
     result = assess_match(album_dir, rel)
     tc = result.track_comparisons[0]
     assert tc.mb_track_title == "Song A"

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -207,6 +207,38 @@ def test_tag_album_track_artist_credit_overrides_release(album_with_tracks):
     assert track2[ATOM_ALBUM_ARTIST] == ["Test Artist"]
 
 
+def test_tag_album_prefers_track_title_over_recording_title(album_with_tracks):
+    """Regression for #27: the per-release track title wins over the recording
+    title. After an editor applies MB featured-artist style, the guest moves out
+    of the *track* title into the artist credit while the *recording* title keeps
+    its original form — re-tagging must write the track title, not the stale
+    recording title."""
+    album_dir = album_with_tracks(2)
+    release = _release_2_tracks()
+    # Track 1: release track title differs from its recording title.
+    release["medium-list"][0]["track-list"][0]["title"] = "Ground Glass"
+    release["medium-list"][0]["track-list"][0]["recording"]["title"] = (
+        "Ground Glass /w Foxes in Fiction"
+    )
+    tagger.tag_album(album_dir, release)
+
+    track1 = MP4(album_dir / "01 Track 1.m4a")
+    assert track1[ATOM_TITLE] == ["Ground Glass"]
+
+
+def test_tag_album_falls_back_to_recording_title(album_with_tracks):
+    """When a track carries no per-release title of its own, fall back to the
+    recording title rather than writing an empty title."""
+    album_dir = album_with_tracks(2)
+    release = _release_2_tracks()
+    del release["medium-list"][0]["track-list"][0]["title"]
+    release["medium-list"][0]["track-list"][0]["recording"]["title"] = "Recording Only"
+    tagger.tag_album(album_dir, release)
+
+    track1 = MP4(album_dir / "01 Track 1.m4a")
+    assert track1[ATOM_TITLE] == ["Recording Only"]
+
+
 def test_tag_album_removes_legacy_release_id(album_with_tracks):
     album_dir = album_with_tracks(1)
     f = album_dir / "01 Track 1.m4a"


### PR DESCRIPTION
## Summary

Re-tagging from MusicBrainz kept the **stale track title** when only the
per-release track title had been edited (e.g. cleaning up a featured-artist
credit): the artist updated but the title did not, and the assessment reported
an exact match while the "current MB info" display showed the old title.

`_track_title` preferred the underlying **recording** title over the per-release
**track** title — backwards from Picard, whose `track_to_metadata` seeds from the
recording then overrides with the track title. After an editor applies MB's
featured-artist style, the guest moves out of the *track* title into the artist
credit while the *recording* title keeps its original form, so Harmonist wrote
the artist from the (edited) track credit but the title from the (stale)
recording.

The fix prefers `track["title"]`, falling back to the recording title. Because
`match.py` consumes the same helper, this corrects the written tag, the
assessment display, and the MB-info view in one place.

## Tests

- `test_tagger.py`: prefer the per-release track title; fall back to the
  recording title when a track has none.
- `test_match.py`: the assessment comparison surfaces the authoritative track
  title over a differing recording title.
- `make check` green locally (599 passed).

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8