### PR TITLE
Add a "Won't download" list to Settings; fix where user ignores are written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,22 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- Settings now lists the purchases you told Harmonist not to download, with a
+  Restore button — an ignore is no longer a one-way door. Only choices you made
+  yourself are listed, never the albums Harmonist has already downloaded.
 - Activity entries written by a sync or by auto-reconcile now name and link their
   album too — including "Auto-tagged … after sync", the one worth clicking when
   Harmonist has tagged something on its own initiative. Previously only entries
   from actions you took yourself were linked.
+
+### Fixed
+
+- "Don't download" is now recorded in the user section of `ignores.txt` rather
+  than the section bandcampsync manages automatically. Previously the choice was
+  indistinguishable from an already-downloaded album, and could be lost entirely
+  if it was made while a sync was running.
+- Demo mode no longer writes to your real `ignores.txt` — trying "Don't
+  download" on a demo purchase used to add that fixture to your genuine ignores.
 
 ## [1.1.0] - 2026-07-31
 

--- a/src/harmonist/config.py
+++ b/src/harmonist/config.py
@@ -178,7 +178,20 @@ def load() -> Config:
         # toml/env. (Tests build Config directly and don't go through load(), so
         # they keep their own isolated dirs.)
         sandbox = Path(tempfile.gettempdir()) / "harmonist-demo"
-        cfg = cfg.model_copy(update={"paths": cfg.paths.model_copy(update={"music_dir": sandbox})})
+        # The ignores file too (#77): it lives in the CONFIG dir, which demo
+        # shares with the real install, so "Don't download" on a demo purchase
+        # was appending fixture item_ids to the user's genuine ignores.txt and
+        # suppressing them from real syncs. Same trap as the activity store
+        # (#69) — sandboxing the music dir alone is not enough for config-dir
+        # state that demo actions write to.
+        cfg = cfg.model_copy(
+            update={
+                "paths": cfg.paths.model_copy(update={"music_dir": sandbox}),
+                "bandcamp": cfg.bandcamp.model_copy(
+                    update={"ignores_file": sandbox / "ignores.txt"}
+                ),
+            }
+        )
 
     return cfg
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1263,6 +1263,13 @@ def _pending_suggestions(request: Request) -> dict[int, dict[str, str]]:
     return ps
 
 
