### PR TITLE
Capture album identity aliases so history survives a re-identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Links and bookmarks to an album keep working after Harmonist re-identifies it
+  (tagging it, or correcting its MusicBrainz match) — previously the old link
+  dead-ended, and a restart made it unrecoverable. Harmonist now remembers that
+  an album's identity moved, so its history stays joined to it.
 - The "that album isn't in your library any more" notice can now be dismissed,
   and no longer reappears when you refresh.
 - Demo mode no longer writes into your real activity history, and no longer logs

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -87,6 +87,23 @@ _MIGRATIONS: tuple[tuple[str, ...], ...] = (
     # events not about one album, and rows written before this migration, have
     # none. No index — it's display-only, never a query key.
     ("ALTER TABLE events ADD COLUMN album_label TEXT",),
+    # 3 -> 4: album identity aliases (#33). Album ids MOVE: tagging drops the
+    # sidecar's temp_uid in favour of the MBID, a re-match rewrites the MBID, an
+    # unlink reverses it. Crucially the superseded id is ERASED from disk, so the
+    # link between an album's past and present identity is observable ONLY at the
+    # instant it changes — after that, nothing can reconstruct it. Recording the
+    # pair keeps an album's history joinable across the flip (#14) and lets a
+    # deep link written under the old id still resolve.
+    # old_id is the PK: an id is superseded exactly once, so it maps forward to at
+    # most one successor. new_id is indexed for the reverse walk (#14's union).
+    (
+        """CREATE TABLE album_aliases (
+            old_id TEXT PRIMARY KEY,
+            new_id TEXT NOT NULL,
+            ts     TEXT NOT NULL
+        )""",
+        "CREATE INDEX idx_album_aliases_new_id ON album_aliases (new_id)",
+    ),
 )
 
 SCHEMA_VERSION = len(_MIGRATIONS)  # the version this build expects/creates
@@ -258,12 +275,70 @@ def recent(
     ]
 
 
+def record_alias(old_id: str, new_id: str) -> None:
+    """Remember that `old_id` became `new_id` (#33).
+
+    Called at the moment an album's identity changes, which is the only time the
+    pair is knowable — the superseded id is erased from the sidecar, so this is
+    not reconstructible after the fact. Best-effort: identity changes must not
+    fail because the log is unavailable.
+
+    Idempotent via REPLACE: re-writing the same sidecar re-asserts the same pair
+    rather than erroring on the primary key.
+    """
+    if not old_id or not new_id or old_id == new_id:
+        return
+    ts = datetime.now(UTC).isoformat()
+    try:
+        conn = _ensure()
+        with _LOCK:
+            conn.execute(
+                "INSERT OR REPLACE INTO album_aliases (old_id, new_id, ts) VALUES (?, ?, ?)",
+                (old_id, new_id, ts),
+            )
+            conn.commit()
+    except sqlite3.Error:
+        log.debug("activity_store record_alias failed", exc_info=True, extra={"_activity": True})
+
+
+def resolve_alias(album_id: str, *, max_hops: int = 20) -> str | None:
+    """Follow the alias chain forward to the album's CURRENT id, or None if this
+    id was never superseded.
+
+    Walks transitively (temp_uid -> mbid -> corrected mbid). `max_hops` and the
+    seen-set bound the walk: a cycle would otherwise spin forever, and while the
+    schema shouldn't permit one, a log is not worth hanging a request over.
+    """
+    seen = {album_id}
+    current = album_id
+    try:
+        conn = _ensure()
+        with _LOCK:
+            for _ in range(max_hops):
+                row = conn.execute(
+                    "SELECT new_id FROM album_aliases WHERE old_id = ?", (current,)
+                ).fetchone()
+                if row is None or row[0] in seen:
+                    break
+                current = row[0]
+                seen.add(current)
+    except sqlite3.Error:
+        return None
+    return None if current == album_id else current
+
+
 def clear() -> None:
-    """Drop all events (tests / demo reset)."""
+    """Drop all stored state — events AND aliases (tests / demo reset).
+
+    Aliases go too: they describe albums in the library this store was recording,
+    so after a demo re-seed (or between tests) they'd point at identities that no
+    longer exist, and could mis-resolve a deep link to the wrong album.
+    """
     try:
         conn = _ensure()
         with _LOCK:
             conn.execute("DELETE FROM events")
