### PR TITLE
Make the event level a StrEnum, with logging-style wrappers

### DIFF
--- a/src/harmonist/activity.py
+++ b/src/harmonist/activity.py
@@ -17,23 +17,25 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from . import activity_store
-from .activity_store import Source
-
-_Level = str  # "info" | "warning" | "error"
+from .activity_store import Level, Source
 
 
 @dataclass(frozen=True)
 class Event:
     ts: datetime
-    level: _Level
+    level: Level
     message: str
 
 
 log = logging.getLogger(__name__)
-_LOG_LEVELS = {"info": logging.INFO, "warning": logging.WARNING, "error": logging.ERROR}
+_LOG_LEVELS = {
+    Level.INFO: logging.INFO,
+    Level.WARNING: logging.WARNING,
+    Level.ERROR: logging.ERROR,
+}
 
 
-def record(message: str, level: _Level = "info") -> None:
+def record(message: str, level: Level = Level.INFO) -> None:
     """Append an event (Activity feed) AND emit it to the log, so the docker
     log is a superset of the feed. Safe to call from any thread."""
     message = (message or "").strip()
@@ -43,6 +45,21 @@ def record(message: str, level: _Level = "info") -> None:
     # Mirror to the log. The `_activity` flag stops _ActivityLogHandler from
     # re-recording it (which would feed back into this function — a loop).
     log.log(_LOG_LEVELS.get(level, logging.INFO), "%s", message, extra={"_activity": True})
+
+
+def info(message: str) -> None:
+    """Record an info-level activity event (logging-style shorthand for record())."""
+    record(message, Level.INFO)
+
+
+def warning(message: str) -> None:
+    """Record a warning-level activity event."""
+    record(message, Level.WARNING)
+
+
+def error(message: str) -> None:
+    """Record an error-level activity event."""
+    record(message, Level.ERROR)
 
 
 def recent(limit: int = 100) -> list[Event]:
@@ -69,7 +86,7 @@ class _ActivityLogHandler(logging.Handler):
             msg = rec.getMessage()
         except Exception:
             return
-        level = "error" if rec.levelno >= logging.ERROR else "warning"
+        level = Level.ERROR if rec.levelno >= logging.ERROR else Level.WARNING
         record(msg, level)
 
 

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -38,9 +38,14 @@ class Source(StrEnum):
     AUDIT = "audit"
 
 
-# TODO(#47): make this a StrEnum too — deferred because `level` is set at ~30
-# flash/record sites across the web layer; that conversion is its own change.
-_Level = str  # "info" | "warning" | "error"
+class Level(StrEnum):
+    """Severity of a stored event — drives the status-pill colour and the mirrored
+    log level. A str at heart (StrEnum), so it stores/compares as its value."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
 
 _LOCK = threading.Lock()
 _conn: sqlite3.Connection | None = None
@@ -73,7 +78,7 @@ SCHEMA_VERSION = len(_MIGRATIONS)  # the version this build expects/creates
 @dataclass(frozen=True)
 class StoredEvent:
     ts: datetime
-    level: _Level
+    level: Level
     source: Source
     message: str
 
@@ -147,7 +152,7 @@ def _ensure() -> sqlite3.Connection:
     return _conn
 
 
-def append(*, message: str, level: _Level, source: Source) -> None:
+def append(*, message: str, level: Level, source: Source) -> None:
     """Append one event. Best-effort: a failure here (e.g. a teardown race in
     tests) must never crash the caller or the logging path."""
     message = (message or "").strip()
@@ -159,7 +164,7 @@ def append(*, message: str, level: _Level, source: Source) -> None:
         with _LOCK:
             conn.execute(
                 "INSERT INTO events (ts, level, source, message) VALUES (?, ?, ?, ?)",
-                (ts, level, source.value, message),
+                (ts, level.value, source.value, message),
             )
             conn.commit()
     except sqlite3.Error:
@@ -182,7 +187,9 @@ def recent(limit: int = 100, *, source: Source | None = None) -> list[StoredEven
     except sqlite3.Error:
         return []
     return [
-        StoredEvent(ts=datetime.fromisoformat(ts), level=level, source=Source(src), message=msg)
+        StoredEvent(
+            ts=datetime.fromisoformat(ts), level=Level(level), source=Source(src), message=msg
+        )
         for ts, level, src, msg in rows
     ]
 

--- a/src/harmonist/audit.py
+++ b/src/harmonist/audit.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import logging
 
 from . import activity_store
-from .activity_store import Source
+from .activity_store import Level, Source
 
 log = logging.getLogger("harmonist.audit")
 
@@ -35,7 +35,7 @@ def record(event: str, **fields: object) -> None:
     """
     line = event if not fields else f"{event} {_detail(fields)}"
     log.info("%s", line)
