### PR TITLE
Opt-in Playwright smoke test for modal actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: css css-watch test coverage run lint format typecheck template-lint check
+.PHONY: css css-watch test coverage run lint format typecheck template-lint check e2e
 
 # Pin the Tailwind standalone binary so `make css` is byte-reproducible across
 # machines + CI — pytailwindcss otherwise downloads 'latest', whose minified
@@ -46,6 +46,10 @@ template-lint:
 
 # Everything CI would gate on (lint + format + types + tests).
 check: lint format-check typecheck template-lint test
+
+# Browser smoke tests (opt-in): pip install -e .[e2e] && playwright install chromium
+e2e:
+	RUN_E2E=1 pytest test/e2e/
 
 # Local dev server. Set HARMONIST_MUSIC_DIR / HARMONIST_CONFIG_DIR as needed.
 run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = ["mutagen", "bandcampsync~=0.8.0", "fastapi", "jinja2", "httpx", 
 # a dev machine and CI (a patch bump reformats code), which fails the format
 # check on a green-locally branch. Bump deliberately, like TAILWINDCSS_VERSION.
 dev = ["pytest", "pytest-mock", "pytailwindcss", "ruff==0.16.0", "mypy==2.3.0", "coverage"]
+# Browser smoke tests (opt-in; see test/e2e/). Needs `playwright install chromium`.
+e2e = ["pytest-playwright"]
 
 [tool.setuptools.packages]
 find = {where = ["src"], include = ["harmonist*"]}

--- a/test/e2e/test_modal_smoke.py
+++ b/test/e2e/test_modal_smoke.py
@@ -1,0 +1,93 @@
+"""Browser smoke test for modal actions (the layer unit tests can't see).
+
+Issue #40 was invisible to the Python suite: the handler, template, and
+route were all individually correct — only a real browser exercises the
+onclick/htmx event ordering. This smoke test opens the album detail dialog
+in demo mode and verifies that a destructive-ish action button actually
+fires its confirm and its request.
+
+Opt-in: requires playwright (`pip install -e .[e2e]` + `playwright install
+chromium`) and RUN_E2E=1, so `make test` / `make check` stay green without
+a browser. Run via `make e2e`.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1", reason="e2e disabled (set RUN_E2E=1)"
+)
+playwright_sync = pytest.importorskip("playwright.sync_api")
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture(scope="module")
+def demo_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Uvicorn in demo mode against throwaway dirs; yields the base URL."""
+    root = tmp_path_factory.mktemp("e2e")
+    port = _free_port()
+    env = os.environ | {
+        "HARMONIST_DEMO_MODE": "1",
+        "HARMONIST_MUSIC_DIR": str(root / "music"),
+        "HARMONIST_CONFIG_DIR": str(root / "config"),
+    }
+    (root / "music").mkdir()
+    (root / "config").mkdir()
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "harmonist.web.main:app", "--port", str(port)],
+        env=env,
+        cwd=Path(__file__).resolve().parents[2],
+    )
+    base = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
+                    break
+            except OSError:
+                time.sleep(0.3)
+        else:
+            pytest.fail("demo server did not come up")
+        yield base
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def test_album_dialog_rematch_fires_confirm_and_post(demo_server: str) -> None:
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        page.goto(demo_server)
+
+        # Library tab → first tile → native dialog opens.
+        page.click('[data-tab="library"]')
+        page.locator("#panel-library img").first.click()
+        dialog = page.locator("#modal dialog[open]")
+        dialog.wait_for(state="visible")
+
+        # Accept the hx-confirm, then click the rematch pencil and require
+        # that the POST is actually issued — the #40 regression check.
+        page.on("dialog", lambda d: d.accept())
+        with page.expect_request(lambda r: "/rematch" in r.url and r.method == "POST"):
+            page.click('button[hx-post*="/rematch"]')
+
+        # On success the dialog closes (hx-on::after-request) and the mount
+        # is cleared by the close handler in base.html.
+        page.locator("#modal dialog").wait_for(state="detached")
+        browser.close()


### PR DESCRIPTION
Fixes #55.

#40 was invisible to the Python suite by construction: route, template and handler were each individually correct — the bug lived in browser event ordering, a layer with 0% coverage. This adds one opt-in Playwright smoke test that opens the album `<dialog>` in demo mode, accepts the `hx-confirm`, and asserts the POST is actually issued and the dialog closes on success.

Opt-in behind `RUN_E2E=1` + the `[e2e]` extra + a `make e2e` target, so `make check` and CI stay browser-free (wiring chromium into CI is a separate decision).

**Validated locally** — the scaffold was authored without a browser, so it needed a real run before merge:

- `uv pip install -e '.[e2e]'` + `playwright install chromium`, then `make e2e` → passes, no selector adjustments needed.
- Mutation-checked so we know it can fail: reintroducing the #40 pattern (`onclick="harmonistCloseModal()"` on the rematch button, `harmonistCloseModal` back to wiping `innerHTML`) makes it fail on the `expect_request` for `POST /rematch`. Restored → green.

Known gap, not addressed here: the test covers the rematch pencil, not the "Link this to …" button that #53 actually fixed — reaching that dialog in demo mode needs a completed Bandcamp sync, so the pending section is empty on a cold start. The template lint from #54 covers that button statically.