### PR TITLE
Tie activity + audit events to their album (#33 increment 2)

### DIFF
--- a/src/harmonist/activity.py
+++ b/src/harmonist/activity.py
@@ -35,31 +35,33 @@ _LOG_LEVELS = {
 }
 
 
-def record(message: str, level: Level = Level.INFO) -> None:
+def record(message: str, level: Level = Level.INFO, *, album_id: str | None = None) -> None:
     """Append an event (Activity feed) AND emit it to the log, so the docker
-    log is a superset of the feed. Safe to call from any thread."""
+    log is a superset of the feed. `album_id` ties the event to an album for
+    per-album history (#33); None when it isn't about one album. Safe to call
+    from any thread."""
     message = (message or "").strip()
     if not message:
         return
-    activity_store.append(message=message, level=level, source=Source.ACTIVITY)
+    activity_store.append(message=message, level=level, source=Source.ACTIVITY, album_id=album_id)
     # Mirror to the log. The `_activity` flag stops _ActivityLogHandler from
     # re-recording it (which would feed back into this function — a loop).
     log.log(_LOG_LEVELS.get(level, logging.INFO), "%s", message, extra={"_activity": True})
 
 
-def info(message: str) -> None:
+def info(message: str, *, album_id: str | None = None) -> None:
     """Record an info-level activity event (logging-style shorthand for record())."""
-    record(message, Level.INFO)
+    record(message, Level.INFO, album_id=album_id)
 
 
-def warning(message: str) -> None:
+def warning(message: str, *, album_id: str | None = None) -> None:
     """Record a warning-level activity event."""
-    record(message, Level.WARNING)
+    record(message, Level.WARNING, album_id=album_id)
 
 
-def error(message: str) -> None:
+def error(message: str, *, album_id: str | None = None) -> None:
     """Record an error-level activity event."""
-    record(message, Level.ERROR)
+    record(message, Level.ERROR, album_id=album_id)
 
 
 def recent(limit: int = 100) -> list[Event]:

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -70,6 +70,14 @@ _MIGRATIONS: tuple[tuple[str, ...], ...] = (
         )""",
         "CREATE INDEX idx_events_source_id ON events (source, id)",
     ),
+    # 1 -> 2: per-album reference (an album's `Album.id`) so events can be filtered
+    # by album — the foundation for per-album history (#14) and the gardener (#32).
+    # Nullable: events not about one album (sync started, settings updated) have
+    # none. Set on BOTH sources, so one query returns an album's activity + audit.
+    (
+        "ALTER TABLE events ADD COLUMN album_id TEXT",
+        "CREATE INDEX idx_events_album_id ON events (album_id, id)",
+    ),
 )
 
 SCHEMA_VERSION = len(_MIGRATIONS)  # the version this build expects/creates
@@ -81,6 +89,7 @@ class StoredEvent:
     level: Level
     source: Source
     message: str
+    album_id: str | None = None
 
 
 def _migrate(conn: sqlite3.Connection) -> None:
@@ -152,9 +161,11 @@ def _ensure() -> sqlite3.Connection:
     return _conn
 
 
-def append(*, message: str, level: Level, source: Source) -> None:
-    """Append one event. Best-effort: a failure here (e.g. a teardown race in
-    tests) must never crash the caller or the logging path."""
+def append(*, message: str, level: Level, source: Source, album_id: str | None = None) -> None:
+    """Append one event. `album_id` (an album's `Album.id`) ties the event to an
+    album so per-album history spans both sources; None when it isn't about one
+    album. Best-effort: a failure here (e.g. a teardown race in tests) must never
+    crash the caller or the logging path."""
     message = (message or "").strip()
     if not message:
         return
@@ -163,21 +174,31 @@ def append(*, message: str, level: Level, source: Source) -> None:
         conn = _ensure()
         with _LOCK:
             conn.execute(
-                "INSERT INTO events (ts, level, source, message) VALUES (?, ?, ?, ?)",
-                (ts, level.value, source.value, message),
+                "INSERT INTO events (ts, level, source, message, album_id) VALUES (?, ?, ?, ?, ?)",
+                (ts, level.value, source.value, message, album_id),
             )
             conn.commit()
     except sqlite3.Error:
         log.debug("activity_store append failed", exc_info=True, extra={"_activity": True})
 
 
