### PR TITLE
Fix flaky engaged-lifespan test; tolerate request_scan after shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Shutting down while a reconcile pass was finishing no longer logs a spurious
+  "reconcile run failed — Event loop is closed" error; the pass's trailing
+  rescan request is simply dropped.
 - Linking a potential download from the "Verify album" dialog now actually links
   it — previously the dialog closed without sending the request (same root cause
   as #40: closing from `onclick` detached the button before HTMX could act).

--- a/src/harmonist/web/scan_runner.py
+++ b/src/harmonist/web/scan_runner.py
@@ -160,11 +160,10 @@ class ScanRunner:
     def request_scan(self) -> None:
         """Mark the library dirty and ensure a scan runs. Thread-safe — safe to
         call from FastAPI's sync route handlers (threadpool) and the sync/
-        reconcile runner threads. No-op until engaged."""
-        loop = self._loop
-        if loop is None:
-            return
-        loop.call_soon_threadsafe(self._kick)
+        reconcile runner threads. No-op until engaged, and again after the app
+        shuts down — a sync/reconcile thread finishing its last pass during
+        teardown must not die with 'Event loop is closed' (issue #52)."""
+        self._kick_threadsafe(self._kick)
 
     def reset_and_rescan(self) -> None:
         """Drop the current snapshot, then kick a fresh scan. Used after a nuke
@@ -175,10 +174,19 @@ class ScanRunner:
         (The rescan itself is cheap now — erasing sidecars leaves the audio
         unchanged, so the cache reuses the tag fields and only re-reads the absent
         sidecars.)"""
+        self._kick_threadsafe(self._reset_and_kick)
+
+    def _kick_threadsafe(self, kick: Callable[[], None]) -> None:
+        # No-op when not yet engaged OR the loop has since closed (app shutdown).
+        # The is_closed() check races with close(), so the call itself can still
+        # raise — swallow that too; a scan requested during teardown is moot.
         loop = self._loop
-        if loop is None:
+        if loop is None or loop.is_closed():
             return
-        loop.call_soon_threadsafe(self._reset_and_kick)
+        try:
+            loop.call_soon_threadsafe(kick)
+        except RuntimeError:
+            pass
 
     def _reset_and_kick(self) -> None:
         # On the loop thread: clear the snapshot before the scan task starts so a

--- a/test/test_scan_runner.py
+++ b/test/test_scan_runner.py
@@ -51,6 +51,23 @@ def test_refresh_now_updates_snapshot_without_scanning_status(tmp_path):
     assert {a.path.name for a in runner.albums()} == {"One", "Two"}
 
 
+def test_request_scan_after_loop_close_is_noop(tmp_path):
+    """A sync/reconcile thread can outlive the app's event loop (daemon thread,
+    lifespan already torn down) and still call request_scan() as its last act.
+    That must be a silent no-op, not 'RuntimeError: Event loop is closed'
+    surfacing as a bogus 'reconcile run failed' (issue #52)."""
+    runner = ScanRunner(tmp_path)
+
+    async def go() -> None:
+        runner.attach_loop()
+        await _wait(runner.has_completed)
+
+    asyncio.run(go())  # asyncio.run closes the loop on exit
+    assert runner.is_engaged()  # still holds the (now closed) loop
+    runner.request_scan()  # must not raise
+    runner.reset_and_rescan()  # must not raise, must not clear the snapshot
+
+
 def test_reset_and_rescan_no_loop_is_noop(tmp_path):
     """Before the runner is engaged, reset_and_rescan must be a safe no-op (the
     erase-sidecars handler may run before/without the background loop)."""

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2803,19 +2803,37 @@ def test_tasks_shows_scanning_placeholder_while_scanning(client, cfg, monkeypatc
 def test_engaged_lifespan_serves_background_scan_snapshot(cfg):
     """With the lifespan running (TestClient as a context manager), the
     background scanner engages and routes serve its snapshot — not a
-    request-time scan. The /scan/status endpoint reports progress."""
+    request-time scan. The /scan/status endpoint reports progress.
+
+    Startup also auto-kicks a reconcile pass the moment the first scan
+    completes, and /tasks deliberately replaces the album cards with a
+    "Sorting your library…" progress panel while reconcile is running — so
+    asserting on /tasks right after the scan reports "done" raced that pass
+    (the issue #52 flake: near-instant locally, but a late-scheduled thread
+    on a loaded CI runner left it mid-pass). Wait for full startup
+    quiescence — scan done AND the reconcile pass finished — first."""
     import time as _time
 
     _make_album(cfg, "BgAlbum")  # present before startup → initial scan finds it
     with TestClient(create_app(cfg), headers={"HX-Request": "true"}) as client:
-        status = {}
+        status: dict = {}
+        reconcile: dict = {}
         for _ in range(200):
             status = client.get("/scan/status").json()
-            if status["state"] == "done":
+            reconcile = client.get("/reconcile/status").json()
+            # finished_at set ⇒ the startup reconcile ran to completion (its
+            # initial state is also "idle", so "idle" alone can't tell
+            # not-yet-started from done).
+            if (
+                status["state"] == "done"
+                and reconcile["state"] == "idle"
+                and (reconcile["finished_at"] is not None)
+            ):
                 break
             _time.sleep(0.02)
         assert status["state"] == "done"
         assert status["albums_found"] == 1
+        assert reconcile["state"] == "idle" and reconcile["finished_at"] is not None
         # /tasks serves the snapshot the background scan produced.
         assert "BgAlbum" in client.get("/tasks").text
 


### PR DESCRIPTION
Root-causes and fixes the `test_engaged_lifespan_serves_background_scan_snapshot` flake (2 CI hits on unrelated branches, never reproducible locally).

## Root cause

The failure text was the tell. `0 Needs Link · 0 to Library` is the `{% if reconciling %}` branch of `tasks.html` — not the empty-inbox branch and not the scanning branch. The first scan's completion auto-kicks a reconcile pass via `set_on_first_complete`, and while that pass runs `/tasks` deliberately replaces the album cards with the "Sorting your library…" progress panel.

So: the scan reports `done` + `albums_found == 1` (both genuinely true), the test breaks out of its poll loop, and the `/tasks` request lands while the reconcile daemon thread is still mid-pass — the page hides the cards, so `BgAlbum` isn't in it. The snapshot was intact the whole time.

The one-orphan pass (no MBID atom, no network) finishes in well under a millisecond locally, so the window is effectively unhittable; on a loaded CI runner the thread is scheduled late and it opens. Delaying `reconcile_pending_orphans` by 0.5s makes the old test fail every time with the exact CI signature, and the new test pass under that same schedule.

**The issue's open question is answered:** a client can never observe `state == "done"` alongside an empty snapshot. There is no production bug on the read path — the render was the intended reconciling UI.

## The teardown noise is the same thread

`reconcile run failed` / `RuntimeError: Event loop is closed` is the same late reconcile thread finishing after the TestClient's loop closed and calling `scan_runner.request_scan()` as its last act. Not a separate cause, but the mislabelled failure was worth fixing on its own.

## Changes

- **`test/test_web.py`** — the test waits for startup quiescence (scan done **and** the reconcile pass finished) before asserting on `/tasks`. `state == "idle"` alone can't distinguish not-yet-started from done, so it also requires `finished_at` to be set.
- **`src/harmonist/web/scan_runner.py`** — `request_scan()` / `reset_and_rescan()` route through a shared `_kick_threadsafe` that treats a closed loop like the not-engaged case (a scan requested during teardown is moot), swallowing the `RuntimeError` that races `close()`.
- **`test/test_scan_runner.py`** — covers `request_scan()` / `reset_and_rescan()` after the loop has closed.
- **`CHANGELOG.md`** — entry for the spurious shutdown error.

`make check` green locally: 632 passed, 2 skipped.

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8