### PR TITLE
Link the remaining per-album activity entries (sync + reconcile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Activity entries written by a sync or by auto-reconcile now name and link their
+  album too — including "Auto-tagged … after sync", the one worth clicking when
+  Harmonist has tagged something on its own initiative. Previously only entries
+  from actions you took yourself were linked.
+
 ## [1.1.0] - 2026-07-31
 
 ### Added

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -112,6 +112,24 @@ def write(album_dir: Path, sidecar: Sidecar) -> None:
     library_index.upsert(album_dir, sidecar)
 
 
+def album_id_for(album_dir: Path) -> str | None:
+    """The album's canonical id as recorded ON DISK right now, or None if it has
+    no sidecar yet.
+
+    Read this AFTER a mutation, never before: tagging drops the sidecar's
+    `temp_uid` in favour of the MBID, so an id captured beforehand is frequently
+    already dead (#65). Callers that want to tie a log entry to an album need the
+    id that will still resolve afterwards.
+
+    Lives here because identity is the sidecar's business, and callers outside
+    the web layer (the reconcile runner) need it too."""
+    try:
+        sc = read(album_dir)
+    except Exception:
+        return None
+    return None if sc is None else _album_id_of(sc)
+
+
 def _album_id_of(sc: Sidecar) -> str | None:
     """The album's canonical id for this sidecar — mirrors `scanner._album_id`
     (MBID preferred, else temp_uid). `write()` normalises identity before this is

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1585,16 +1585,35 @@ def _resolve_by_store_url(album_path: Path, cfg: config_mod.Config, tagger: Tagg
     sc = sidecar_mod.read(album_path)
     if sc is None or not sc.store_url or sc.mb_release_id:
         return "skipped"  # nothing to resolve, or already resolved
+    # The album's name for the feed's album column. No artist/title is available
+    # on this path — neither MatchCandidate nor BandcampInfo carries one, and
+    # _apply_best_match returns plain strings — so use the directory name, which
+    # is what these messages already displayed and what bandcampsync put on disk.
+    label = album_path.name
     try:
         mbids = mb_lookup.lookup_by_bandcamp_url(sc.store_url)
         if not mbids:
-            activity.record(f"Synced {album_path.name} — no MusicBrainz match yet")
+            # Ids are read back from disk AFTER each mutation below, never from
+            # `sc` above: tagging drops temp_uid for the MBID, so the id captured
+            # before the write is often already dead (#65).
+            activity.record(
+                "Synced — no MusicBrainz match yet",
+                album_id=sidecar_mod.album_id_for(album_path),
+                album_label=label,
+            )
             return "no_match"
         status_str, _ = _apply_best_match(album_path, mbids, cfg, tagger)
+        album_id = sidecar_mod.album_id_for(album_path)
         if status_str == "tagged":
-            activity.info(f"Auto-tagged {album_path.name} from MusicBrainz after sync")
+            activity.info(
+                "Auto-tagged from MusicBrainz after sync", album_id=album_id, album_label=label
+            )
         else:
-            activity.info(f"Synced {album_path.name} — MusicBrainz suggestion to review")
+            activity.info(
+                "Synced — MusicBrainz suggestion to review",
+                album_id=album_id,
+                album_label=label,
+            )
         return status_str
     except Exception as e:
         log.warning("auto-resolve failed for %s: %s", album_path, e)
@@ -1725,7 +1744,15 @@ def _register_routes(app: FastAPI) -> None:
         _link_pending_to_album(album, p)
         _append_ignore(cfg.ignores_file, item_id, f"{p.band} — {p.title}")
         pending_downloads.remove(item_id)
-        activity.record(f"Linked {p.band} — {p.title} → {album.artist} — {album.title}")
+        # This one IS about an on-disk album (unlike the skip/approve entries
+        # above, which concern a purchase with nothing on disk yet), so it links.
+        # Id read back after _link_pending_to_album wrote the sidecar.
+        album_id_now, album_label = _live_album_ref(album)
+        activity.record(
+            f"Linked purchase {p.band} — {p.title}",
+            album_id=album_id_now,
+            album_label=album_label,
+        )
         request.state.skip_rescan = not was_inbox
         return _render_pending_section(request)
 
@@ -2640,12 +2667,9 @@ def _live_album_ref(album: Album) -> tuple[str | None, str]:
     wrote that same file, so it's warm.
     """
     label = f"{album.artist} — {album.title}".strip(" —")
-    try:
-        sc = sidecar_mod.read(album.path)
-    except Exception:
-        sc = None
-    if sc is not None and (sc.mb_release_id or sc.temp_uid):
-        return (sc.mb_release_id or sc.temp_uid), label
+    current = sidecar_mod.album_id_for(album.path)
+    if current is not None:
+        return current, label
     # No sidecar (still NEW, or it was just erased): the registry id the caller
     # already holds is the best available handle, and it IS resolvable.
     return album.id, label

--- a/src/harmonist/web/reconcile_runner.py
+++ b/src/harmonist/web/reconcile_runner.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from harmonist import activity, live_counts
+from harmonist import activity, live_counts, sidecar
 
 if TYPE_CHECKING:
     from harmonist.models import Album
@@ -266,6 +266,9 @@ def reconcile_pending_orphans(
 
     for album in pending:
         label = f"{album.artist} / {album.title}"
+        # The feed's album column: same "Artist — Title" shape the rest of the
+        # log uses (the status bar keeps `label`'s " / " form).
+        feed_label = f"{album.artist} — {album.title}".strip(" —")
         if status_updater:
             status_updater(current_item=label)
         try:
@@ -292,21 +295,39 @@ def reconcile_pending_orphans(
             # The sidecar adopted the file tags (external Picard re-tag). The new
             # state (Library / Needs Link) settles on the post-reconcile rescan.
             adopted += 1
-            activity.warning(f"{label}: adopted external re-tag — sidecar now {sc.mb_release_id}")
+            # Id read back from disk AFTER reconcile_album wrote the sidecar —
+            # it just moved the album's identity, so a pre-write id is dead (#65).
+            activity.warning(
+                f"Adopted external re-tag — sidecar now {sc.mb_release_id}",
+                album_id=sidecar.album_id_for(album.path),
+                album_label=feed_label,
+            )
         elif sc.mb_release_id and sc.store_url:
             reconciled_bandcamp += 1
             live_counts.move(AlbumState.NEW, AlbumState.NEEDS_SYNC)
-            activity.record(f"{label}: New → Needs Link (reconciled from tags)")
+            activity.record(
+                "New → Needs Link (reconciled from tags)",
+                album_id=sidecar.album_id_for(album.path),
+                album_label=feed_label,
+            )
         elif sc.mb_release_id:
             reconciled_manual += 1
             # → Library; COMPLETE is the proxy bucket (the scan reset splits
             # COMPLETE/INCOMPLETE exactly — only the library *total* matters here).
             live_counts.move(AlbumState.NEW, AlbumState.COMPLETE)
-            activity.record(f"{label}: New → Library (reconciled from tags)")
+            activity.record(
+                "New → Library (reconciled from tags)",
+                album_id=sidecar.album_id_for(album.path),
+                album_label=feed_label,
+            )
         else:
             recovered_url += 1
             live_counts.move(AlbumState.NEW, AlbumState.NEEDS_MBID)
-            activity.record(f"{label}: New → Needs MBID (recovered Bandcamp URL from tags)")
+            activity.record(
+                "New → Needs MBID (recovered Bandcamp URL from tags)",
+                album_id=sidecar.album_id_for(album.path),
+                album_label=feed_label,
+            )
         completed += 1
         _report()
         # No explicit pacing: reconcile_album now derives the store_url from the

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2344,6 +2344,53 @@ def test_deep_link_resolves_through_the_alias_chain_after_a_restart(client, cfg)
     assert 'hx-get="/library/rel-al/detail"' in r.text
 
 
+def test_post_sync_auto_tag_entry_links_to_the_album(cfg, monkeypatch):
+    """#75: the entry a user is most likely to want to click — Harmonist tagged
+    something on its own initiative after a sync — was plain text. The id must be
+    read back AFTER tagging, since that write moves the album's identity."""
+    from harmonist import activity
+    from harmonist.tagger import PicardCompatibleTagger
+    from harmonist.web.main import _resolve_by_store_url
+
+    d = _make_album(cfg, "AutoTagged")
+    sc.write(d, Sidecar(store_url="https://x.bandcamp.com/album/auto"))
+    monkeypatch.setattr("harmonist.mb_lookup.lookup_by_bandcamp_url", lambda url: ["rel-auto"])
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
+    )
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    activity.clear()
+
+    assert _resolve_by_store_url(d, cfg, PicardCompatibleTagger()) == "tagged"
+
+    entry = next(e for e in activity.recent(10) if "Auto-tagged" in e.message)
+    assert entry.album_label == "AutoTagged"  # the on-disk name, as shown before
+    # Resolves to the id the album has NOW (the MBID), not its pre-tag temp_uid.
+    assert entry.album_id == "rel-auto"
+    assert _id_for(cfg, d) == entry.album_id
+    # The name is no longer duplicated inside the message.
+    assert "AutoTagged" not in entry.message
+
+
+def test_reconcile_entries_link_to_their_album(cfg):
+    """#75: reconcile's 'New -> ...' entries carry the album too, with the same
+    'Artist — Title' column the rest of the feed uses."""
+    from harmonist import activity
+    from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+    d = _make_album(cfg, "Reconciled", mbid="rel-rec")
+    activity.clear()
+
+    reconcile_pending_orphans(cfg.paths.music_dir, fetch_urls=lambda mbid: [])
+
+    entry = next(e for e in activity.recent(20) if "New →" in e.message)
+    # The recorded id is the one the album actually has after reconcile wrote its
+    # sidecar — i.e. the link resolves, rather than merely being non-empty.
+    assert entry.album_id == _id_for(cfg, d)
+    assert entry.album_label and "Reconciled" in entry.album_label
+    assert "Reconciled" not in entry.message  # not duplicated in the text
+
+
 def test_deep_link_follows_moved_album_id(client, cfg):
     """The id in an old activity row is a snapshot. When a NEW album's registry
     UUID is superseded (a sidecar write giving it an MBID identity), the deep


### PR DESCRIPTION
Found dogfooding 1.1: **"Auto-tagged … from MusicBrainz after sync" was plain text.** #65 wired the 32 `_flash_response` sites and explicitly deferred the direct `activity.record()` calls in the sync and reconcile paths — this closes that gap.

It's arguably the more valuable half. A user-initiated tag is something you already know about; an **autonomous** post-sync auto-tag is precisely the entry you'd want to click through and verify.

## Eight entries now carry their album

- **post-sync auto-resolve** (3) — auto-tagged / suggestion to review / no match
- **reconcile** (4) — `New → Needs Link` / `Library` / `Needs MBID`, adopted external re-tag
- **linking a purchase** to an on-disk album (1)

## Identity derivation moved to `sidecar.album_id_for()`

Identity is the sidecar's business, and the reconcile runner needs it without importing web internals. `_live_album_ref` now delegates to it, so there's one implementation rather than two.

Every call site reads the id back **after** its mutation, for the #65 reason: tagging drops `temp_uid` in favour of the MBID, so an id captured beforehand is already dead. A test pins that ordering — moving the read ahead of the write fails it with the original symptom (a stale `temp_uid` recorded instead of the MBID).

## Labels differ, deliberately

Reconcile has the `Album`, so it uses `"Artist — Title"` like the rest of the feed. The post-sync path has only `album_path` — `_apply_best_match` returns plain strings, and neither `MatchCandidate` nor `BandcampInfo` carries artist/title — so it uses the **directory name**, which is exactly what those messages already displayed and what bandcampsync wrote to disk. Each is the best identifier available at that point.

Messages were reworded per-site so the name isn't duplicated beside the column, as with #65's 18 `details` strings. Editorial work, not a mechanical pass.

## Left unlinked on purpose

`"Won't download …"` and `"Will download …"` concern a Bandcamp purchase with **nothing on disk yet** — there is no album to point at, so they stay plain text.

## Verification

`make check` green: 676 passed. `make e2e` green: 4 passed. New tests cover the post-sync and reconcile paths, and assert the recorded id equals the album's *actual* current id (so the link resolves) rather than merely being non-empty.

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8