### PR TITLE
Fix modal action buttons that closed without performing their action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Album-detail actions that close the modal (Unlink, and the new per-badge
+  wrong-match controls) now actually perform their action. Previously the modal
+  closed before the request could fire, so the control did nothing.
 - Manual "Re-tag from MB" now shows a progress spinner while it runs and refreshes
   the album details view when it finishes, so the disk-vs-MusicBrainz comparison
   reflects the just-written tags without reopening the album.

--- a/templates/partials/library_detail.html
+++ b/templates/partials/library_detail.html
@@ -43,7 +43,7 @@
                 {# Wrong MB release → back to Needs MBID to re-pick. Rare, so subtle
                    (muted until hover); confirms first to guard against a mis-click. #}
                 <button type="button" hx-post="/library/{{ album.id }}/rematch"
-                        hx-swap="none" hx-disabled-elt="this" onclick="harmonistCloseModal()"
+                        hx-swap="none" hx-disabled-elt="this" hx-on::after-request="if (event.detail.successful) harmonistCloseModal()"
                         hx-confirm="Wrong MusicBrainz release? The album goes back to Needs MBID so you can pick the correct one. Your files keep their current tags until you re-tag."
                         title="Wrong MusicBrainz match — pick the correct release"
                         aria-label="Wrong MusicBrainz match — pick the correct release"
@@ -86,7 +86,7 @@
                    a link to forget. Subtle × grouped with the badge; confirms first. #}
                 {% if bc and bc.item_id is not none %}
                 <button type="button" hx-post="/library/{{ album.id }}/unlink" hx-vals='{"forget_url": "true"}'
-                        hx-swap="none" hx-disabled-elt="this" onclick="harmonistCloseModal()"
+                        hx-swap="none" hx-disabled-elt="this" hx-on::after-request="if (event.detail.successful) harmonistCloseModal()"
                         hx-confirm="Wrong Bandcamp purchase? Unlink AND forget the store URL. The album stays correctly tagged in your Library, no future sync will re-link it, and the purchase reappears as a potential download so you can match it correctly."
                         title="Wrong Bandcamp purchase — forget this link"
                         aria-label="Wrong Bandcamp purchase — forget this link"
@@ -168,7 +168,7 @@
                 {% if bc and bc.item_id is not none %}
                 <button hx-post="/library/{{ album.id }}/unlink"
                         hx-swap="none" hx-disabled-elt="this"
-                        onclick="harmonistCloseModal()"
+                        hx-on::after-request="if (event.detail.successful) harmonistCloseModal()"
                         hx-confirm="Unlink this album from its Bandcamp purchase? It reverts to Needs Link — tags and store URL are kept, so the next sync can re-link it."
                         class="px-3 py-1.5 bg-surface hover:bg-line text-ink border border-line rounded text-xs font-bold uppercase tracking-widest transition">
                     Unlink

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2061,6 +2061,27 @@ def test_library_detail_wrong_match_controls_beside_badges(client, cfg):
     assert "Wrong match" not in html  # old ambiguous button is gone
 
 
+def test_library_detail_modal_actions_close_after_success_not_onclick(client, cfg):
+    """Regression for #40: modal action buttons that close the modal must do so via
+    hx-on::after-request (after htmx has run its confirm + request), NOT via
+    onclick. An onclick that wipes #modal detaches the button before htmx's
+    delegated handler runs, so the confirm never shows and the request never
+    fires — the control silently does nothing but close the modal."""
+    import re
+
+    d = _make_tagged_album(cfg, "ModalActs", mbid="rel-ma", tagged_at=datetime.now(UTC), item_id=5)
+    html = client.get(f"/library/{_id_for(cfg, d)}/detail").text
+    assert "/rematch" in html
+    assert "forget_url" in html
+    # No hx-post *action* button may use onclick to close (that detaches it before
+    # htmx runs). The modal's own pure-close × button (no hx-post) is fine.
+    action_buttons = re.findall(r"<button[^>]*\shx-post[^>]*>", html)
+    assert action_buttons
+    assert all("onclick=" not in b for b in action_buttons)
+    # The ones that close after acting use hx-on::after-request instead.
+    assert any("hx-on::after-request" in b for b in action_buttons)
+
+
 # ---------- retag / forget ----------
 
 


### PR DESCRIPTION
## Summary

The album-detail buttons that close the modal — the #37/#38 per-badge wrong-match
controls **and** the pre-existing "Unlink" — did nothing except close the modal.

**Root cause (verified in a real browser):** they carried
`onclick="harmonistCloseModal()"` alongside `hx-post`/`hx-confirm`.
`harmonistCloseModal()` sets `#modal.innerHTML = ""`, detaching the button before
htmx's delegated click handler runs, so htmx never showed the confirm and never sent
the request. Reproduced: clicking the pencil emptied the modal (9906 → 0 chars),
`confirm` was never called, and no `/rematch` POST fired.

**Fix:** replace `onclick` with
`hx-on::after-request="if (event.detail.successful) harmonistCloseModal()"`, so htmx
runs the confirm + request normally and the modal closes only after success (and
stays open on cancel).

## Verification

Re-tested in-browser after the fix:
- **Cancel** → confirm shows, modal stays, no POST.
- **Confirm** → POST fires, album demotes to Needs MBID, status bar reports it, the
  album leaves the Library, modal closes.

Added a regression test asserting no `hx-post` action button uses the onclick-close
pattern and that the closing ones use `hx-on::after-request`. `make check` green
(612 passed).

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8