+def _render_ignored_section(request: Request) -> Response:
+    """Re-render the #ignored-section partial (the target of a Restore swap)."""
+    cfg: config_mod.Config = request.app.state.cfg
+    ctx = _ctx(request, ignored=_read_user_ignores(cfg.ignores_file))
+    return _templates(request).TemplateResponse(request, "partials/_ignored.html", ctx)
+
+
 def _render_pending_section(request: Request) -> Response:
     """Re-render the #pending-section partial (the target of every action swap)."""
     ctx = _ctx(
@@ -1273,15 +1280,90 @@ def _render_pending_section(request: Request) -> Response:
     return _templates(request).TemplateResponse(request, "partials/_pending.html", ctx)
 
 
+# A comment line of 10+ '=' splits ignores.txt: user-entered ids above,
+# bandcampsync's "already downloaded" ids below. Mirrors its own detection.
+_IGNORES_SEPARATOR = re.compile(r"^\s*#.*={10,}")
+
+
+def _ignores_split(text: str) -> tuple[list[str], list[str]]:
+    """`(user_lines, auto_lines)` — the halves of ignores.txt either side of the
+    separator. With no separator the whole file is the user region, which is
+    correct: bandcampsync appends the separator *at the end* when it first adds
+    one, so everything already present becomes user data."""
+    lines = text.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if _IGNORES_SEPARATOR.match(line):
+            return lines[:i], lines[i:]
+    return lines, []
+
+
 def _append_ignore(ignores_file: Path, item_id: int, label: str) -> None:
-    """Append a purchase to bandcampsync's ignores.txt so it's never downloaded.
-    The next sync reads it; best-effort (a failed write just means it may re-surface)."""
+    """Record a purchase the user declined, in ignores.txt's USER region.
+
+    Written above the separator, not appended (#77). Below it is bandcampsync's
+    auto-managed list of already-downloaded ids, which it rewrites wholesale from
+    the copy it read at startup — so an append there is both semantically wrong
+    (indistinguishable from "already downloaded", which is what blocks a UI over
+    this data) and racy: bandcampsync's own source notes that changes made while
+    it runs are lost.
+
+    Best-effort; a failed write just means the purchase may re-surface."""
     try:
         ignores_file.parent.mkdir(parents=True, exist_ok=True)
-        with ignores_file.open("a", encoding="utf-8") as f:
-            f.write(f"{item_id}  # {label}\n")
+        text = ignores_file.read_text(encoding="utf-8") if ignores_file.exists() else ""
+        user, auto = _ignores_split(text)
+        if user and not user[-1].endswith("\n"):
+            user[-1] += "\n"
+        user.append(f"{item_id}  # {label}\n")
+        ignores_file.write_text("".join(user + auto), encoding="utf-8")
     except OSError as e:
         log.warning("could not append %s to ignores %s: %s", item_id, ignores_file, e)
+
+
+def _read_user_ignores(ignores_file: Path) -> list[dict[str, Any]]:
+    """Purchases the user explicitly declined — newest first.
+
+    ONLY the user region (above the separator). The auto-managed region below it
+    is bandcampsync's record of everything already downloaded; listing that would
+    present the user's whole collection as "ignored" (#19).
+
+    Entries written before #77 landed in the auto region and are unrecoverable as
+    user intent, so they simply don't appear. That's the safe direction to fail:
+    an ignore we can't prove was deliberate is better hidden than wrongly offered
+    for un-ignoring."""
+    try:
+        text = ignores_file.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    user, _ = _ignores_split(text)
+    out: list[dict[str, Any]] = []
+    for line in user:
+        token, _, comment = line.partition("#")
+        token = token.strip()
+        if token.isdigit():
+            out.append({"item_id": int(token), "label": comment.strip() or token})
+    out.reverse()  # newest first — they're appended in order
+    return out
+
+
+def _remove_user_ignore(ignores_file: Path, item_id: int) -> bool:
+    """Drop one id from the USER region so the next sync offers it again.
+    Returns True if a line was removed. Never touches the auto-managed region —
+    removing an already-downloaded id there would re-download the album."""
+    try:
+        text = ignores_file.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    user, auto = _ignores_split(text)
+    kept = [ln for ln in user if (ln.partition("#")[0].strip() or None) != str(item_id)]
+    if len(kept) == len(user):
+        return False
+    try:
+        ignores_file.write_text("".join(kept + auto), encoding="utf-8")
+    except OSError as e:
+        log.warning("could not rewrite ignores %s: %s", ignores_file, e)
+        return False
+    return True
 
 
 def _search_albums(request: Request, q: str, *, limit: int = 25) -> list[dict[str, str]]:
@@ -1756,6 +1838,24 @@ def _register_routes(app: FastAPI) -> None:
         request.state.skip_rescan = not was_inbox
         return _render_pending_section(request)
 
+    @app.post("/ignored/{item_id}/restore", response_class=HTMLResponse)
+    def ignored_restore(request: Request, item_id: int) -> Response:
+        """Un-ignore a declined purchase so the next sync offers it again (#19).
+
+        Only ever removes from the USER region — the auto-managed region records
+        what is already downloaded, and dropping an id from there would make the
+        next sync re-download an album the user already has."""
+        cfg: config_mod.Config = request.app.state.cfg
+        entry = next(
+            (i for i in _read_user_ignores(cfg.ignores_file) if i["item_id"] == item_id), None
+        )
+        if _remove_user_ignore(cfg.ignores_file, item_id):
+            label = entry["label"] if entry else str(item_id)
+            activity.info(f"Restored {label} — it'll be offered again on the next sync")
+        # Nothing on disk changed; a rescan here would just flicker the inbox.
+        request.state.skip_rescan = True
+        return _render_ignored_section(request)
+
     @app.get("/activity", response_class=HTMLResponse)
     def activity_feed(request: Request) -> Response:
         ctx = _ctx(request, events=activity.recent(100))
@@ -1773,6 +1873,7 @@ def _register_routes(app: FastAPI) -> None:
             request,
             bandcamp_ok=_bandcamp_configured(cfg),
             sidecar_count=sidecar_mod.count_all(cfg.paths.music_dir),
+            ignored=_read_user_ignores(cfg.ignores_file),
         )
         return _templates(request).TemplateResponse(request, "settings.html", ctx)
 

