### PR TITLE
Don't write duplicate ids to ignores.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Deciding the same purchase twice no longer adds a duplicate line to
+  `ignores.txt`.
 - "Don't download" is now recorded in the user section of `ignores.txt` rather
   than the section bandcampsync manages automatically. Previously the choice was
   indistinguishable from an already-downloaded album, and could be lost entirely

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1297,6 +1297,17 @@ def _ignores_split(text: str) -> tuple[list[str], list[str]]:
     return lines, []
 
 
+def _ignored_ids(text: str) -> set[str]:
+    """Every item_id already present in ignores.txt, from BOTH regions —
+    bandcampsync honours an id wherever it appears in the file."""
+    ids: set[str] = set()
+    for line in text.splitlines():
+        token = line.partition("#")[0].strip()
+        if token.isdigit():
+            ids.add(token)
+    return ids
+
+
 def _append_ignore(ignores_file: Path, item_id: int, label: str) -> None:
     """Record a purchase the user declined, in ignores.txt's USER region.
 
@@ -1311,6 +1322,13 @@ def _append_ignore(ignores_file: Path, item_id: int, label: str) -> None:
     try:
         ignores_file.parent.mkdir(parents=True, exist_ok=True)
         text = ignores_file.read_text(encoding="utf-8") if ignores_file.exists() else ""
+        # Already ignored? Nothing to do (#79). Checked across BOTH regions: an
+        # id in the auto-managed region is honoured just the same, so re-adding
+        # it changes no behaviour and only inflates the file. bandcampsync guards
+        # its own writes this way; ours didn't, so re-deciding a purchase — which
+        # the pre-#77 write race made routine — appended a duplicate each time.
+        if str(item_id) in _ignored_ids(text):
+            return
         user, auto = _ignores_split(text)
         if user and not user[-1].endswith("\n"):
             user[-1] += "\n"

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3931,3 +3931,36 @@ def test_demo_mode_sandboxes_the_ignores_file(monkeypatch, tmp_path):
     assert cfg.demo_mode
     assert cfg.paths.config_dir not in cfg.ignores_file.parents
     assert cfg.ignores_file.parent == cfg.paths.music_dir  # the demo sandbox
+
+
+def test_ignore_is_not_written_twice(client, cfg):
+    """#79: re-deciding the same purchase must not append a duplicate. Ours was
+    the only unguarded writer — bandcampsync checks is_ignored() before its own
+    adds — which is how a real file grew 55 lines for 31 unique ids."""
+    from harmonist.web.main import _append_ignore, _read_user_ignores
+
+    cfg.ignores_file.parent.mkdir(parents=True, exist_ok=True)
+    cfg.ignores_file.write_text("# header\n")
+
+    _append_ignore(cfg.ignores_file, 4242, "Band — Album")
+    _append_ignore(cfg.ignores_file, 4242, "Band — Album")
+    _append_ignore(cfg.ignores_file, 4242, "Band — Album (different label)")
+
+    assert cfg.ignores_file.read_text().count("4242") == 1
+    assert len(_read_user_ignores(cfg.ignores_file)) == 1
+
+
+def test_ignore_already_in_the_auto_region_is_a_noop(client, cfg):
+    """An id bandcampsync already recorded is honoured wherever it sits, so
+    re-adding it to the user region would change nothing and just inflate the
+    file — and would wrongly offer an album you HAVE for un-ignoring."""
+    from harmonist.web.main import _append_ignore, _read_user_ignores
+
+    cfg.ignores_file.parent.mkdir(parents=True, exist_ok=True)
+    cfg.ignores_file.write_text(_IGNORES_WITH_SEPARATOR)
+
+    _append_ignore(cfg.ignores_file, 2222, "Already / Downloaded")
+
+    assert cfg.ignores_file.read_text().count("2222") == 1
+    # Not promoted into the user region either.
+    assert [i["item_id"] for i in _read_user_ignores(cfg.ignores_file)] == [1111]


### PR DESCRIPTION
**Cause**

bandcampsync guards its own writes (`if not self.ignores.is_ignored(item)` — `bandcamp_hook.py:613`), but `_append_ignore` didn't, and **both** its callers — "Don't download" (`pending_skip`) and "Match to an existing album" (`pending_match_link`) — reach it unguarded. Re-deciding the same purchase appended again.

Measured on a real install: **55 Harmonist-written lines covering 31 unique ids** — 24 duplicates.

The pre-#77 write race made that routine rather than rare. An append made during a sync was clobbered by bandcampsync's rewrite (it rebuilds the file from lines read at startup), so the purchase was re-offered on the next run and decided again. That race is fixed; this guard was still missing.

**Fix**

No-op when the id is already present, checked across **both** regions. bandcampsync honours an id wherever it appears in the file, so re-adding one that's already in the auto-managed region changes no behaviour — and promoting it into the user region would list an album you *have* as "won't download", offering it for un-ignoring.

**Verification**

`make check` green: 683 passed. Both tests are mutation-checked — removing the guard fails them.

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8