+            conn.execute("DELETE FROM album_aliases")
             conn.commit()
     except sqlite3.Error:
         pass

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from . import audit, id_registry, library_index
+from . import activity_store, audit, id_registry, library_index
 
 # Re-exported so existing `from harmonist.sidecar import CURRENT_SCHEMA_VERSION`
 # keeps working; it's defined in models.py so Sidecar can default to it.
@@ -106,6 +106,7 @@ def write(album_dir: Path, sidecar: Sidecar) -> None:
         os.fsync(f.fileno())
     os.replace(tmp, target)
     _audit_identity_change(album_dir, old, sidecar)
+    _record_identity_alias(old, sidecar)
     # The ONE place the in-memory index learns of a sidecar change (link, demote,
     # tag, download, reconcile all land here) — so sync-time dedup never re-reads.
     library_index.upsert(album_dir, sidecar)
@@ -117,6 +118,29 @@ def _album_id_of(sc: Sidecar) -> str | None:
     called, so exactly one is set. Defined locally: scanner imports sidecar, so
     importing it back would be circular."""
     return sc.mb_release_id or sc.temp_uid
+
+
+def _record_identity_alias(old: Sidecar | None, new: Sidecar) -> None:
+    """Durably link an album's superseded id to its new one (#33).
+
+    This write is the ONLY moment the pair is knowable: `_normalise_identity`
+    drops `temp_uid` once an MBID lands, so a second later there is nothing on
+    disk connecting the two. Without the alias, everything recorded under the old
+    id — the album's whole pre-tag history, and any deep link already written into
+    the activity feed — is orphaned the instant it's tagged.
+
+    Covers every direction, since it compares canonical ids rather than fields:
+    temp_uid -> MBID (tag/reconcile), MBID -> MBID (re-match), MBID -> temp_uid
+    (unlink). A create (`old is None`) supersedes nothing.
+
+    The audit trail already notes the change, but only as a message string —
+    unqueryable, so it can't answer "what is this album's id now?".
+    """
+    if old is None:
+        return
+    old_id, new_id = _album_id_of(old), _album_id_of(new)
+    if old_id and new_id and old_id != new_id:
+        activity_store.record_alias(old_id, new_id)
 
 
 def _audit_identity_change(album_dir: Path, old: Sidecar | None, new: Sidecar) -> None:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1139,6 +1139,17 @@ def _find_album(request: Request, album_id: str) -> Album:
         for a in albums:
             if a.path == legacy_path:
                 return a
+    # Durable fallback: the album's identity has since MOVED (tagging replaced its
+    # temp_uid with an MBID, a re-match rewrote the MBID). The registry can't help
+    # — it's in-memory and only knows ids it minted, so it's empty for anything
+    # already sidecar'd and after every restart. The alias chain, recorded at each
+    # change, does: it maps the superseded id forward to the current one (#33).
+    # This is what keeps an old activity-feed deep link working.
+    current_id = activity_store.resolve_alias(album_id)
+    if current_id is not None:
+        for a in albums:
+            if a.id == current_id:
+                return a
     raise HTTPException(status.HTTP_404_NOT_FOUND, f"album {album_id} not found")
 
 

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -298,3 +298,99 @@ def test_non_demo_mode_still_writes_the_file(tmp_path):
     activity.record("persisted event")
 
     assert (cfg.paths.config_dir / "activity.db").exists()
+
+
+# ---------- album identity aliases (#33) ----------
+
+
+def test_migrates_a_v3_database_in_place_keeping_its_rows(tmp_path):
+    """The 3 -> 4 upgrade (album_aliases): a v3 activity.db gains the table in
+    place, keeps every existing row, and starts empty of aliases. Built from a
+    PREFIX of the real _MIGRATIONS so it can't drift from what shipped."""
+    db = tmp_path / "v3.db"
+    conn = sqlite3.connect(db, isolation_level=None)
+    for step in activity_store._MIGRATIONS[:3]:
+        for stmt in step:
+            conn.execute(stmt)
+    conn.execute(
+        "INSERT INTO events (ts, level, source, message, album_id) VALUES (?, ?, ?, ?, ?)",
+        ("2026-07-01T00:00:00+00:00", "info", "activity", "written by v3", "rel-old"),
+    )
+    conn.execute("PRAGMA user_version = 3")
+    conn.close()
+
+    activity_store.init(db)
+
+    assert _user_version(db) == activity_store.SCHEMA_VERSION
+    assert [e.message for e in activity_store.recent()] == ["written by v3"]
+    assert activity_store.resolve_alias("rel-old") is None  # no aliases yet
+    # ...and the upgraded DB accepts them.
+    activity_store.record_alias("rel-old", "rel-new")
+    assert activity_store.resolve_alias("rel-old") == "rel-new"
+
+
+def test_resolve_alias_follows_a_chain_and_survives_a_cycle(tmp_path):
+    """Identity can move more than once (temp_uid -> mbid -> corrected mbid), so
+    resolution is transitive. A cycle must terminate rather than hang a request."""
+    activity_store.init(tmp_path / "a.db")
+    activity_store.record_alias("uid-1", "mbid-a")
+    activity_store.record_alias("mbid-a", "mbid-b")
+    assert activity_store.resolve_alias("uid-1") == "mbid-b"
+    assert activity_store.resolve_alias("mbid-a") == "mbid-b"
+    assert activity_store.resolve_alias("mbid-b") is None  # current; nothing beyond
+    assert activity_store.resolve_alias("never-seen") is None
+
+    # A -> B -> A must not spin.
+    activity_store.record_alias("mbid-b", "uid-1")
+    assert activity_store.resolve_alias("uid-1") is not None  # terminates
+
+
+def test_clear_drops_aliases_too(tmp_path):
+    """A demo re-seed (or the next test) must not inherit aliases pointing at
+    albums that no longer exist — they could mis-resolve a deep link."""
+    activity_store.init(tmp_path / "a.db")
+    activity_store.record_alias("old", "new")
+    activity_store.clear()
+    assert activity_store.resolve_alias("old") is None
+
+
+def test_sidecar_write_records_the_identity_change(tmp_path):
+    """Capture happens at the sidecar write — the only moment the pair is
+    knowable, since normalisation erases temp_uid once an MBID lands."""
+    from harmonist import sidecar as sc
+    from harmonist.models import Sidecar
+
+    activity_store.init(tmp_path / "a.db")
+    album = tmp_path / "album"
+    album.mkdir()
+
+    sc.write(album, Sidecar(store_url="https://x.bandcamp.com/album/y"))
+    uid = sc.read(album).temp_uid
+    assert uid
+
+    # Tagging moves the identity to the MBID and erases temp_uid...
+    sc.write(album, Sidecar(store_url="https://x.bandcamp.com/album/y", mb_release_id="rel-1"))
+    assert sc.read(album).temp_uid is None
+    # ...but the link survives in the alias table.
+    assert activity_store.resolve_alias(uid) == "rel-1"
+
+    # A re-match (MBID -> MBID) is captured too, and chains.
+    sc.write(album, Sidecar(store_url="https://x.bandcamp.com/album/y", mb_release_id="rel-2"))
+    assert activity_store.resolve_alias("rel-1") == "rel-2"
+    assert activity_store.resolve_alias(uid) == "rel-2"
+
+
+def test_sidecar_create_and_noop_rewrite_record_no_alias(tmp_path):
+    """A create supersedes nothing, and re-writing an unchanged identity must not
+    manufacture a self-alias."""
+    from harmonist import sidecar as sc
+    from harmonist.models import Sidecar
+
+    activity_store.init(tmp_path / "a.db")
+    album = tmp_path / "album"
+    album.mkdir()
+
+    sc.write(album, Sidecar(mb_release_id="rel-1"))
+    assert activity_store.resolve_alias("rel-1") is None
+    sc.write(album, Sidecar(mb_release_id="rel-1", notes="changed something else"))
+    assert activity_store.resolve_alias("rel-1") is None

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2316,6 +2316,34 @@ def test_successful_deep_link_keeps_the_url_parameter(client, cfg):
     assert 'id="deep-link-notice"' not in body
 
 
