### PR TITLE
Length Δ in whole seconds; mute within-tolerance differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Changed
 
+- The disk-vs-MusicBrainz length Δ column now shows whole seconds, and a
+  within-tolerance difference is muted (the lengths are effectively the same) while
+  an over-tolerance difference stays highlighted.
 - The ambiguous "Wrong match" button in the album detail is gone. Correcting a wrong
   MusicBrainz release is now a pencil beside the MusicBrainz badge (see Added). The
   Bandcamp link-removal controls (the old "Wrong match" and "Unlink") are temporarily

--- a/templates/partials/_track_comparison.html
+++ b/templates/partials/_track_comparison.html
@@ -15,11 +15,12 @@
         </thead>
         <tbody>
             {% for tc in candidate.track_comparisons %}
+            {# Only an over-tolerance gap is worth flagging. A within-tolerance
+               difference is muted — these lengths are "the same" (> 4000ms mirrors
+               match.LENGTH_TOLERANCE_MS). #}
             {% set delta_class = 'text-muted' %}
             {% if tc.delta_ms is not none and tc.delta_ms > 4000 %}
                 {% set delta_class = 'text-amber-700 font-bold' %}
-            {% elif tc.delta_ms is not none %}
-                {% set delta_class = 'text-accent font-semibold' %}
             {% endif %}
             {# Flag on-disk titles that differ from MB — only where the caller asks
                (the verify-tagging view), so the pre-link suggestion card, where
@@ -36,7 +37,8 @@
                     {% if tc.mb_track_title %}{{ tc.mb_track_title }}{% else %}<span class="text-muted italic">— missing —</span>{% endif %}
                 </td>
                 <td class="py-1 px-2 font-mono text-muted">{% if tc.mb_track_length_ms is not none %}{{ '%d:%02d' | format(tc.mb_track_length_ms // 60000, (tc.mb_track_length_ms // 1000) % 60) }}{% else %}<span class="text-muted">?</span>{% endif %}</td>
-                <td class="py-1 px-2 font-mono {{ delta_class }}">{% if tc.delta_ms is not none %}{{ '%+.1fs' | format(tc.delta_ms / 1000) }}{% else %}—{% endif %}</td>
+                {# Whole seconds only (delta_ms is an absolute magnitude), rounded. #}
+                <td class="py-1 px-2 font-mono {{ delta_class }}">{% if tc.delta_ms is not none %}{{ '%ds' | format((tc.delta_ms + 500) // 1000) }}{% else %}—{% endif %}</td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
The disk-vs-MusicBrainz comparison showed the length Δ at sub-second precision (e.g. "+0.0s"), finer than track lengths warrant, and rendered within-tolerance differences in accent+semibold — making a sub-second gap look as notable as a real one.

Now the Δ shows whole (rounded) seconds, and the two buckets read distinctly: a within-tolerance difference is muted (the lengths are effectively the same), while an over-tolerance one (`> LENGTH_TOLERANCE_MS`, 4s) stays amber+bold. Display only — matching and the confidence verdict are unchanged.

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8