-    activity_store.append(message=line, level="info", source=Source.AUDIT)
+    activity_store.append(message=line, level=Level.INFO, source=Source.AUDIT)
 
 
 def _detail(fields: dict[str, object]) -> str:

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -642,7 +642,7 @@ def _download(
             progress_callback(f"{spec['artist']} / {spec['album']}")
     time.sleep(STEP_DELAY_SECONDS)
     _materialise(music_dir, spec)
-    activity.record(f"Downloaded {spec['artist']} / {spec['album']}", "info")
+    activity.info(f"Downloaded {spec['artist']} / {spec['album']}")
 
 
 def _purchase_item_id(spec: dict[str, Any]) -> int:
@@ -719,9 +719,7 @@ def _fill_in_existing_item_ids(
         )
         sidecar_mod.write(album_dir, new_sc)
         patched += 1
-        activity.record(
-            f"Linked {album_dir.parent.name} / {album_dir.name} to its Bandcamp purchase", "info"
-        )
+        activity.info(f"Linked {album_dir.parent.name} / {album_dir.name} to its Bandcamp purchase")
         if progress_callback:
             with contextlib.suppress(Exception):
                 progress_callback(f"Linked: {album_dir.parent.name} / {album_dir.name}")

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -40,6 +40,7 @@ from harmonist import (
 )
 from harmonist import config as config_mod
 from harmonist import sidecar as sidecar_mod
+from harmonist.activity_store import Level
 from harmonist.bandcamp_hook import HarmonistSyncer, album_slug
 from harmonist.match import assess_match, best_match
 from harmonist.models import (
@@ -288,7 +289,7 @@ def create_app(
             if link_only and pending_links == 0:
                 _clear_bandcampsync_checkpoint(cfg.paths.music_dir)
             if link_only:
-                activity.record(
+                activity.info(
                     f"Linking your library — {pending_links} album(s) to match. "
                     "Downloads are paused this sync and resume on the next one.",
                 )
@@ -536,7 +537,7 @@ def _register_demo_routes(app: FastAPI) -> None:
             demo.reset(request.app.state.cfg.paths.music_dir)
         except RuntimeError as e:
             return _flash_response(
-                "Demo reset failed", str(e), level="error", tasks_changed=False, status_code=400
+                "Demo reset failed", str(e), level=Level.ERROR, tasks_changed=False, status_code=400
             )
         return _flash_response("Demo data reset", "back to original state")
 
@@ -918,10 +919,9 @@ def _detect_mistags_after_sync(
     if not albums or not owned:
         return
     if len(albums) > _MISTAG_DETECTION_MAX_ALBUMS:
-        activity.record(
+        activity.warning(
             f"Mis-tag detection skipped: {len(albums)} unmatched albums after sync exceeds "
-            f"the cap of {_MISTAG_DETECTION_MAX_ALBUMS} — something looks wrong with this sync.",
-            level="warning",
+            f"the cap of {_MISTAG_DETECTION_MAX_ALBUMS} — something looks wrong with this sync."
         )
         return
 
@@ -991,11 +991,10 @@ def _detect_mistags_after_sync(
         # must NOT also show as a potential download. `replace_all` already ran
         # during the sync, so remove the now-claimed id.
         pending_downloads.remove(owned_item_id)
-        activity.record(
+        activity.warning(
             f"Possible mis-tag: {album.artist} — {album.title}. You own “{label}” on "
             f"Bandcamp ({url}) — the same release group but a different release than it's "
-            f"tagged as. Moved to Needs MBID with {owned_mbid} suggested; confirm to re-tag.",
-            level="warning",
+            f"tagged as. Moved to Needs MBID with {owned_mbid} suggested; confirm to re-tag."
         )
 
 
@@ -1040,10 +1039,9 @@ def _report_unmatched_after_sync(
         )
         for a in unmatched:
             store_url = a.sidecar.store_url if a.sidecar else None
-            activity.record(
+            activity.warning(
                 f"Not linked to a Bandcamp purchase: {a.artist} — {a.title} "
-                f"[{store_url or 'no store URL'}] (use 'Try a different URL' to link it)",
-                level="warning",
+                f"[{store_url or 'no store URL'}] (use 'Try a different URL' to link it)"
             )
         return
 
@@ -1072,19 +1070,17 @@ def _report_unmatched_after_sync(
             unmatched_purchase=True,
         )
         _demote_to_needs_mbid(a.path, sc, candidate=candidate)
-        activity.record(
+        activity.warning(
             f"No Bandcamp purchase matched {a.artist} — {a.title} — kept its tags, moved "
             "to Needs MBID. Add its Bandcamp URL to the MusicBrainz release (or match it "
-            "manually) so it links instead of risking a duplicate download.",
-            level="warning",
+            "manually) so it links instead of risking a duplicate download."
         )
         if twins:
-            activity.record(
+            activity.warning(
                 f"Heads up: {a.artist} — {a.title} is tagged as the same MusicBrainz "
                 f"release as “{twins[0].title}” ({twins[0].path.name}), which already "
                 f"linked to a purchase — possibly a duplicate copy, or a release split "
-                f"across directories.",
-                level="warning",
+                f"across directories."
             )
 
 
@@ -1575,13 +1571,13 @@ def _resolve_by_store_url(album_path: Path, cfg: config_mod.Config, tagger: Tagg
     try:
         mbids = mb_lookup.lookup_by_bandcamp_url(sc.store_url)
         if not mbids:
-            activity.record(f"Synced {album_path.name} — no MusicBrainz match yet", "info")
+            activity.record(f"Synced {album_path.name} — no MusicBrainz match yet")
             return "no_match"
         status_str, _ = _apply_best_match(album_path, mbids, cfg, tagger)
         if status_str == "tagged":
-            activity.record(f"Auto-tagged {album_path.name} from MusicBrainz after sync", "info")
+            activity.info(f"Auto-tagged {album_path.name} from MusicBrainz after sync")
         else:
-            activity.record(f"Synced {album_path.name} — MusicBrainz suggestion to review", "info")
+            activity.info(f"Synced {album_path.name} — MusicBrainz suggestion to review")
         return status_str
     except Exception as e:
         log.warning("auto-resolve failed for %s: %s", album_path, e)
@@ -1657,7 +1653,7 @@ def _register_routes(app: FastAPI) -> None:
         label = f"{p.band} — {p.title}" if p else str(item_id)
         _append_ignore(cfg.ignores_file, item_id, label)
         pending_downloads.remove(item_id)
-        activity.record(f"Won't download {label} — added to your Bandcamp ignores")
+        activity.info(f"Won't download {label} — added to your Bandcamp ignores")
         request.state.skip_rescan = True  # only removed a pending; no album changed
         return _render_pending_section(request)
 
@@ -1734,13 +1730,13 @@ def _register_routes(app: FastAPI) -> None:
         # returns to the main page — not the pre-erase cards lingering.
         live_counts.reset_from([])
         request.app.state.scan_runner.reset_and_rescan()
-        activity.record(
-            f"Erased {removed} sidecar(s) — albums revert to tag-derived state{suffix}", "warning"
+        activity.warning(
+            f"Erased {removed} sidecar(s) — albums revert to tag-derived state{suffix}"
         )
         return _flash_response(
             "Sidecars erased",
             f"{removed} removed — audio untouched; albums re-derive on next scan{suffix}",
-            level="warning",
+            level=Level.WARNING,
         )
 
     @app.post("/settings", response_class=HTMLResponse)
@@ -1797,7 +1793,7 @@ def _register_routes(app: FastAPI) -> None:
         # MB user-agent is applied at startup, so re-configure it now too.
         request.app.state.cfg = new_cfg
         mb_lookup.configure(new_cfg.musicbrainz.user_agent)
-        activity.record("Settings updated", "info")
+        activity.info("Settings updated")
 
         ctx = _ctx(
             request,
@@ -1848,7 +1844,7 @@ def _register_routes(app: FastAPI) -> None:
         return _flash_response(
             "Reconcile busy",
             "already running or just finished",
-            level="warning",
+            level=Level.WARNING,
             tasks_changed=False,
         )
 
@@ -1867,7 +1863,7 @@ def _register_routes(app: FastAPI) -> None:
             return _flash_response(
                 "Sync unavailable",
                 "reconciling — try again in a moment",
-                level="warning",
+                level=Level.WARNING,
                 tasks_changed=False,
                 status_code=status.HTTP_409_CONFLICT,
             )
@@ -1885,7 +1881,7 @@ def _register_routes(app: FastAPI) -> None:
             return _flash_response(
                 "Sync busy",
                 "already running",
-                level="warning",
+                level=Level.WARNING,
                 tasks_changed=False,
                 status_code=status.HTTP_409_CONFLICT,
             )
@@ -2016,7 +2012,7 @@ def _register_routes(app: FastAPI) -> None:
         sc = album.sidecar
         if sc is None or sc.bandcamp is None or sc.bandcamp.item_id is None:
             return _flash_response(
-                "Nothing to unlink", f"{album.title} isn't linked", level="warning"
+                "Nothing to unlink", f"{album.title} isn't linked", level=Level.WARNING
             )
         old_id = sc.bandcamp.item_id
         if forget_url:
@@ -2044,7 +2040,7 @@ def _register_routes(app: FastAPI) -> None:
         sc = album.sidecar
         if sc is None or not sc.mb_release_id:
             return _flash_response(
-                "Nothing to re-match", f"{album.title} has no MB release", level="warning"
+                "Nothing to re-match", f"{album.title} has no MB release", level=Level.WARNING
             )
         old_mbid = sc.mb_release_id
         new_sc = replace(sc, mb_release_id=None, tagged_at=None, mb_match_candidate=None)
@@ -2076,7 +2072,7 @@ def _register_routes(app: FastAPI) -> None:
             )
         except Exception as e:
             log.exception("retag failed")
-            return _flash_response("Re-tag failed", str(e), level="error", tasks_changed=False)
+            return _flash_response("Re-tag failed", str(e), level=Level.ERROR, tasks_changed=False)
         details = f"{album.title} (artwork replaced)" if overwrite_art else album.title
         # Reload the open detail modal so its disk-vs-MB comparison + metadata
         # reflect the just-written tags (tasks-changed only refreshes the tiles).
@@ -2183,7 +2179,7 @@ def _register_routes(app: FastAPI) -> None:
             return _flash_response(
                 "Reconcile failed",
                 str(e),
-                level="error",
+                level=Level.ERROR,
                 tasks_changed=False,
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
@@ -2195,7 +2191,7 @@ def _register_routes(app: FastAPI) -> None:
             return _flash_response(
                 "No MBID atom",
                 f"{album.title} has no MusicBrainz Album Id",
-                level="warning",
+                level=Level.WARNING,
                 tasks_changed=False,
             )
         label = "Bandcamp source" if sc.store_url else "manual source"
@@ -2210,12 +2206,14 @@ def _register_routes(app: FastAPI) -> None:
         try:
             mbids = mb_lookup.lookup_by_bandcamp_url(sc.store_url)
         except mb_lookup.MBError as e:
-            return _flash_response("MB lookup failed", str(e), level="error", tasks_changed=False)
+            return _flash_response(
+                "MB lookup failed", str(e), level=Level.ERROR, tasks_changed=False
+            )
         if not mbids:
             return _flash_response(
                 "Still no match",
                 f"{album.title}: no MusicBrainz release for this URL yet",
-                level="warning",
+                level=Level.WARNING,
                 tasks_changed=False,
             )
 
@@ -2227,7 +2225,7 @@ def _register_routes(app: FastAPI) -> None:
                 results, total = mb_lookup.candidate_summaries_for_url(sc.store_url)
             except mb_lookup.MBError as e:
                 return _flash_response(
-                    "MB lookup failed", str(e), level="error", tasks_changed=False
+                    "MB lookup failed", str(e), level=Level.ERROR, tasks_changed=False
                 )
             return _render_release_picker(
                 request,
@@ -2241,7 +2239,9 @@ def _register_routes(app: FastAPI) -> None:
         try:
             releases = [mb_lookup.fetch_release(m) for m in mbids]
         except mb_lookup.MBError as e:
-            return _flash_response("MB fetch failed", str(e), level="error", tasks_changed=False)
+            return _flash_response(
+                "MB fetch failed", str(e), level=Level.ERROR, tasks_changed=False
+            )
         candidate = best_match(album.path, releases)
         assert candidate is not None  # releases is non-empty (mbids guarded)
         mbid = candidate.mb_release_id
@@ -2268,7 +2268,7 @@ def _register_routes(app: FastAPI) -> None:
                 return _flash_response(
                     "Tagging failed",
                     str(e),
-                    level="error",
+                    level=Level.ERROR,
                     tasks_changed=False,
                 )
         return _flash_response(
@@ -2294,7 +2294,7 @@ def _register_routes(app: FastAPI) -> None:
             )
         except Exception as e:
             log.exception("tag failed")
-            return _flash_response("Tagging failed", str(e), level="error", tasks_changed=False)
+            return _flash_response("Tagging failed", str(e), level=Level.ERROR, tasks_changed=False)
         return _flash_response("Tagged", album.title)
 
     @app.post("/confirm/{album_id}/incomplete", response_class=HTMLResponse)
@@ -2319,7 +2319,7 @@ def _register_routes(app: FastAPI) -> None:
             )
         except Exception as e:
             log.exception("incomplete tag failed")
-            return _flash_response("Tagging failed", str(e), level="error", tasks_changed=False)
+            return _flash_response("Tagging failed", str(e), level=Level.ERROR, tasks_changed=False)
         return _flash_response("Tagged as incomplete", album.title)
 
     @app.post("/reject/{album_id}", response_class=HTMLResponse)
@@ -2414,7 +2414,9 @@ def _register_routes(app: FastAPI) -> None:
             # tool. Each row links out to the release for closer inspection.
             results = mb_search.search_releases(artist, title, limit=5)
         except mb_search.MBSearchError as e:
-            return _flash_response("MB search failed", str(e), level="error", tasks_changed=False)
+            return _flash_response(
+                "MB search failed", str(e), level=Level.ERROR, tasks_changed=False
+            )
         return _render_release_picker(
             request, album, results, len(results), heading="MusicBrainz search results"
         )
@@ -2431,7 +2433,9 @@ def _register_routes(app: FastAPI) -> None:
         try:
             results, total = mb_lookup.candidate_summaries_for_url(sc.store_url)
         except mb_lookup.MBError as e:
-            return _flash_response("MB lookup failed", str(e), level="error", tasks_changed=False)
+            return _flash_response(
+                "MB lookup failed", str(e), level=Level.ERROR, tasks_changed=False
+            )
         return _render_release_picker(
             request, album, results, total, heading="Releases linked to this store URL"
         )
@@ -2444,7 +2448,7 @@ def _register_routes(app: FastAPI) -> None:
             return _flash_response(
                 "Could not parse",
                 "Paste a full MB release URL or the 36-char MBID",
-                level="error",
+                level=Level.ERROR,
                 tasks_changed=False,
             )
         try:
@@ -2452,10 +2456,14 @@ def _register_routes(app: FastAPI) -> None:
                 album.path, [extracted], request.app.state.cfg, request.app.state.tagger
             )
         except mb_lookup.MBError as e:
-            return _flash_response("MB lookup failed", str(e), level="error", tasks_changed=False)
+            return _flash_response(
+                "MB lookup failed", str(e), level=Level.ERROR, tasks_changed=False
+            )
         except Exception as e:
             log.exception("manual assign failed")
-            return _flash_response("Assignment failed", str(e), level="error", tasks_changed=False)
+            return _flash_response(
+                "Assignment failed", str(e), level=Level.ERROR, tasks_changed=False
+            )
         # status_str is 'tagged' or 'needs_confirmation' — use the friendlier
         # verb from msg's first clause.
         verb = "Tagged" if status_str == "tagged" else "Needs review"
@@ -2541,7 +2549,7 @@ def _flash_response(
     verb: str,
     details: str | None = None,
     *,
-    level: str = "info",
+    level: Level = Level.INFO,
     tasks_changed: bool = True,
     status_code: int = 200,
     extra_triggers: dict[str, Any] | None = None,
@@ -2564,7 +2572,7 @@ def _flash_response(
     """
     message = verb if not details else f"{verb} — {details}"
     # Every action outcome is also an activity-log entry (the Activity tab).
-    activity.record(message, level if level in ("info", "warning", "error") else "info")
+    activity.record(message, level)
     triggers: dict[str, Any] = {
         "harmonist-status": {
             "verb": verb,

--- a/src/harmonist/web/reconcile_runner.py
+++ b/src/harmonist/web/reconcile_runner.py
@@ -212,7 +212,7 @@ def reconcile_pending_orphans(
     if albums is None:
         # No snapshot handed in — walk the library ourselves. This can take a
         # while on a large tree, so announce it (the feed would be silent).
-        activity.record("Reconcile started — scanning the library for albums to reconcile…")
+        activity.info("Reconcile started — scanning the library for albums to reconcile…")
         albums = scanner.scan(music_dir)
     else:
         activity.record("Reconcile started")
@@ -292,10 +292,7 @@ def reconcile_pending_orphans(
             # The sidecar adopted the file tags (external Picard re-tag). The new
             # state (Library / Needs Link) settles on the post-reconcile rescan.
             adopted += 1
-            activity.record(
-                f"{label}: adopted external re-tag — sidecar now {sc.mb_release_id}",
-                "warning",
-            )
+            activity.warning(f"{label}: adopted external re-tag — sidecar now {sc.mb_release_id}")
         elif sc.mb_release_id and sc.store_url:
             reconciled_bandcamp += 1
             live_counts.move(AlbumState.NEW, AlbumState.NEEDS_SYNC)

--- a/src/harmonist/web/sync_runner.py
+++ b/src/harmonist/web/sync_runner.py
@@ -100,7 +100,7 @@ class SyncRunner:
         return self._status
 
     def _run(self) -> None:
-        activity.record("Bandcamp sync started", "info")
+        activity.info("Bandcamp sync started")
         new_items = 0
         remaining = 0
         error: str | None = None
@@ -124,10 +124,10 @@ class SyncRunner:
                 self._status.new_items = new_items
                 self._status.current_item = ""
         if error:
-            activity.record(f"Bandcamp sync failed — {error}", "error")
+            activity.error(f"Bandcamp sync failed — {error}")
         else:
             plural = "" if new_items == 1 else "s"
             msg = f"Bandcamp sync finished — {new_items} new item{plural}"
             if remaining:
                 msg += f"; {remaining} more reached the per-sync limit — run Sync again"
-            activity.record(msg, "info")
+            activity.info(msg)

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -7,7 +7,7 @@ import sqlite3
 import pytest
 
 from harmonist import activity, activity_store, audit
-from harmonist.activity_store import Source
+from harmonist.activity_store import Level, Source
 
 
 @pytest.fixture(autouse=True)
@@ -20,7 +20,7 @@ def _fresh_store(tmp_path):
 
 
 def test_append_and_recent_roundtrip():
-    activity_store.append(message="hello", level="info", source=Source.ACTIVITY)
+    activity_store.append(message="hello", level=Level.INFO, source=Source.ACTIVITY)
     events = activity_store.recent()
     assert [e.message for e in events] == ["hello"]
     assert events[0].level == "info"
@@ -29,22 +29,22 @@ def test_append_and_recent_roundtrip():
 
 def test_recent_is_most_recent_first_and_respects_limit():
     for i in range(5):
-        activity_store.append(message=f"e{i}", level="info", source=Source.ACTIVITY)
+        activity_store.append(message=f"e{i}", level=Level.INFO, source=Source.ACTIVITY)
     msgs = [e.message for e in activity_store.recent(limit=3)]
     assert msgs == ["e4", "e3", "e2"]  # newest first, capped at 3
 
 
 def test_source_filter_separates_activity_and_audit():
-    activity_store.append(message="user action", level="info", source=Source.ACTIVITY)
-    activity_store.append(message="download url=x", level="info", source=Source.AUDIT)
+    activity_store.append(message="user action", level=Level.INFO, source=Source.ACTIVITY)
+    activity_store.append(message="download url=x", level=Level.INFO, source=Source.AUDIT)
     assert [e.message for e in activity_store.recent(source=Source.ACTIVITY)] == ["user action"]
     assert [e.message for e in activity_store.recent(source=Source.AUDIT)] == ["download url=x"]
     assert {e.message for e in activity_store.recent()} == {"user action", "download url=x"}
 
 
 def test_blank_messages_are_dropped():
-    activity_store.append(message="   ", level="info", source=Source.ACTIVITY)
-    activity_store.append(message="", level="info", source=Source.ACTIVITY)
+    activity_store.append(message="   ", level=Level.INFO, source=Source.ACTIVITY)
+    activity_store.append(message="", level=Level.INFO, source=Source.ACTIVITY)
     assert activity_store.recent() == []
 
 
@@ -54,7 +54,7 @@ def test_survives_reopen(tmp_path):
     db = tmp_path / "persist.db"
     activity_store.init(db)
     activity_store.clear()
-    activity_store.append(message="before restart", level="warning", source=Source.AUDIT)
+    activity_store.append(message="before restart", level=Level.WARNING, source=Source.AUDIT)
 
     activity_store.init(db)  # simulate a restart: new connection, same file
     events = activity_store.recent()
@@ -79,8 +79,29 @@ def test_audit_record_stores_as_audit_and_is_absent_from_the_feed():
     assert activity.recent() == []
 
 
+def test_level_roundtrips_as_enum():
+    activity_store.append(message="boom", level=Level.ERROR, source=Source.ACTIVITY)
+    e = activity_store.recent()[0]
+    assert e.level is Level.ERROR
+    # StrEnum stays a str, so the template's `e.level == 'error'` still matches
+    # (checked via a str-typed alias — mypy rejects the literal comparison as
+    # non-overlapping, but the runtime behaviour is what the template relies on).
+    as_str: str = e.level
+    assert as_str == "error"
+
+
+def test_activity_level_wrappers_record_the_right_level():
+    activity.info("fyi")
+    activity.warning("careful")
+    activity.error("broke")
+    got = {(e.message, e.level) for e in activity_store.recent(source=Source.ACTIVITY)}
+    assert ("fyi", Level.INFO) in got
+    assert ("careful", Level.WARNING) in got
+    assert ("broke", Level.ERROR) in got
+
+
 def test_clear_empties_the_store():
-    activity_store.append(message="x", level="info", source=Source.ACTIVITY)
+    activity_store.append(message="x", level=Level.INFO, source=Source.ACTIVITY)
     activity_store.clear()
     assert activity_store.recent() == []
 
@@ -97,7 +118,7 @@ def _user_version(db) -> int:
 def test_fresh_db_is_migrated_to_current_schema_version(tmp_path):
     db = tmp_path / "ver.db"
     activity_store.init(db)
-    activity_store.append(message="x", level="info", source=Source.ACTIVITY)
+    activity_store.append(message="x", level=Level.INFO, source=Source.ACTIVITY)
     assert activity_store.SCHEMA_VERSION >= 1
     assert _user_version(db) == activity_store.SCHEMA_VERSION
 
@@ -111,7 +132,7 @@ def test_downgrade_guard_falls_back_to_memory_without_crashing(tmp_path):
     conn.close()
 
     activity_store.init(db)  # must not raise
-    activity_store.append(message="still works", level="info", source=Source.ACTIVITY)
+    activity_store.append(message="still works", level=Level.INFO, source=Source.ACTIVITY)
     assert [e.message for e in activity_store.recent()] == ["still works"]
 
     # The future-versioned file was left untouched — no events table written to it.

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 from mutagen.mp4 import MP4
 
 from harmonist import sidecar as sc
+from harmonist.activity_store import Level
 from harmonist.config import BandcampConfig, Config, PathsConfig, ServerConfig, TestConfig
 from harmonist.models import BandcampInfo, MatchCandidate, Sidecar, TrackComparison
 from harmonist.tagger import (
@@ -2655,8 +2656,8 @@ def test_activity_empty_state(client):
 def test_activity_lists_recorded_events(client):
     from harmonist import activity
 
-    activity.record("Tagged — Some Album", "info")
-    activity.record("Sync failed — boom", "error")
+    activity.record("Tagged — Some Album", Level.INFO)
+    activity.record("Sync failed — boom", Level.ERROR)
     r = client.get("/activity")
     assert r.status_code == 200
     assert "Tagged — Some Album" in r.text


### PR DESCRIPTION
Replaces the `_Level = str` alias with a `Level` StrEnum alongside `Source`, and types `activity_store.append`, `activity.record` and `_flash_response` with it.

Adds logging-style convenience wrappers — `activity.info(msg)` / `activity.warning(msg)` / `activity.error(msg)` — so call sites read like the logging API instead of passing an explicit level. Converted the ~30 call sites across the web layer, runners and demo.

`StrEnum` keeps the stored values identical (`"info"` / `"warning"` / `"error"`), so existing `activity.db` rows stay readable and the template comparison (`e.level == "error"`) is unchanged — no schema migration needed.

### Verification note

An initial bulk regex conversion silently swapped the severity of four events (it matched across call boundaries while remaining valid Python, so tests still passed). Those are fixed, and the remaining multi-line sites were converted by hand. I added an AST-based audit comparing every `activity.*` call's effective level between `HEAD` and the branch — it reports all levels preserved, so this refactor is verified semantics-neutral rather than eyeballed.

Tests: 625 pass, plus new coverage for the `Level` round-trip and the three wrappers.

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8