-def recent(limit: int = 100, *, source: Source | None = None) -> list[StoredEvent]:
-    """Most-recent-first events, optionally filtered by source."""
-    q = "SELECT ts, level, source, message FROM events"
+def recent(
+    limit: int = 100, *, source: Source | None = None, album_id: str | None = None
+) -> list[StoredEvent]:
+    """Most-recent-first events, optionally filtered by source and/or album.
+    Filtering by `album_id` alone returns that album's whole history — activity
+    AND audit."""
+    q = "SELECT ts, level, source, message, album_id FROM events"
+    where: list[str] = []
     args: list[object] = []
     if source is not None:
-        q += " WHERE source = ?"
+        where.append("source = ?")
         args.append(source.value)
+    if album_id is not None:
+        where.append("album_id = ?")
+        args.append(album_id)
+    if where:
+        q += " WHERE " + " AND ".join(where)
     q += " ORDER BY id DESC LIMIT ?"
     args.append(limit)
     try:
@@ -188,9 +209,13 @@ def recent(limit: int = 100, *, source: Source | None = None) -> list[StoredEven
         return []
     return [
         StoredEvent(
-            ts=datetime.fromisoformat(ts), level=Level(level), source=Source(src), message=msg
+            ts=datetime.fromisoformat(ts),
+            level=Level(level),
+            source=Source(src),
+            message=msg,
+            album_id=aid,
         )
-        for ts, level, src, msg in rows
+        for ts, level, src, msg, aid in rows
     ]
 
 

--- a/src/harmonist/audit.py
+++ b/src/harmonist/audit.py
@@ -26,16 +26,18 @@ from .activity_store import Level, Source
 log = logging.getLogger("harmonist.audit")
 
 
-def record(event: str, **fields: object) -> None:
+def record(event: str, *, album_id: str | None = None, **fields: object) -> None:
     """Record one audit event as ``event key=value …`` — to the server log and to
     the durable store.
 
-    Values containing whitespace (album paths!) are quoted so each event stays a
-    single, parseable line. None is rendered as ``-``.
+    ``album_id`` (an album's ``Album.id``) is a structured column, not part of the
+    message: it ties the row to an album so per-album history spans activity+audit
+    (#33). Values containing whitespace (album paths!) are quoted so each event
+    stays a single, parseable line. None is rendered as ``-``.
     """
     line = event if not fields else f"{event} {_detail(fields)}"
     log.info("%s", line)
-    activity_store.append(message=line, level=Level.INFO, source=Source.AUDIT)
+    activity_store.append(message=line, level=Level.INFO, source=Source.AUDIT, album_id=album_id)
 
 
 def _detail(fields: dict[str, object]) -> str:

--- a/src/harmonist/bandcamp_hook.py
+++ b/src/harmonist/bandcamp_hook.py
@@ -24,7 +24,7 @@ import bandcampsync.sync as _bcsync
 from bandcampsync.options import BandcampSyncOptions
 from bandcampsync.sync import Syncer as _BCSyncer
 
-from . import activity, audit, formats, library_index, pending_downloads
+from . import activity, audit, formats, id_registry, library_index, pending_downloads
 from . import sidecar as sidecar_mod
 from .models import BandcampInfo, Sidecar, is_bandcamp_url, title_words, titles_match
 from .pending_downloads import PendingPurchase
@@ -762,15 +762,23 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
         result = bool(super().sync_item(item, encoding))
         if result:
             self.new_items += 1
+            # Mint the album's id NOW, before the sidecar exists, so these audit
+            # rows can be attached to it. `write_sidecar_for_item` below writes a
+            # sidecar with no MBID, and sidecar.write's identity normalisation
+            # adopts this same registry UUID as `temp_uid` — so the download rows
+            # and the album's later history share one id (#33).
+            album_id = id_registry.get_or_mint(local_path)
             if collided is not None:
                 audit.record(
                     "case_collision",
+                    album_id=album_id,
                     item_id=getattr(item, "item_id", "?"),
                     created=local_path.parent,
                     existing=collided,
                 )
             audit.record(
                 "download",
+                album_id=album_id,
                 item_id=getattr(item, "item_id", "?"),
                 fmt=encoding or getattr(self, "media_format", "?"),
                 path=local_path,

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -111,13 +111,26 @@ def write(album_dir: Path, sidecar: Sidecar) -> None:
     library_index.upsert(album_dir, sidecar)
 
 
+def _album_id_of(sc: Sidecar) -> str | None:
+    """The album's canonical id for this sidecar — mirrors `scanner._album_id`
+    (MBID preferred, else temp_uid). `write()` normalises identity before this is
+    called, so exactly one is set. Defined locally: scanner imports sidecar, so
+    importing it back would be circular."""
+    return sc.mb_release_id or sc.temp_uid
+
+
 def _audit_identity_change(album_dir: Path, old: Sidecar | None, new: Sidecar) -> None:
     """Audit a sidecar write that creates a sidecar or changes its load-bearing
-    identity (MBID / Bandcamp item_id / store_url). No-op re-writes don't log."""
+    identity (MBID / Bandcamp item_id / store_url). No-op re-writes don't log.
+
+    Rows carry the album's id AFTER the write; when the id itself changes (an MBID
+    rewrite), the `mbid` field records both sides so the two ids can be linked."""
     new_item = new.bandcamp.item_id if new.bandcamp else None
+    album_id = _album_id_of(new)
     if old is None:
         audit.record(
             "sidecar.create",
+            album_id=album_id,
             album=album_dir,
             mbid=new.mb_release_id,
             item_id=new_item,
@@ -125,7 +138,9 @@ def _audit_identity_change(album_dir: Path, old: Sidecar | None, new: Sidecar) -
         )
         return
     old_item = old.bandcamp.item_id if old.bandcamp else None
-    changes: dict[str, object] = {}
+    # str-valued (not object) so it splats cleanly into audit.record's typed
+    # keyword-only params.
+    changes: dict[str, str] = {}
     if old.mb_release_id != new.mb_release_id:
         changes["mbid"] = f"{old.mb_release_id}->{new.mb_release_id}"
     if old_item != new_item:
@@ -133,7 +148,7 @@ def _audit_identity_change(album_dir: Path, old: Sidecar | None, new: Sidecar) -
     if old.store_url != new.store_url:
         changes["store_url"] = f"{old.store_url}->{new.store_url}"
     if changes:
-        audit.record("sidecar.update", album=album_dir, **changes)
+        audit.record("sidecar.update", album_id=album_id, album=album_dir, **changes)
 
 
 def _normalise_identity(s: Sidecar, album_dir: Path) -> Sidecar:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -2012,7 +2012,10 @@ def _register_routes(app: FastAPI) -> None:
         sc = album.sidecar
         if sc is None or sc.bandcamp is None or sc.bandcamp.item_id is None:
             return _flash_response(
-                "Nothing to unlink", f"{album.title} isn't linked", level=Level.WARNING
+                "Nothing to unlink",
+                f"{album.title} isn't linked",
+                level=Level.WARNING,
+                album_id=album.id,
             )
         old_id = sc.bandcamp.item_id
         if forget_url:
@@ -2026,7 +2029,7 @@ def _register_routes(app: FastAPI) -> None:
             f"Unlinked {album.artist} — {album.title} (was Bandcamp purchase {old_id}): {arrow}"
         )
         request.app.state.scan_runner.request_scan()
-        return _flash_response("Unlinked", f"{album.title} → {dest}")
+        return _flash_response("Unlinked", f"{album.title} → {dest}", album_id=album.id)
 
     @app.post("/library/{album_id}/rematch", response_class=HTMLResponse)
     def library_rematch(request: Request, album_id: str) -> Response:
@@ -2040,7 +2043,10 @@ def _register_routes(app: FastAPI) -> None:
         sc = album.sidecar
         if sc is None or not sc.mb_release_id:
             return _flash_response(
-                "Nothing to re-match", f"{album.title} has no MB release", level=Level.WARNING
+                "Nothing to re-match",
+                f"{album.title} has no MB release",
+                level=Level.WARNING,
+                album_id=album.id,
             )
         old_mbid = sc.mb_release_id
         new_sc = replace(sc, mb_release_id=None, tagged_at=None, mb_match_candidate=None)
@@ -2051,7 +2057,9 @@ def _register_routes(app: FastAPI) -> None:
         )
         request.app.state.scan_runner.request_scan()
         return _flash_response(
-            "MB match cleared", f"{album.title} → Needs MBID — pick the correct release"
+            "MB match cleared",
+            f"{album.title} → Needs MBID — pick the correct release",
+            album_id=album.id,
         )
 
     @app.post("/retag/{album_id}", response_class=HTMLResponse)
@@ -2072,11 +2080,15 @@ def _register_routes(app: FastAPI) -> None:
             )
         except Exception as e:
             log.exception("retag failed")
-            return _flash_response("Re-tag failed", str(e), level=Level.ERROR, tasks_changed=False)
+            return _flash_response(
+                "Re-tag failed", str(e), level=Level.ERROR, tasks_changed=False, album_id=album.id
+            )
         details = f"{album.title} (artwork replaced)" if overwrite_art else album.title
         # Reload the open detail modal so its disk-vs-MB comparison + metadata
         # reflect the just-written tags (tasks-changed only refreshes the tiles).
-        return _flash_response("Re-tagged", details, extra_triggers={"album-retagged": True})
+        return _flash_response(
+            "Re-tagged", details, extra_triggers={"album-retagged": True}, album_id=album.id
+        )
 
     @app.post("/forget/{album_id}", response_class=HTMLResponse)
     def forget(request: Request, album_id: str) -> Response:
@@ -2092,7 +2104,7 @@ def _register_routes(app: FastAPI) -> None:
         if sc_path.exists():
             sc_path.unlink()
         request.app.state.forgotten_paths.add(album.path)
-        return _flash_response("Forgotten", f"{album.title} reverted to NEW")
+        return _flash_response("Forgotten", f"{album.title} reverted to NEW", album_id=album.id)
 
     @app.get("/healthz")
     def healthz(request: Request) -> Response:
@@ -2182,20 +2194,22 @@ def _register_routes(app: FastAPI) -> None:
                 level=Level.ERROR,
                 tasks_changed=False,
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                album_id=album.id,
             )
         if sc is None:
             # reconcile_album returns None for two reasons: existing sidecar
             # (already reconciled, often by the auto-runner) or no MBID atom.
             if sidecar_mod.has_sidecar(album.path):
-                return _flash_response("Already reconciled", album.title)
+                return _flash_response("Already reconciled", album.title, album_id=album.id)
             return _flash_response(
                 "No MBID atom",
                 f"{album.title} has no MusicBrainz Album Id",
                 level=Level.WARNING,
                 tasks_changed=False,
+                album_id=album.id,
             )
         label = "Bandcamp source" if sc.store_url else "manual source"
-        return _flash_response("Reconciled", f"{album.title} ({label})")
+        return _flash_response("Reconciled", f"{album.title} ({label})", album_id=album.id)
 
     @app.post("/recheck/{album_id}", response_class=HTMLResponse)
     def recheck(request: Request, album_id: str) -> Response:
@@ -2207,7 +2221,11 @@ def _register_routes(app: FastAPI) -> None:
             mbids = mb_lookup.lookup_by_bandcamp_url(sc.store_url)
         except mb_lookup.MBError as e:
             return _flash_response(
-                "MB lookup failed", str(e), level=Level.ERROR, tasks_changed=False
+                "MB lookup failed",
+                str(e),
+                level=Level.ERROR,
+                tasks_changed=False,
+                album_id=album.id,
             )
         if not mbids:
             return _flash_response(
@@ -2215,6 +2233,7 @@ def _register_routes(app: FastAPI) -> None:
                 f"{album.title}: no MusicBrainz release for this URL yet",
                 level=Level.WARNING,
                 tasks_changed=False,
+                album_id=album.id,
             )
 
         # A URL can map to several MB releases (e.g. a long digital edition plus
@@ -2225,7 +2244,11 @@ def _register_routes(app: FastAPI) -> None:
                 results, total = mb_lookup.candidate_summaries_for_url(sc.store_url)
             except mb_lookup.MBError as e:
                 return _flash_response(
-                    "MB lookup failed", str(e), level=Level.ERROR, tasks_changed=False
+                    "MB lookup failed",
+                    str(e),
+                    level=Level.ERROR,
+                    tasks_changed=False,
+                    album_id=album.id,
                 )
             return _render_release_picker(
                 request,
@@ -2240,7 +2263,7 @@ def _register_routes(app: FastAPI) -> None:
             releases = [mb_lookup.fetch_release(m) for m in mbids]
         except mb_lookup.MBError as e:
             return _flash_response(
-                "MB fetch failed", str(e), level=Level.ERROR, tasks_changed=False
+                "MB fetch failed", str(e), level=Level.ERROR, tasks_changed=False, album_id=album.id
             )
         candidate = best_match(album.path, releases)
         assert candidate is not None  # releases is non-empty (mbids guarded)
@@ -2262,7 +2285,9 @@ def _register_routes(app: FastAPI) -> None:
         if candidate.confidence == "exact":
             try:
                 _tag_with_release(album.path, mbid, request.app.state.cfg, request.app.state.tagger)
-                return _flash_response("Tagged", f"{album.title} (match found via Recheck)")
+                return _flash_response(
+                    "Tagged", f"{album.title} (match found via Recheck)", album_id=album.id
+                )
             except Exception as e:
                 log.exception("tag after recheck failed")
                 return _flash_response(
@@ -2270,10 +2295,12 @@ def _register_routes(app: FastAPI) -> None:
                     str(e),
                     level=Level.ERROR,
                     tasks_changed=False,
+                    album_id=album.id,
                 )
         return _flash_response(
             "Needs review",
             f"{album.title}: {candidate.confidence} match — please review and confirm",
+            album_id=album.id,
         )
 
     @app.post("/confirm/{album_id}", response_class=HTMLResponse)
@@ -2294,8 +2321,10 @@ def _register_routes(app: FastAPI) -> None:
             )
         except Exception as e:
             log.exception("tag failed")
-            return _flash_response("Tagging failed", str(e), level=Level.ERROR, tasks_changed=False)
-        return _flash_response("Tagged", album.title)
+            return _flash_response(
+                "Tagging failed", str(e), level=Level.ERROR, tasks_changed=False, album_id=album.id
+            )
+        return _flash_response("Tagged", album.title, album_id=album.id)
 
     @app.post("/confirm/{album_id}/incomplete", response_class=HTMLResponse)
     def confirm_match_incomplete(request: Request, album_id: str) -> Response:
@@ -2319,8 +2348,10 @@ def _register_routes(app: FastAPI) -> None:
             )
         except Exception as e:
             log.exception("incomplete tag failed")
-            return _flash_response("Tagging failed", str(e), level=Level.ERROR, tasks_changed=False)
-        return _flash_response("Tagged as incomplete", album.title)
+            return _flash_response(
+                "Tagging failed", str(e), level=Level.ERROR, tasks_changed=False, album_id=album.id
+            )
+        return _flash_response("Tagged as incomplete", album.title, album_id=album.id)
 
     @app.post("/reject/{album_id}", response_class=HTMLResponse)
     def reject_match(request: Request, album_id: str) -> Response:
@@ -2340,7 +2371,7 @@ def _register_routes(app: FastAPI) -> None:
             notes=sc.notes,
         )
         sidecar_mod.write(album.path, new_sc)
-        return _flash_response("Match rejected", album.title)
+        return _flash_response("Match rejected", album.title, album_id=album.id)
 
     @app.post("/surrender/{album_id}/keep", response_class=HTMLResponse)
     def surrender_keep(request: Request, album_id: str) -> Response:
@@ -2381,7 +2412,7 @@ def _register_routes(app: FastAPI) -> None:
         if runner.is_engaged():
             runner.refresh_now()
         request.state.skip_rescan = True
-        return _flash_response("Moved to Library", album.title)
+        return _flash_response("Moved to Library", album.title, album_id=album.id)
 
     @app.post("/unconfirmed/{album_id}/url", response_class=HTMLResponse)
     def update_unconfirmed_url(request: Request, album_id: str, url: str = Form(...)) -> Response:
@@ -2398,7 +2429,9 @@ def _register_routes(app: FastAPI) -> None:
             new_bandcamp = BandcampInfo(item_id=None, band_id=sc.bandcamp.band_id)
         new_sc = _replace_url(sc, url.strip(), new_bandcamp)
         sidecar_mod.write(album.path, new_sc)
-        return _flash_response("URL updated", f"{album.title} — run Sync to confirm")
+        return _flash_response(
+            "URL updated", f"{album.title} — run Sync to confirm", album_id=album.id
+        )
 
     @app.post("/manual/{album_id}/search", response_class=HTMLResponse)
     def manual_search(
@@ -2415,7 +2448,11 @@ def _register_routes(app: FastAPI) -> None:
             results = mb_search.search_releases(artist, title, limit=5)
         except mb_search.MBSearchError as e:
             return _flash_response(
-                "MB search failed", str(e), level=Level.ERROR, tasks_changed=False
+                "MB search failed",
+                str(e),
+                level=Level.ERROR,
+                tasks_changed=False,
+                album_id=album.id,
             )
         return _render_release_picker(
             request, album, results, len(results), heading="MusicBrainz search results"
@@ -2434,7 +2471,11 @@ def _register_routes(app: FastAPI) -> None:
             results, total = mb_lookup.candidate_summaries_for_url(sc.store_url)
         except mb_lookup.MBError as e:
             return _flash_response(
-                "MB lookup failed", str(e), level=Level.ERROR, tasks_changed=False
+                "MB lookup failed",
+                str(e),
+                level=Level.ERROR,
+                tasks_changed=False,
+                album_id=album.id,
             )
         return _render_release_picker(
             request, album, results, total, heading="Releases linked to this store URL"
@@ -2450,6 +2491,7 @@ def _register_routes(app: FastAPI) -> None:
                 "Paste a full MB release URL or the 36-char MBID",
                 level=Level.ERROR,
                 tasks_changed=False,
+                album_id=album.id,
             )
         try:
             status_str, msg = _apply_best_match(
@@ -2457,17 +2499,25 @@ def _register_routes(app: FastAPI) -> None:
             )
         except mb_lookup.MBError as e:
             return _flash_response(
-                "MB lookup failed", str(e), level=Level.ERROR, tasks_changed=False
+                "MB lookup failed",
+                str(e),
+                level=Level.ERROR,
+                tasks_changed=False,
+                album_id=album.id,
             )
         except Exception as e:
             log.exception("manual assign failed")
             return _flash_response(
-                "Assignment failed", str(e), level=Level.ERROR, tasks_changed=False
+                "Assignment failed",
+                str(e),
+                level=Level.ERROR,
+                tasks_changed=False,
+                album_id=album.id,
             )
         # status_str is 'tagged' or 'needs_confirmation' — use the friendlier
         # verb from msg's first clause.
         verb = "Tagged" if status_str == "tagged" else "Needs review"
-        return _flash_response(verb, f"{album.title}: {msg}")
+        return _flash_response(verb, f"{album.title}: {msg}", album_id=album.id)
 
     @app.post("/unconfirmed/{album_id}/manual", response_class=HTMLResponse)
     def mark_unconfirmed_manual(request: Request, album_id: str) -> Response:
@@ -2489,7 +2539,9 @@ def _register_routes(app: FastAPI) -> None:
             notes="marked as purchased elsewhere",
         )
         sidecar_mod.write(album.path, new_sc)
-        return _flash_response("Marked manual", f"{album.title} (purchased elsewhere)")
+        return _flash_response(
+            "Marked manual", f"{album.title} (purchased elsewhere)", album_id=album.id
+        )
 
 
 def _replace_url(sc: Sidecar, new_url: str, new_bandcamp: BandcampInfo | None) -> Sidecar:
@@ -2553,6 +2605,7 @@ def _flash_response(
     tasks_changed: bool = True,
     status_code: int = 200,
     extra_triggers: dict[str, Any] | None = None,
+    album_id: str | None = None,
 ) -> HTMLResponse:
     """Standard action response: flash HTML body + HX-Trigger events.
 
@@ -2569,10 +2622,13 @@ def _flash_response(
     Use for every endpoint that mutates album state. For pure-display
     failures (e.g. MB lookup error with no state change), pass
     `tasks_changed=False` to avoid spurious refreshes.
+
+    Pass `album_id` whenever the action concerns one album, so the entry joins
+    that album's history (#33).
     """
     message = verb if not details else f"{verb} — {details}"
     # Every action outcome is also an activity-log entry (the Activity tab).
-    activity.record(message, level)
+    activity.record(message, level, album_id=album_id)
     triggers: dict[str, Any] = {
         "harmonist-status": {
             "verb": verb,

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -100,6 +100,33 @@ def test_activity_level_wrappers_record_the_right_level():
     assert ("broke", Level.ERROR) in got
 
 
+def test_album_id_filter_spans_both_sources():
+    """The point of album_id (#33): one query returns an album's whole history —
+    the user-facing activity AND the forensic audit rows — and excludes other
+    albums plus events not tied to any album."""
+    activity.info("Re-tagged Album A", album_id="rel-a")
+    audit.record("sidecar.update", album_id="rel-a", mbid="x->y")
+    activity.info("Re-tagged Album B", album_id="rel-b")
+    activity.info("Bandcamp sync started")  # not about one album
+
+    mine = activity_store.recent(album_id="rel-a")
+    assert {e.message for e in mine} == {"Re-tagged Album A", "sidecar.update mbid=x->y"}
+    assert {e.source for e in mine} == {Source.ACTIVITY, Source.AUDIT}
+
+
+def test_album_id_is_none_when_not_supplied():
+    activity.info("Bandcamp sync started")
+    assert activity_store.recent()[0].album_id is None
+
+
+def test_album_id_not_embedded_in_the_audit_message():
+    """album_id is a structured column, not part of the `key=value` line."""
+    audit.record("download", album_id="rel-x", item_id=7)
+    e = activity_store.recent(source=Source.AUDIT)[0]
+    assert e.message == "download item_id=7"
+    assert e.album_id == "rel-x"
+
+
 def test_clear_empties_the_store():
     activity_store.append(message="x", level=Level.INFO, source=Source.ACTIVITY)
     activity_store.clear()
@@ -121,6 +148,42 @@ def test_fresh_db_is_migrated_to_current_schema_version(tmp_path):
     activity_store.append(message="x", level=Level.INFO, source=Source.ACTIVITY)
     assert activity_store.SCHEMA_VERSION >= 1
     assert _user_version(db) == activity_store.SCHEMA_VERSION
+
+
+def test_migrates_a_v1_database_in_place_keeping_its_rows(tmp_path):
+    """A v1 activity.db (no album_id column) written by an older Harmonist must
+    upgrade in place on open — schema bumped, existing rows preserved and readable
+    with album_id NULL. This is the migration machinery doing its job."""
+    db = tmp_path / "v1.db"
+    conn = sqlite3.connect(db, isolation_level=None)
+    conn.executescript(
+        """
+        CREATE TABLE events (
+            id      INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts      TEXT NOT NULL,
+            level   TEXT NOT NULL,
+            source  TEXT NOT NULL,
+            message TEXT NOT NULL
+        );
+        CREATE INDEX idx_events_source_id ON events (source, id);
+        """
+    )
+    conn.execute(
+        "INSERT INTO events (ts, level, source, message) VALUES (?, ?, ?, ?)",
+        ("2026-07-01T00:00:00+00:00", "info", "activity", "written by v1"),
+    )
+    conn.execute("PRAGMA user_version = 1")
+    conn.close()
+
+    activity_store.init(db)  # should migrate 1 -> current
+
+    assert _user_version(db) == activity_store.SCHEMA_VERSION
+    events = activity_store.recent()
+    assert [e.message for e in events] == ["written by v1"]
+    assert events[0].album_id is None  # the new column defaults to NULL
+    # ...and the upgraded DB accepts album-tagged rows.
+    activity.info("after migration", album_id="rel-new")
+    assert [e.message for e in activity_store.recent(album_id="rel-new")] == ["after migration"]
 
 
 def test_downgrade_guard_falls_back_to_memory_without_crashing(tmp_path):

--- a/test/test_bandcamp_hook.py
+++ b/test/test_bandcamp_hook.py
@@ -107,6 +107,38 @@ def test_url_returns_none_with_garbage_hints():
     assert construct_bandcamp_url(item) is None
 
 
+def test_download_audit_id_matches_the_albums_sidecar_id(tmp_path):
+    """A download is audited before any sidecar exists, so the album id is minted
+    from the registry. The sidecar written straight after must adopt that SAME id
+    as its temp_uid — otherwise the download rows would be orphaned from the
+    album's later history (#33)."""
+    from harmonist import activity_store, audit, id_registry
+    from harmonist.activity_store import Source
+
+    id_registry.clear()
+    activity_store.init(tmp_path / "activity.db")
+    activity_store.clear()
+
+    album_dir = tmp_path / "Artist" / "Album"
+    album_dir.mkdir(parents=True)
+
+    # What sync_item does: mint the id, then audit the download against it.
+    album_id = id_registry.get_or_mint(album_dir)
+    audit.record("download", album_id=album_id, item_id=999, path=album_dir)
+
+    # ...then the post-download sidecar write.
+    item = _StubItem(
+        item_id=999,
+        url_hints={"subdomain": "myartist", "slug": "my-album", "item_type": "album"},
+    )
+    assert write_sidecar_for_item(item, album_dir) is True
+
+    # The sidecar adopted the registry id, so both rows share one album id.
+    assert sc.read(album_dir).temp_uid == album_id
+    rows = activity_store.recent(album_id=album_id, source=Source.AUDIT)
+    assert {r.message.split()[0] for r in rows} == {"download", "sidecar.create"}
+
+
 # ---------- write_sidecar_for_item ----------
 
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2108,6 +2108,31 @@ def test_retag_re_runs_tagger(client, cfg, monkeypatch):
     assert loaded.tagged_at > datetime(2026, 1, 1, tzinfo=UTC)
 
 
+def test_album_action_records_activity_against_that_album(client, cfg, monkeypatch):
+    """End-to-end for #33: a per-album action tags its activity entry with the
+    album's id, so the album's history is queryable (and other albums' events
+    aren't mixed in)."""
+    from harmonist import activity_store
+
+    d = _make_tagged_album(
+        cfg, "Historied", mbid="rel-hist", tagged_at=datetime.now(UTC), item_id=3
+    )
+    aid = _id_for(cfg, d)
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
+    )
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    activity_store.clear()
+
+    r = client.post(f"/retag/{aid}")
+    assert r.status_code == 200
+
+    mine = activity_store.recent(album_id=aid)
+    assert any("Re-tagged" in e.message for e in mine)
+    # Nothing recorded against this album belongs to another one.
+    assert all(e.album_id == aid for e in mine)
+
+
 def test_retag_emits_album_retagged_trigger(client, cfg, monkeypatch):
     """On success /retag fires an `album-retagged` HX-Trigger so the open detail
     modal reloads itself — otherwise its disk-vs-MB comparison stays stale (#34)."""


### PR DESCRIPTION
Second increment of #33. Adds a nullable `album_id` column to the event store via a **v1→v2 migration** — the first real use of the `PRAGMA user_version` migration machinery — plus an index and a `recent(album_id=...)` query that spans **both** sources, so one call returns an album's whole history: user-facing activity *and* forensic audit rows together.

`album_id` is threaded through `activity.record/info/warning/error`, `audit.record` and `_flash_response`, and populated at 32 per-album web actions plus the `sidecar.create` / `sidecar.update` audit rows.

**Downloads get an id too.** A download is audited before any sidecar exists, so those rows would otherwise be orphaned. The album id is minted from `id_registry` at download time, and `sidecar.write`'s identity normalisation then adopts that same UUID as `temp_uid` — so the download and the album's later history share one id. A test asserts that continuity.

Events genuinely not about a single album (sync started, `checkpoint.clear`, the low-level bcsync `move` hook where the destination isn't reliably an album dir) carry `None` rather than an invented id.

### Verification

The 32-site population was applied by byte-accurate AST-position insertion, then *proved* rather than eyeballed:

- an AST audit comparing `HEAD` vs the branch shows **every message and level identical — only `album_id` added**;
- a second static check confirms **`album` is bound before every annotated call** (no latent `NameError`).

Both caught real bugs during development (a UTF-8 byte-vs-char offset error, and a nested-function double-annotation), neither of which survived.

Tests: 631 pass, including a v1 database migrating in place with its rows preserved, the cross-source per-album query, and the download-id continuity.

### Scope

Data layer only — the per-album UI reader belongs to #14. Increment 2 of #33; the issue stays open for retention and the reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8