--- a/templates/partials/_ignored.html
+++ b/templates/partials/_ignored.html
@@ -1,0 +1,35 @@
+{# Purchases the user chose not to download (#19). Lives on Settings, not the
+   Inbox: it's an exclusion LIST — a preference — and a declined purchase is
+   resolved, not pending. Keeping it out of the Inbox leaves that a pure work
+   queue. Rendered as a normal Settings section; absent entirely when empty.
+
+   Shows ONLY the user region of ignores.txt. The auto-managed region below the
+   separator is bandcampsync's record of everything already downloaded; listing
+   that would present the user's whole collection as "ignored". #}
+<div id="ignored-section">
+{% if ignored %}
+<section class="border border-line rounded-lg p-4 space-y-3">
+    <h2 class="text-sm font-bold text-ink uppercase tracking-widest">
+        Won't download
+        <span class="text-muted font-normal normal-case tracking-normal ml-1">· {{ ignored|length }}</span>
+    </h2>
+    <p class="text-2xs text-muted">
+        Purchases you told Harmonist to skip. Restoring one offers it again on the
+        next sync — it doesn't download anything on its own.
+    </p>
+    <ul class="divide-y divide-line">
+        {% for item in ignored %}
+        <li class="flex items-center justify-between gap-3 py-1.5 text-sm">
+            <span class="min-w-0 break-words text-ink">{{ item.label }}</span>
+            <button hx-post="/ignored/{{ item.item_id }}/restore"
+                    hx-target="#ignored-section" hx-swap="outerHTML"
+                    hx-disabled-elt="this"
+                    class="flex-shrink-0 text-xs text-muted hover:text-accent underline decoration-dotted underline-offset-2"
+                    title="Offer this purchase again on the next sync"
+                    aria-label="Restore {{ item.label }}">Restore</button>
+        </li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}
+</div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -126,6 +126,9 @@
         </div>
     </form>
 
