### PR TITLE
Flag on-disk vs MB title discrepancies in the verify view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- The library "verify tagging" view now flags tracks whose on-disk title differs
+  from MusicBrainz: the header reports the count instead of claiming "exact match",
+  and the differing rows are highlighted.
+
 ### Fixed
 
 - Re-tagging from MusicBrainz now writes the per-release track title, not the

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -84,6 +84,14 @@ class BandcampInfo:
     candidate_item_ids: list[int] | None = None
 
 
+def _norm_title(s: str) -> str:
+    """Light normalisation for comparing a disk title against an MB title:
+    collapse whitespace and casefold. Deliberately *not* the aggressive
+    `_norm_*` used for matching — here we want to surface real differences, so
+    only cosmetic noise (spacing, case) is ignored."""
+    return " ".join(s.split()).casefold()
+
+
 @dataclass
 class TrackComparison:
     """One row in a side-by-side files-vs-MB-release comparison.
@@ -99,6 +107,15 @@ class TrackComparison:
     mb_track_title: str | None
     mb_track_length_ms: int | None
     delta_ms: int | None  # None when either side's length is unknown
+
+    @property
+    def title_differs(self) -> bool:
+        """True when both titles are present and differ after light
+        normalisation. A padding row (either side missing) is a count mismatch,
+        not a metadata discrepancy, so it returns False. Derived, never stored."""
+        if not self.file_title or not self.mb_track_title:
+            return False
+        return _norm_title(self.file_title) != _norm_title(self.mb_track_title)
 
 
 @dataclass
@@ -139,6 +156,14 @@ class MatchCandidate:
     # Load-bearing: drives that read-only render. Distinct from a mis-tag (where
     # the candidate is a *different*, confirmable release).
     unmatched_purchase: bool = False
+
+    @property
+    def title_mismatch_count(self) -> int:
+        """How many track rows have an on-disk title that differs from MB.
+        Derived from `track_comparisons`, never stored — lets the verify-tagging
+        view flag a metadata discrepancy that the length-based `confidence`
+        can't see."""
+        return sum(1 for tc in self.track_comparisons if tc.title_differs)
 
 
 @dataclass

--- a/templates/partials/_track_comparison.html
+++ b/templates/partials/_track_comparison.html
@@ -21,13 +21,18 @@
             {% elif tc.delta_ms is not none %}
                 {% set delta_class = 'text-accent font-semibold' %}
             {% endif %}
