### PR TITLE
No inbox flicker on Move to Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- "Move to Library" no longer flickers the inbox — the album now resolves in a
+  single render instead of triggering a background rescan that briefly dimmed and
+  reloaded the list.
+
 ## [1.0.1] - 2026-07-28
 
 ### Added

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -150,6 +150,24 @@ LIBRARY: list[dict[str, Any]] = [
         },
     },
     {
+        # State: NEEDS_MBID via SURRENDER — a sync couldn't match this owned
+        # purchase (withdrawn from Bandcamp), so it was dropped back with a
+        # read-only "couldn't link" candidate. Its store_url is deliberately NOT a
+        # known purchase, so a sync never re-links it. "Move to Library"
+        # (surrender_keep) accepts it as a terminal Library album — the action that
+        # must resolve without an inbox flicker (#11).
+        "artist": "Barry Jive and the Uptown Five",
+        "album": "Withdrawn from Sale",
+        "tracks": ["No Longer Listed", "Gone from the Store", "Yours to Keep"],
+        "cover": "cover-8.jpg",
+        "file_mbid": "demo-rel-barryjive",
+        "sidecar": {
+            "store_url": "https://barryjive.bandcamp.com/album/withdrawn-from-sale",
+            "bandcamp_item_id": None,
+            "surrender": {"mb_release_id": "demo-rel-barryjive"},
+        },
+    },
+    {
         # State: COMPLETE — fully tagged & confirmed. Hidden from inbox;
         # appears in the Library section.
         "artist": "Various Artists",
@@ -922,6 +940,31 @@ def _build_sidecar(sc_spec: dict[str, Any], album_spec: dict[str, Any]) -> Sidec
             mistag_tagged_label=mistag["tagged_label"],
             mistag_tagged_disambig=mistag.get("tagged_disambig"),
             mistag_release_group_mbid=mistag["release_group_mbid"],
+        )
+
+    # A surrendered purchase: a sync couldn't match this owned album to any
+    # purchase (e.g. withdrawn from Bandcamp), so it was dropped back to NEEDS_MBID
+    # with a read-only "couldn't link" candidate. "Move to Library" accepts it as a
+    # terminal Library album (surrender_keep).
+    if surrender := sc_spec.get("surrender"):
+        candidate = MatchCandidate(
+            mb_release_id=surrender["mb_release_id"],
+            confidence="exact",
+            file_count=len(album_spec["tracks"]),
+            track_count=len(album_spec["tracks"]),
+            track_comparisons=[
+                TrackComparison(
+                    file_name=f"{i:02d} {_safe(t)}.m4a",
+                    file_duration_ms=1000,
+                    file_title=t,
+                    mb_track_title=t,
+                    mb_track_length_ms=1000,
+                    delta_ms=0,
+                )
+                for i, t in enumerate(album_spec["tracks"], start=1)
+            ],
+            proposed_at=now,
+            unmatched_purchase=True,
         )
 
     tagged_at = now if sc_spec.get("tagged") else None

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -2369,6 +2369,14 @@ def _register_routes(app: FastAPI) -> None:
         )
         if album.state not in _TERMINAL_STATES:
             live_counts.move(album.state, AlbumState.COMPLETE)
+        # Reflect the move in one render: refresh the snapshot synchronously and opt
+        # out of the async post-mutation rescan, whose "scanning" status dims the
+        # inbox — the #11 flicker. (When not engaged, the render re-scans fresh, so
+        # nothing to refresh and skip_rescan is a harmless no-op.)
+        runner = request.app.state.scan_runner
+        if runner.is_engaged():
+            runner.refresh_now()
+        request.state.skip_rescan = True
         return _flash_response("Moved to Library", album.title)
 
     @app.post("/unconfirmed/{album_id}/url", response_class=HTMLResponse)

--- a/src/harmonist/web/scan_runner.py
+++ b/src/harmonist/web/scan_runner.py
@@ -141,6 +141,17 @@ class ScanRunner:
         background scan is safe — worst case a redundant re-read of one album."""
         return scanner.scan(self._music_dir, album_cache=self._cache)
 
+    def refresh_now(self) -> None:
+        """Synchronously refresh the snapshot from a cache-warm scan and patch
+        `_albums` in place, WITHOUT flipping status to 'scanning'. A single-album
+        mutation that must show immediately pairs this with
+        `request.state.skip_rescan = True`, so the album resolves in one render
+        instead of via the async post-mutation rescan — whose 'scanning' status
+        dims the inbox (the #11 flicker). Safe from a worker thread: the cache is
+        shared safely (see `scan_now`) and the `_albums` assignment is GIL-atomic."""
+        self._albums = self.scan_now()
+        self._completed_once = True
+
     def status(self) -> dict[str, Any]:
         return self._status.to_dict()
 

--- a/test/test_scan_runner.py
+++ b/test/test_scan_runner.py
@@ -34,6 +34,23 @@ def test_scan_runner_not_engaged_before_attach(tmp_path):
     runner.request_scan()  # no-op without a loop, must not raise
 
 
+def test_refresh_now_updates_snapshot_without_scanning_status(tmp_path):
+    """refresh_now patches the snapshot from a synchronous cache-warm scan and
+    never flips to 'scanning' — so a single-album mutation can reflect in one
+    render with no async rescan (and no inbox busy-lock flash). See #11."""
+    runner = ScanRunner(tmp_path)
+    _album(tmp_path, "One")
+    runner.refresh_now()
+    assert {a.path.name for a in runner.albums()} == {"One"}
+    assert runner.has_completed() is True
+    assert runner.status()["state"] == "idle"  # never advertised a scan
+
+    # A subsequent change shows up on the next refresh.
+    _album(tmp_path, "Two")
+    runner.refresh_now()
+    assert {a.path.name for a in runner.albums()} == {"One", "Two"}
+
+
 def test_reset_and_rescan_no_loop_is_noop(tmp_path):
     """Before the runner is engaged, reset_and_rescan must be a safe no-op (the
     erase-sidecars handler may run before/without the background loop)."""


### PR DESCRIPTION
Move to Library (`surrender_keep`) relied on the global post-mutation rescan to move the album out of the inbox. That async rescan flips the scan status to "scanning", which dims + locks the inbox for the brief cache-warm scan — a visible flicker for a one-album change. (`skip_rescan` alone can't fix it: the card renders from the scan snapshot, so without a refresh it lingers.)

Add `ScanRunner.refresh_now()` — a synchronous cache-warm scan that patches the snapshot in place without advertising a scan — and have `surrender_keep` call it then set `skip_rescan`, so the album resolves in one render. Reuses the already-tested `scan_now()`; no changes to the scanner hot path.

Also seeds a surrendered album in demo mode ("Barry Jive and the Uptown Five — Withdrawn from Sale") so the flow is demoable — verified there that the album leaves the inbox and lands in the Library in a single request cycle.

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8