+    {# ---- Won't download (#19) ---- #}
+    {% include 'partials/_ignored.html' %}
+
     {# ---- Maintenance (destructive) ---- #}
     <section class="border border-red-300 rounded-lg p-4 space-y-3">
         <h2 class="text-sm font-bold text-red-700 uppercase tracking-widest">Maintenance</h2>

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3836,3 +3836,98 @@ def test_sync_popover_exposes_ids_for_live_default_js(client, cfg):
     assert 'id="sync-link-only"' in home
     assert 'id="sync-max-row"' in home
     assert 'id="sync-max-downloads"' in home
+
+
+# ---------- ignores.txt: write region + the "Won't download" surface (#19/#77) ----------
+
+_IGNORES_WITH_SEPARATOR = """\
+# This file allows you to exclude releases from downloads.
+1111  # Manually / Added
+# =========================================================
+2222  # Already / Downloaded
+3333  # Also Already / Downloaded
+"""
+
+
+def test_ignore_is_written_above_the_separator(client, cfg):
+    """#77: a declined purchase belongs in the USER region. Appending put it in
+    bandcampsync's auto-managed region, where it's indistinguishable from
+    'already downloaded' and gets clobbered when bandcampsync rewrites the file."""
+    from harmonist.web.main import _append_ignore
+
+    cfg.ignores_file.parent.mkdir(parents=True, exist_ok=True)
+    cfg.ignores_file.write_text(_IGNORES_WITH_SEPARATOR)
+
+    _append_ignore(cfg.ignores_file, 4444, "New / Ignore")
+
+    lines = cfg.ignores_file.read_text().splitlines()
+    sep = next(i for i, ln in enumerate(lines) if "=========" in ln)
+    ours = next(i for i, ln in enumerate(lines) if ln.startswith("4444"))
+    assert ours < sep, "user ignore must land above the separator"
+    # The auto-managed region is untouched.
+    assert lines[sep + 1 :] == ["2222  # Already / Downloaded", "3333  # Also Already / Downloaded"]
+
+
+def test_ignore_with_no_separator_still_appends(client, cfg):
+    """A fresh ignores.txt has no separator yet (bandcampsync adds it at the end
+    on first run), so everything present is user data — append is correct."""
+    from harmonist.web.main import _append_ignore
+
+    cfg.ignores_file.parent.mkdir(parents=True, exist_ok=True)
+    cfg.ignores_file.write_text("# header only\n")
+    _append_ignore(cfg.ignores_file, 55, "Solo / Ignore")
+    assert "55  # Solo / Ignore" in cfg.ignores_file.read_text()
+
+
+def test_ignored_surface_lists_only_user_entries(client, cfg):
+    """#19: the surface must NOT list the auto-managed region — that's every
+    album already downloaded, i.e. the user's whole collection."""
+    from harmonist.web.main import _read_user_ignores
+
+    cfg.ignores_file.parent.mkdir(parents=True, exist_ok=True)
+    cfg.ignores_file.write_text(_IGNORES_WITH_SEPARATOR)
+
+    got = _read_user_ignores(cfg.ignores_file)
+    assert [i["item_id"] for i in got] == [1111]
+    assert got[0]["label"] == "Manually / Added"
+
+    # Lives on Settings, not the Inbox: a declined purchase is resolved, not
+    # pending, so the Inbox stays a pure work queue.
+    settings = client.get("/settings").text
+    assert "Manually / Added" in settings
+    assert "Already / Downloaded" not in settings
+    assert "Manually / Added" not in client.get("/tasks").text
+
+
+def test_restore_removes_only_from_the_user_region(client, cfg):
+    """Restoring must never drop an id from the auto-managed region — that would
+    make the next sync re-download an album the user already has."""
+    from harmonist.web.main import _read_user_ignores
+
+    cfg.ignores_file.parent.mkdir(parents=True, exist_ok=True)
+    cfg.ignores_file.write_text(_IGNORES_WITH_SEPARATOR)
+
+    r = client.post("/ignored/1111/restore")
+    assert r.status_code == 200
+    assert _read_user_ignores(cfg.ignores_file) == []
+    # ...and the downloaded ids survive.
+    text = cfg.ignores_file.read_text()
+    assert "2222" in text and "3333" in text
+
+    # Restoring an id that only exists in the auto region is a no-op.
+    client.post("/ignored/2222/restore")
+    assert "2222" in cfg.ignores_file.read_text()
+
+
+def test_demo_mode_sandboxes_the_ignores_file(monkeypatch, tmp_path):
+    """#77: demo shares the real CONFIG dir, so 'Don't download' on a demo
+    purchase was appending fixture item_ids to the user's genuine ignores.txt."""
+    from harmonist import config as config_mod
+
+    monkeypatch.setenv("HARMONIST_DEMO_MODE", "1")
+    monkeypatch.setenv("HARMONIST_CONFIG_DIR", str(tmp_path / "config"))
+    cfg = config_mod.load()
+
+    assert cfg.demo_mode
+    assert cfg.paths.config_dir not in cfg.ignores_file.parents
+    assert cfg.ignores_file.parent == cfg.paths.music_dir  # the demo sandbox


### PR DESCRIPTION
#19 asked for a UI over `ignores.txt` so an ignore isn't a black hole. Scoping it turned up two defects in how that file is written; they're fixed here first, so the list reads trustworthy data instead of inferring which entries were deliberate from an incidental formatting quirk.

## Background

`ignores.txt` is split by a separator line (a comment of 10+ `=`): **user entries above**, bandcampsync's auto-managed *"already downloaded"* ids **below**.

## Two defects fixed

**1. Our writes landed in the machine-managed region.** `_append_ignore` opened the file in `"a"` mode, so a user's explicit decline went to the *end*. That made intent indistinguishable from "already downloaded" — on a real library, ~2 deliberate ignores among ~400 download records — and it's racy: bandcampsync rewrites the file from lines read at startup, and its own source warns *"any manual change made while the process is running will be lost."*

Now inserted above the separator. With no separator present, appending is still correct, since bandcampsync adds the separator at the *end* and everything prior becomes user data.

**2. Demo mode wrote to the real `ignores.txt`.** `cfg.ignores_file` resolves under the **config** dir, which demo shares with the real install — so "Don't download" on a demo purchase appended fixture item_ids to genuine ignores. Confirmed on a real install whose last two entries were demo fixtures (`Mouse Rat`, `Autobahn`). Same class as #69; the sandbox now covers this file too.

## Where the list lives

**Settings, not the Inbox.** It's an exclusion list — a preference — and a declined purchase is *resolved*, not pending, so the Inbox stays a pure work queue. It can't live in the Library either: a pending purchase has **no files**, and Library state is derived from sidecar + disk.

Restore **only ever removes from the user region**. Dropping an id from the auto-managed region would make the next sync re-download an album the user already has — a test pins this and fails if the search widens.

## Known limitation

Entries written before this fix sit below the separator and can't be reclassified as deliberate, so they won't appear. That's the safe direction to fail: an ignore we can't prove was intentional is better hidden than wrongly offered for un-ignoring. (Maintainer's two stale demo lines are best deleted by hand.)

## Verification

`make check` green: 681 passed. `make e2e` green: 4 passed. No CSS drift. Both invariants mutation-checked — reverting to a plain append fails the write-region test, and letting Restore search the whole file fails the auto-region test.

Fixes #19
Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8