### PR TITLE
Template lint: no onclick alongside hx-*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: css css-watch test coverage run lint format typecheck check
+.PHONY: css css-watch test coverage run lint format typecheck template-lint check
 
 # Pin the Tailwind standalone binary so `make css` is byte-reproducible across
 # machines + CI — pytailwindcss otherwise downloads 'latest', whose minified
@@ -39,8 +39,13 @@ format-check:
 typecheck:
 	mypy
 
+# Forbid onclick alongside hx-* on one element (the #40 race) — see
+# scripts/lint_templates.py for the rationale.
+template-lint:
+	python3 scripts/lint_templates.py
+
 # Everything CI would gate on (lint + format + types + tests).
-check: lint format-check typecheck test
+check: lint format-check typecheck template-lint test
 
 # Local dev server. Set HARMONIST_MUSIC_DIR / HARMONIST_CONFIG_DIR as needed.
 run:

--- a/scripts/lint_templates.py
+++ b/scripts/lint_templates.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Template lint: forbid `onclick` alongside `hx-*` on the same element.
+
+Why: an inline onclick runs before htmx's *delegated* click handler. If the
+onclick mutates the DOM so the element is detached (e.g. closing a modal by
+wiping innerHTML), htmx never fires its confirm or request — the button
+silently does nothing except whatever the onclick did. This bit us in #40
+(and a second latent instance on the verify-dialog Link button). The safe
+pattern is to let htmx own the click and sequence side effects declaratively
+(`hx-on::after-request`, `hx-on::before-request`, ...).
+
+Mechanical rule, so it lives here (Makefile `check`) rather than in the
+review-gate skill — see CLAUDE.md "Working conventions".
+
+Exit 0 when clean; exit 1 listing template:line for each offending element.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+TEMPLATES = Path(__file__).resolve().parent.parent / "templates"
+
+# An open tag, possibly spanning lines. Jinja `{{ ... }}` inside attribute
+# values can contain `>` only via filters we don't use; good enough for lint.
+OPEN_TAG = re.compile(r"<[a-zA-Z][^>]*>", re.DOTALL)
+ONCLICK = re.compile(r"\bonclick\s*=", re.IGNORECASE)
+HX_ATTR = re.compile(r"\bhx-[a-z:.-]+\s*=", re.IGNORECASE)
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in sorted(TEMPLATES.rglob("*.html")):
+        text = path.read_text(encoding="utf-8")
+        for match in OPEN_TAG.finditer(text):
+            tag = match.group(0)
+            if ONCLICK.search(tag) and HX_ATTR.search(tag):
+                line = text.count("\n", 0, match.start()) + 1
+                rel = path.relative_to(TEMPLATES.parent)
+                failures.append(f"{rel}:{line}: element mixes onclick with hx-*")
+    if failures:
+        print("template-lint: onclick must not share an element with hx-* attributes")
+        print("(onclick runs before htmx's delegated handler — see #40)\n")
+        print("\n".join(failures))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #54.

An inline `onclick` runs before htmx's delegated click handler. If it detaches the element — closing a modal destructively, re-swapping the container — htmx never fires its `hx-confirm` and never sends the request; the control silently does nothing. That was #40, and a second latent instance survived on the verify-dialog Link button until the `<dialog>` migration.

The rule is mechanical and grep-able, so it belongs in tooling rather than a review checklist (per the CLAUDE.md split: design invariants → review-gate skill, mechanical rules → Makefile enforcement). `scripts/lint_templates.py` scans template open tags and fails on any element carrying both, pointing at the safe pattern. Wired into `make check` as `template-lint`.

Verified to have teeth: reintroducing the #40 pattern on the rematch button makes the lint fail at `library_detail.html:45`; restoring it passes.

(Supersedes #57, which GitHub auto-closed when its base branch was deleted on merge of #56.)