+            {# Flag on-disk titles that differ from MB — only where the caller asks
+               (the verify-tagging view), so the pre-link suggestion card, where
+               differing titles are normal, stays uncluttered. #}
+            {% set title_diff = highlight_titles | default(false) and tc.title_differs %}
+            {% set title_class = 'text-amber-700 font-semibold' if title_diff else 'text-ink' %}
             <tr class="border-b border-line last:border-0">
                 <td class="py-1 px-2 font-mono text-muted">{{ loop.index }}</td>
-                <td class="py-1 px-2 text-ink truncate max-w-xs">
+                <td class="py-1 px-2 truncate max-w-xs {{ title_class }}">
                     {% if tc.file_title %}{{ tc.file_title }}{% else %}<span class="text-muted italic">— missing —</span>{% endif %}
                 </td>
                 <td class="py-1 px-2 font-mono text-muted">{% if tc.file_duration_ms is not none %}{{ '%d:%02d' | format(tc.file_duration_ms // 60000, (tc.file_duration_ms // 1000) % 60) }}{% else %}—{% endif %}</td>
-                <td class="py-1 px-2 text-ink truncate max-w-xs">
+                <td class="py-1 px-2 truncate max-w-xs {{ title_class }}">
                     {% if tc.mb_track_title %}{{ tc.mb_track_title }}{% else %}<span class="text-muted italic">— missing —</span>{% endif %}
                 </td>
                 <td class="py-1 px-2 font-mono text-muted">{% if tc.mb_track_length_ms is not none %}{{ '%d:%02d' | format(tc.mb_track_length_ms // 60000, (tc.mb_track_length_ms // 1000) % 60) }}{% else %}<span class="text-muted">?</span>{% endif %}</td>

--- a/templates/partials/library_compare.html
+++ b/templates/partials/library_compare.html
@@ -2,14 +2,23 @@
    `candidate` is a freshly-computed MatchCandidate (disk vs the tagged MB
    release) — computed on demand, never persisted (sidecar-minimalism). #}
 <div class="mt-2 rounded border border-line p-2 bg-white">
+    {% set title_diffs = candidate.title_mismatch_count %}
     <div class="text-2xs text-muted mb-1">
         On disk vs MusicBrainz —
-        {% if candidate.confidence == 'exact' %}
+        {% if candidate.confidence == 'exact' and title_diffs == 0 %}
         <span class="text-accent font-bold">exact match</span>
         {% else %}
+        {# "exact" here is purely the length/track-fit verdict; say so plainly
+           rather than "exact match" when the metadata (titles) actually differs. #}
+        {% if candidate.confidence == 'exact' %}
+        <span class="text-muted font-semibold">lengths match</span>
+        {% else %}
         <span class="text-amber-700 font-bold">{{ candidate.confidence }}</span>
+        {% endif %}
         {% for note in candidate.notes %}<span> · {{ note }}</span>{% endfor %}
+        {% if title_diffs %}<span class="text-amber-700 font-bold"> · {{ title_diffs }} title difference{{ 's' if title_diffs != 1 }}</span>{% endif %}
         {% endif %}
     </div>
+    {% set highlight_titles = true %}
     {% include 'partials/_track_comparison.html' %}
 </div>

--- a/test/test_match.py
+++ b/test/test_match.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 
 from harmonist.match import _mb_track_length_ms, assess_match, best_match
+from harmonist.models import MatchCandidate, TrackComparison
 from harmonist.tagger import ATOM_TITLE
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -275,3 +276,57 @@ def test_best_match_breaks_count_ties_on_closest_lengths(tmp_path):
     result = best_match(album_dir, [far, close])
     assert result is not None
     assert result.mb_release_id == "rel-close"
+
+
+# -- title-discrepancy signal (issue #29) --
+
+
+def _tc(file_title: str | None, mb_title: str | None) -> TrackComparison:
+    return TrackComparison(
+        file_name="x.m4a",
+        file_duration_ms=1000,
+        file_title=file_title,
+        mb_track_title=mb_title,
+        mb_track_length_ms=1000,
+        delta_ms=0,
+    )
+
+
+def test_title_differs_flags_real_difference():
+    assert _tc("Ground Glass [w/ Foxes in Fiction]", "Ground Glass").title_differs is True
+
+
+def test_title_differs_ignores_case_and_whitespace():
+    assert _tc("Ground  Glass", "ground glass").title_differs is False
+
+
+def test_title_differs_false_when_a_side_is_missing():
+    # Padding rows (count mismatch) are not a metadata discrepancy.
+    assert _tc(None, "Ground Glass").title_differs is False
+    assert _tc("Ground Glass", None).title_differs is False
+
+
+def test_title_mismatch_count_sums_differing_rows():
+    cand = MatchCandidate(
+        mb_release_id="rel",
+        confidence="exact",
+        file_count=3,
+        track_count=3,
+        track_comparisons=[
+            _tc("Same", "Same"),
+            _tc("Ground Glass [w/ Foxes in Fiction]", "Ground Glass"),
+            _tc("Etalon [w/ Foxes in Fiction]", "Etalon"),
+        ],
+    )
+    assert cand.title_mismatch_count == 2
+
+
+def test_title_mismatch_count_zero_on_clean_match():
+    cand = MatchCandidate(
+        mb_release_id="rel",
+        confidence="exact",
+        file_count=1,
+        track_count=1,
+        track_comparisons=[_tc("Same Title", "Same Title")],
+    )
+    assert cand.title_mismatch_count == 0

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -18,7 +18,13 @@ from mutagen.mp4 import MP4
 from harmonist import sidecar as sc
 from harmonist.config import BandcampConfig, Config, PathsConfig, ServerConfig, TestConfig
 from harmonist.models import BandcampInfo, MatchCandidate, Sidecar, TrackComparison
-from harmonist.tagger import ATOM_ALBUM, ATOM_ARTIST, ATOM_COMMENT, ATOM_MB_ALBUM_ID
+from harmonist.tagger import (
+    ATOM_ALBUM,
+    ATOM_ARTIST,
+    ATOM_COMMENT,
+    ATOM_MB_ALBUM_ID,
+    ATOM_TITLE,
+)
 from harmonist.web.main import create_app
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -2787,6 +2793,35 @@ def test_library_compare_renders_side_by_side(client, cfg, monkeypatch):
     assert r.status_code == 200
     assert "On disk vs MusicBrainz" in r.text
     assert "Track 1" in r.text
+
+
+def test_library_compare_flags_title_discrepancy(client, cfg, monkeypatch):
+    """When on-disk track titles differ from MB (e.g. a featured-artist tidy-up
+    on MB after tagging), the verify view must not claim 'exact match' — it
+    reports the metadata difference even though lengths line up (issue #29)."""
+    d = _make_tagged_album(cfg, "Mismatch", mbid="rel-mm", tagged_at=datetime.now(UTC))
+    audio = MP4(d / "01 Track.m4a")
+    audio[ATOM_TITLE] = ["Ground Glass [w/ Foxes in Fiction]"]
+    audio.save()
+
+    def fake_release(mbid):
+        return {
+            "id": mbid,
+            "title": "Mismatch",
+            "medium-list": [
+                {
+                    "position": "1",
+                    # MB has the cleaned-up title; the file still carries the old one.
+                    "track-list": [{"id": "t1", "title": "Ground Glass", "length": "1000"}],
+                }
+            ],
+        }
+
+    monkeypatch.setattr("harmonist.web.main.mb_lookup.fetch_release", fake_release)
+    r = client.get(f"/library/{_id_for(cfg, d)}/compare")
+    assert r.status_code == 200
+    assert "title difference" in r.text
+    assert "exact match" not in r.text
 
 
 def test_library_detail_auto_loads_track_comparison(client, cfg):


### PR DESCRIPTION
## Summary

The library "verify tagging" comparison derived its verdict only from track count
and length deltas, so it reported **"exact match"** even when on-disk titles
differed from MusicBrainz — e.g. after tidying a featured-artist credit on MB
(`Ground Glass [w/ Foxes in Fiction]` on disk vs `Ground Glass` on MB). That's
misleading: a re-tag *would* change something.

- New derived, non-persisted signals: `TrackComparison.title_differs` and
  `MatchCandidate.title_mismatch_count` (light whitespace/case normalisation).
- Verify-view header now reads **"lengths match · N title differences"** instead of
  "exact match", and the differing rows are highlighted amber (like the length Δ).
- Gated to the verify view via a `highlight_titles` flag, so the pre-link
  suggestion card — where differing titles are normal — stays uncluttered.
- **Matching confidence is unchanged** (still length-based, per design §2). This is
  recognition/display only.

Detecting/displaying differences in **non-visible** metadata fields (artist, album,
dates) is deferred to #30.

## Tests

- `test_match.py`: `title_differs` (real diff, case/whitespace, missing side) and
  `title_mismatch_count`.
- `test_web.py`: the verify view flips to "title difference" (not "exact match")
  when the on-disk tag diverges from MB.
- `make check` green (605 passed); CSS unchanged.

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8