### PR TITLE
Persistent SQLite activity + audit store (#33 increment 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- The activity feed now persists across restarts, backed by a SQLite store
+  (`activity.db`) in the config dir; audit records (downloads, file/tag rewrites,
+  demotions) are written there durably too, so the record of what Harmonist did
+  survives a restart. The feed still shows only user-facing activity, not audit
+  detail.
+
 ### Fixed
 
 - "Move to Library" no longer flickers the inbox — the album now resolves in a

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ services:
       - "8000:8000"
     volumes:
       - /path/to/music:/music     # your music library
-      - /path/to/config:/config   # persistent: harmonist.toml, cookies.txt, ignores.txt, id registry
+      - /path/to/config:/config   # persistent: harmonist.toml, cookies.txt, ignores.txt, id registry, activity.db
     # Run as the OWNER of the two host dirs above, so sidecars, tags and cover.*
     # files aren't written as root. `id -u` / `id -g` to find yours; omit to run
     # as root. (Synology: usually a 1026+ uid and gid 100 — the `users` group.)

--- a/src/harmonist/activity.py
+++ b/src/harmonist/activity.py
@@ -1,27 +1,23 @@
-"""In-memory activity log — a bounded ring buffer of recent events.
+"""The user-facing activity feed — action outcomes plus mirrored WARNING/ERROR
+log records so background failures are visible.
 
-Process-level only (NOT persisted to sidecars — see the sidecar-minimalism
-rule). Lost on restart, which is fine for a "recent activity" feed. Fed from
-two places: action outcomes (every `_flash_response` in the web layer) and a
-logging handler that mirrors harmonist's own WARNING/ERROR log records so
-background failures show up too.
+Durability lives in `activity_store` (a shared SQLite store, issue #33): `record()`
+appends there tagged `source="activity"`, and `recent()` reads those rows back, so
+the feed survives a restart. This module keeps the public API (`record`, `recent`,
+`Event`, `clear`, `install_log_handler`) and adds the log mirroring on top.
 
-Thread-safe: the sync / reconcile runners append from worker threads.
+Thread-safe: the store serialises appends; the sync / reconcile runners record from
+worker threads.
 """
 
 from __future__ import annotations
 
 import logging
-import threading
-from collections import deque
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 
-# Sized so a bulk pass (e.g. a ~130-album reconcile, which now records a
-# per-album transition each) doesn't evict the notable events — mis-tags,
-# surrenders, sync results — that share the feed. The server log keeps
-# everything regardless; this is the in-memory glance.
-_MAX_EVENTS = 1000
+from . import activity_store
+from .activity_store import Source
 
 _Level = str  # "info" | "warning" | "error"
 
@@ -33,9 +29,6 @@ class Event:
     message: str
 
 
-_LOCK = threading.Lock()
-_EVENTS: deque[Event] = deque(maxlen=_MAX_EVENTS)
-
 log = logging.getLogger(__name__)
 _LOG_LEVELS = {"info": logging.INFO, "warning": logging.WARNING, "error": logging.ERROR}
 
@@ -46,25 +39,23 @@ def record(message: str, level: _Level = "info") -> None:
     message = (message or "").strip()
     if not message:
         return
-    with _LOCK:
-        _EVENTS.append(Event(ts=datetime.now(UTC), level=level, message=message))
+    activity_store.append(message=message, level=level, source=Source.ACTIVITY)
     # Mirror to the log. The `_activity` flag stops _ActivityLogHandler from
     # re-recording it (which would feed back into this function — a loop).
     log.log(_LOG_LEVELS.get(level, logging.INFO), "%s", message, extra={"_activity": True})
 
 
 def recent(limit: int = 100) -> list[Event]:
-    """Most-recent-first list of up to `limit` events."""
-    with _LOCK:
-        items = list(_EVENTS)
-    items.reverse()
-    return items[:limit]
+    """Most-recent-first list of up to `limit` activity events."""
+    return [
+        Event(ts=e.ts, level=e.level, message=e.message)
+        for e in activity_store.recent(limit, source=Source.ACTIVITY)
+    ]
 
 
 def clear() -> None:
-    """Drop all events (used by tests / demo reset)."""
-    with _LOCK:
-        _EVENTS.clear()
+    """Drop all stored events (used by tests / demo reset)."""
+    activity_store.clear()
 
 
 class _ActivityLogHandler(logging.Handler):

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -1,0 +1,198 @@
+"""Durable, append-only event store (SQLite) behind the activity feed and audit log.
+
+Both `activity.record()` and `audit.record()` append here, tagged by `source`
+("activity" | "audit"), so what Harmonist did survives a restart — the point of
+issue #33. The activity feed reads recent `source="activity"` rows directly (no
+in-memory buffer): a bounded `ORDER BY id DESC LIMIT n` on an indexed table is
+cheap, and dropping the ring buffer trims memory.
+
+A *separate* store, not sidecar fields — consistent with sidecar-minimalism.
+
+Thread-safe: the sync / reconcile / scan runners append from worker threads while
+request handlers read. One shared connection (`check_same_thread=False`) guarded by
+a lock; WAL mode so a reader never blocks a writer at the SQLite level.
+
+Until `init()` points it at a file (done once at app start), the store falls back to
+an in-memory database so `record()` still works in unit tests and non-web contexts —
+ephemeral, exactly like the old ring buffer.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+class Source(StrEnum):
+    """Which log a stored event belongs to. The feed shows ACTIVITY; AUDIT is the
+    durable forensic trail (both share this store, distinguished by this column)."""
+
+    ACTIVITY = "activity"
+    AUDIT = "audit"
+
+
+# TODO(#47): make this a StrEnum too — deferred because `level` is set at ~30
+# flash/record sites across the web layer; that conversion is its own change.
+_Level = str  # "info" | "warning" | "error"
+
+_LOCK = threading.Lock()
+_conn: sqlite3.Connection | None = None
+
+# Forward-only schema migrations, applied via SQLite's built-in `PRAGMA
+# user_version`. Entry i takes the DB from user_version i to i+1. On open, every
+# migration past the DB's current version is applied in order, so an `activity.db`
+# created by an older Harmonist upgrades in place. RULES: never edit or reorder a
+# shipped entry — a schema change is always a NEW appended migration. Keep each
+# migration's statements idempotent-free (they run exactly once, tracked by
+# user_version). This is the responsible, dependency-free equivalent of Rails
+# migrations for a small SQLite store.
+_MIGRATIONS: tuple[tuple[str, ...], ...] = (
+    # 0 -> 1: initial events table (durable activity + audit feed, issue #33).
+    (
+        """CREATE TABLE events (
+            id      INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts      TEXT NOT NULL,
+            level   TEXT NOT NULL,
+            source  TEXT NOT NULL,
+            message TEXT NOT NULL
+        )""",
+        "CREATE INDEX idx_events_source_id ON events (source, id)",
+    ),
+)
+
+SCHEMA_VERSION = len(_MIGRATIONS)  # the version this build expects/creates
+
+
+@dataclass(frozen=True)
+class StoredEvent:
+    ts: datetime
+    level: _Level
+    source: Source
+    message: str
+
+
+def _migrate(conn: sqlite3.Connection) -> None:
+    """Bring `conn` up to SCHEMA_VERSION by applying pending forward migrations.
+    Each step (its DDL + the user_version bump) commits atomically. Refuses a DB
+    newer than this build understands, so a downgrade never writes a schema it
+    can't honour."""
+    (version,) = conn.execute("PRAGMA user_version").fetchone()
+    if version > SCHEMA_VERSION:
+        raise RuntimeError(
+            f"activity.db schema is at v{version}, newer than this build supports "
+            f"(v{SCHEMA_VERSION}) — refusing to open it"
+        )
+    for target in range(version, SCHEMA_VERSION):
+        conn.execute("BEGIN")
+        try:
+            for stmt in _MIGRATIONS[target]:
+                conn.execute(stmt)
+            # PRAGMA can't take a bind param; target+1 is a controlled int.
+            conn.execute(f"PRAGMA user_version = {target + 1}")
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+
+def _open(db: str) -> sqlite3.Connection:
+    # autocommit (isolation_level=None) so single appends persist immediately and
+    # _migrate can drive its own BEGIN/COMMIT explicitly.
+    conn = sqlite3.connect(db, check_same_thread=False, isolation_level=None)
+    conn.execute("PRAGMA journal_mode=WAL")
+    _migrate(conn)
+    return conn
+
+
+def init(db_path: Path | str) -> None:
+    """Point the store at a file (call once at app start): create the parent dir,
+    open the DB, and run migrations. Replaces any prior connection. If the DB can't
+    be opened/migrated (e.g. a newer schema after a downgrade), degrade to an
+    in-memory store and log loudly — the app still starts, just without durable
+    history — rather than crash or corrupt the file."""
+    global _conn
+    try:
+        path = Path(db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        conn = _open(str(path))
+    except Exception:
+        log.exception(
+            "activity store: could not open %s — falling back to in-memory (history "
+            "will not persist)",
+            db_path,
+        )
+        conn = _open(":memory:")
+    with _LOCK:
+        old, _conn = _conn, conn
+    if old is not None:
+        try:
+            old.close()
+        except sqlite3.Error:
+            pass
+
+
+def _ensure() -> sqlite3.Connection:
+    global _conn
+    if _conn is None:
+        # No app has initialised a file-backed store — fall back to an ephemeral
+        # in-memory DB so record() never fails (matches the old ring buffer).
+        _conn = _open(":memory:")
+    return _conn
+
+
+def append(*, message: str, level: _Level, source: Source) -> None:
+    """Append one event. Best-effort: a failure here (e.g. a teardown race in
+    tests) must never crash the caller or the logging path."""
+    message = (message or "").strip()
+    if not message:
+        return
+    ts = datetime.now(UTC).isoformat()
+    try:
+        conn = _ensure()
+        with _LOCK:
+            conn.execute(
+                "INSERT INTO events (ts, level, source, message) VALUES (?, ?, ?, ?)",
+                (ts, level, source.value, message),
+            )
+            conn.commit()
+    except sqlite3.Error:
+        log.debug("activity_store append failed", exc_info=True, extra={"_activity": True})
+
+
+def recent(limit: int = 100, *, source: Source | None = None) -> list[StoredEvent]:
+    """Most-recent-first events, optionally filtered by source."""
+    q = "SELECT ts, level, source, message FROM events"
+    args: list[object] = []
+    if source is not None:
+        q += " WHERE source = ?"
+        args.append(source.value)
+    q += " ORDER BY id DESC LIMIT ?"
+    args.append(limit)
+    try:
+        conn = _ensure()
+        with _LOCK:
+            rows = conn.execute(q, args).fetchall()
+    except sqlite3.Error:
+        return []
+    return [
+        StoredEvent(ts=datetime.fromisoformat(ts), level=level, source=Source(src), message=msg)
+        for ts, level, src, msg in rows
+    ]
+
+
+def clear() -> None:
+    """Drop all events (tests / demo reset)."""
+    try:
+        conn = _ensure()
+        with _LOCK:
+            conn.execute("DELETE FROM events")
+            conn.commit()
+    except sqlite3.Error:
+        pass

--- a/src/harmonist/audit.py
+++ b/src/harmonist/audit.py
@@ -8,29 +8,38 @@ transparency (the project's guiding principle): when something unexpected
 happens to the library, there is a precise, timestamped record of exactly what
 Harmonist did and when.
 
-Separate from ``activity`` (the in-memory, user-facing feed). Audit lines go to
-the server log only, at INFO, under one logger name so they're trivial to filter
-(``grep harmonist.audit``).
+Audit lines go to the server log (INFO, under one logger name so they're trivial to
+filter — ``grep harmonist.audit``) AND to the durable `activity_store` (issue #33)
+tagged ``source="audit"``, so the record of what Harmonist did to user data survives
+a restart and log rotation. It's the same one-line ``event key=value …`` string in
+both places. Distinct from the ``activity`` feed, which stores the user-facing
+outcomes (``source="activity"``) and does not show audit rows.
 """
 
 from __future__ import annotations
 
 import logging
 
+from . import activity_store
+from .activity_store import Source
+
 log = logging.getLogger("harmonist.audit")
 
 
 def record(event: str, **fields: object) -> None:
-    """Log one audit event as ``event key=value …``.
+    """Record one audit event as ``event key=value …`` — to the server log and to
+    the durable store.
 
     Values containing whitespace (album paths!) are quoted so each event stays a
     single, parseable line. None is rendered as ``-``.
     """
-    if not fields:
-        log.info("%s", event)
-        return
-    detail = " ".join(f"{key}={_fmt(value)}" for key, value in fields.items())
-    log.info("%s %s", event, detail)
+    line = event if not fields else f"{event} {_detail(fields)}"
+    log.info("%s", line)
+    activity_store.append(message=line, level="info", source=Source.AUDIT)
+
+
+def _detail(fields: dict[str, object]) -> str:
+    return " ".join(f"{key}={_fmt(value)}" for key, value in fields.items())
 
 
 def _fmt(value: object) -> str:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -27,6 +27,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from harmonist import (
     activity,
+    activity_store,
     audit,
     cover_art,
     formats,
@@ -204,6 +205,9 @@ def create_app(
 
     _configure_logging(cfg)
     mb_lookup.configure(cfg.musicbrainz.user_agent)
+    # Durable activity + audit store (issue #33) — point it at the config dir before
+    # anything records, so nothing is lost and the feed survives restarts.
+    activity_store.init(cfg.paths.config_dir / "activity.db")
     activity.install_log_handler()
 
     sync_runner = SyncRunner(runner_fn=lambda: None)  # placeholder, replaced below

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -1,0 +1,121 @@
+"""Tests for the durable activity/audit store (issue #33)."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from harmonist import activity, activity_store, audit
+from harmonist.activity_store import Source
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store(tmp_path):
+    """Point the store at a fresh file per test and reset it afterwards."""
+    activity_store.init(tmp_path / "activity.db")
+    activity_store.clear()
+    yield
+    activity_store.clear()
+
+
+def test_append_and_recent_roundtrip():
+    activity_store.append(message="hello", level="info", source=Source.ACTIVITY)
+    events = activity_store.recent()
+    assert [e.message for e in events] == ["hello"]
+    assert events[0].level == "info"
+    assert events[0].source == "activity"
+
+
+def test_recent_is_most_recent_first_and_respects_limit():
+    for i in range(5):
+        activity_store.append(message=f"e{i}", level="info", source=Source.ACTIVITY)
+    msgs = [e.message for e in activity_store.recent(limit=3)]
+    assert msgs == ["e4", "e3", "e2"]  # newest first, capped at 3
+
+
+def test_source_filter_separates_activity_and_audit():
+    activity_store.append(message="user action", level="info", source=Source.ACTIVITY)
+    activity_store.append(message="download url=x", level="info", source=Source.AUDIT)
+    assert [e.message for e in activity_store.recent(source=Source.ACTIVITY)] == ["user action"]
+    assert [e.message for e in activity_store.recent(source=Source.AUDIT)] == ["download url=x"]
+    assert {e.message for e in activity_store.recent()} == {"user action", "download url=x"}
+
+
+def test_blank_messages_are_dropped():
+    activity_store.append(message="   ", level="info", source=Source.ACTIVITY)
+    activity_store.append(message="", level="info", source=Source.ACTIVITY)
+    assert activity_store.recent() == []
+
+
+def test_survives_reopen(tmp_path):
+    """The whole point of #33: events persist across a restart (a fresh
+    connection to the same file still sees them)."""
+    db = tmp_path / "persist.db"
+    activity_store.init(db)
+    activity_store.clear()
+    activity_store.append(message="before restart", level="warning", source=Source.AUDIT)
+
+    activity_store.init(db)  # simulate a restart: new connection, same file
+    events = activity_store.recent()
+    assert [e.message for e in events] == ["before restart"]
+    assert events[0].level == "warning"
+
+
+def test_activity_record_stores_as_activity_source():
+    activity.record("did a thing")
+    assert [e.message for e in activity_store.recent(source=Source.ACTIVITY)] == ["did a thing"]
+    # The user feed reads it back.
+    assert [e.message for e in activity.recent()] == ["did a thing"]
+
+
+def test_audit_record_stores_as_audit_and_is_absent_from_the_feed():
+    audit.record("tagged", album="/music/The Album", mbid="rel-1")
+    stored = activity_store.recent(source=Source.AUDIT)
+    assert len(stored) == 1
+    # key=value; a path with whitespace is quoted so the line stays parseable.
+    assert stored[0].message == 'tagged album="/music/The Album" mbid=rel-1'
+    # The user-facing activity feed does NOT surface audit rows.
+    assert activity.recent() == []
+
+
+def test_clear_empties_the_store():
+    activity_store.append(message="x", level="info", source=Source.ACTIVITY)
+    activity_store.clear()
+    assert activity_store.recent() == []
+
+
+def _user_version(db) -> int:
+    conn = sqlite3.connect(db, isolation_level=None)
+    try:
+        (v,) = conn.execute("PRAGMA user_version").fetchone()
+        return int(v)
+    finally:
+        conn.close()
+
+
+def test_fresh_db_is_migrated_to_current_schema_version(tmp_path):
+    db = tmp_path / "ver.db"
+    activity_store.init(db)
+    activity_store.append(message="x", level="info", source=Source.ACTIVITY)
+    assert activity_store.SCHEMA_VERSION >= 1
+    assert _user_version(db) == activity_store.SCHEMA_VERSION
+
+
+def test_downgrade_guard_falls_back_to_memory_without_crashing(tmp_path):
+    """A DB stamped newer than this build understands (a Harmonist downgrade) must
+    not be written to or crash startup — the store degrades to in-memory."""
+    db = tmp_path / "future.db"
+    conn = sqlite3.connect(db, isolation_level=None)
+    conn.execute(f"PRAGMA user_version = {activity_store.SCHEMA_VERSION + 5}")
+    conn.close()
+
+    activity_store.init(db)  # must not raise
+    activity_store.append(message="still works", level="info", source=Source.ACTIVITY)
+    assert [e.message for e in activity_store.recent()] == ["still works"]
+
+    # The future-versioned file was left untouched — no events table written to it.
+    conn = sqlite3.connect(db)
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+    assert "events" not in tables


### PR DESCRIPTION
First increment of #33. Adds `activity_store`: an append-only SQLite store in the config dir (`activity.db`) that both `activity.record` and `audit.record` write to, tagged by a `Source` StrEnum. The user-facing feed reads `source="activity"` rows directly (dropping the in-memory ring buffer), so it survives restarts, and the audit record of what Harmonist did to user files is durable — not server-log only. The feed never surfaces audit detail.

Schema evolution uses SQLite's `PRAGMA user_version` plus an append-only list of forward migrations applied on open, each step atomic — the stdlib, dependency-free equivalent of Rails migrations. A DB newer than this build understands (a downgrade) degrades to an in-memory store and logs it, rather than crash or corrupt the file.

Synchronous by design: handlers are sync (Starlette threadpool), so the blocking sqlite call never touches the event loop; one WAL connection guarded by a lock serialises the runner threads. Best-effort writes never crash the caller; the audit server-log line remains a backstop.

10 store tests (round-trip, source filter, restart persistence, migration, downgrade guard). `make check` green (622).

Part of #33 — the issue stays open for the follow-ups (per-album `album_id` + the #14 filter, a `Level` StrEnum #47, retention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8