+def test_deep_link_resolves_through_the_alias_chain_after_a_restart(client, cfg):
+    """#33's payoff, and the case the registry CANNOT cover.
+
+    An album that already had a sidecar was never registry-minted, and the
+    registry is in-memory anyway — so after a restart it knows nothing. When
+    tagging then moves the album's identity (temp_uid dropped for the MBID), a
+    deep link written under the old id has no way home. The durable alias chain,
+    recorded at the moment of the change, is what rescues it.
+    """
+    from harmonist import id_registry
+
+    d = _make_album(cfg, "Aliased")
+    sc.write(d, Sidecar(store_url="https://x.bandcamp.com/album/aliased"))
+    old_id = _id_for(cfg, d)
+
+    # Tag it: identity moves to the MBID and temp_uid is erased from disk.
+    sc.write(d, Sidecar(store_url="https://x.bandcamp.com/album/aliased", mb_release_id="rel-al"))
+    id_registry.clear()  # as after a restart — the in-memory fallback is empty
+    assert sc.read(d).temp_uid is None
+    assert _id_for(cfg, d) == "rel-al"
+
+    r = client.get(f"/?album={old_id}")
+    assert r.status_code == 200
+    assert "isn't in your library any more" not in r.text
+    # Resolved forward to the album's CURRENT id.
+    assert 'hx-get="/library/rel-al/detail"' in r.text
+
+
 def test_deep_link_follows_moved_album_id(client, cfg):
     """The id in an old activity row is a snapshot. When a NEW album's registry
     UUID is superseded (a sidecar write giving it an MBID identity), the deep
@@ -2863,9 +2891,16 @@ def test_canonical_id_change_mid_transaction(client, cfg, monkeypatch):
     # Album's canonical id is now the MBID
     assert _id_for(cfg, d) == mbid
 
-    # The old temp_uid URL no longer resolves
+    # The old temp_uid URL STILL resolves — to the same album. This assertion was
+    # inverted by #33: it previously expected 404, which encoded the limitation of
+    # the in-memory registry (empty for anything already sidecar'd, and after any
+    # restart) rather than a design goal. `_find_album` has always intended the
+    # opposite — "404 only when we can't resolve the id any way" — and the durable
+    # alias chain now makes that achievable. The id refers to the same album, so
+    # acting on it is correct; a stale page's buttons keep working instead of
+    # dead-ending.
     r_stale = client.post(f"/recheck/{temp_uid}")
-    assert r_stale.status_code == 404
+    assert r_stale.status_code == 200
 
 
 # ---------- activity feed ----------


### PR DESCRIPTION
#33 specified an alias table and it was never built. It matters **now**, before dogfooding 1.1.

## Why this can't wait

Album ids move — tagging drops the sidecar's `temp_uid` for the MBID, a re-match rewrites the MBID, an unlink reverses it — and the superseded id is **erased from disk** (`_normalise_identity`). So the pair is knowable *only at the instant it changes*; a second later nothing can reconstruct it.

That means every event recorded under an album's old id is orphaned the moment it's tagged, permanently. Dogfooding 1.1 without capture would fragment that history irrecoverably at every tag.

`_live_album_ref` (#65) fixed which id **new** entries carry. It does nothing for *joining across the flip*, which is exactly what #14's per-album history needs.

## Capture

In `sidecar.write()` — the single funnel every identity change passes through (tag, reconcile, unlink, re-match all land there). It compares **canonical ids** rather than individual fields, so one check covers every direction: `temp_uid → MBID`, `MBID → MBID`, `MBID → temp_uid`.

The audit trail already noted these changes, but only as a message string (`"old->new"`) — unqueryable, so it can't answer "what is this album's id now?".

## Ships with a reader, not as scaffolding

Per the `schema-migration` rule that a new table be load-bearing on day one, `_find_album` now follows the alias chain. Concrete affordance: **a deep link written under an album's old id still resolves.**

The in-memory `id_registry` could never cover this — it only knows ids *it* minted (so nothing already sidecar'd, e.g. a seeded or long-lived library) and it's empty after every restart. The durable chain is what makes `_find_album`'s long-standing promise — *"404 only when we can't resolve the id any way"* — actually true.

Resolution is transitive (`temp_uid → mbid → corrected mbid`) and bounded by a hop limit and seen-set, so a cycle terminates rather than hanging a request.

## ⚠️ Deliberate behavior change

`test_canonical_id_change_mid_transaction` asserted a stale `temp_uid` URL returns **404**; it now returns **200**.

That assertion encoded the registry's *limitation*, not a design goal — `_find_album` has always documented the opposite intent. The id refers to the same album, so acting on it is correct, and a stale page's buttons keep working instead of dead-ending. The test's actual subject (no mid-transaction redirect; 200 + `tasks-changed`) is unchanged. **Flagging it explicitly because it inverts a shipped assertion.**

## Scope

Query-side union over an album's aliases is left to #14, where it has a consumer. This PR is capture + the one reader that justifies the table, so `Part of #33` rather than closing it.

## Verification

- Migration **3 → 4** built from a *prefix of the real `_MIGRATIONS`* so the upgrade test can't drift from what shipped; existing rows preserved, aliases start empty.
- Chain resolution, cycle termination, and `clear()` dropping aliases (so a demo re-seed can't mis-resolve a link) all covered.
- The end-to-end deep-link test is **mutation-checked** — removing the fallback fails it.
- `make check` green: 674 passed. `make e2e` green: 4 passed.

Part of #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8