### PR TITLE
Fix the "Won't download" help text — it promised something untrue

### DIFF
--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1365,7 +1365,7 @@ def _read_user_ignores(ignores_file: Path) -> list[dict[str, Any]]:
 
 
 def _remove_user_ignore(ignores_file: Path, item_id: int) -> bool:
-    """Drop one id from the USER region so the next sync offers it again.
+    """Drop one id from the USER region so the next sync considers it again.
     Returns True if a line was removed. Never touches the auto-managed region —
     removing an already-downloaded id there would re-download the album."""
     try:
@@ -1858,7 +1858,10 @@ def _register_routes(app: FastAPI) -> None:
 
     @app.post("/ignored/{item_id}/restore", response_class=HTMLResponse)
     def ignored_restore(request: Request, item_id: int) -> Response:
-        """Un-ignore a declined purchase so the next sync offers it again (#19).
+        """Un-ignore a declined purchase so the next sync considers it again (#19).
+
+        "Considers", not "offers": whether it resurfaces as a potential-download
+        card or is fetched outright depends on link-only vs a full sync.
 
         Only ever removes from the USER region — the auto-managed region records
         what is already downloaded, and dropping an id from there would make the
@@ -1869,7 +1872,7 @@ def _register_routes(app: FastAPI) -> None:
         )
         if _remove_user_ignore(cfg.ignores_file, item_id):
             label = entry["label"] if entry else str(item_id)
-            activity.info(f"Restored {label} — it'll be offered again on the next sync")
+            activity.info(f"Restored {label} — the next sync will consider it again")
         # Nothing on disk changed; a rescan here would just flicker the inbox.
         request.state.skip_rescan = True
         return _render_ignored_section(request)

--- a/templates/partials/_ignored.html
+++ b/templates/partials/_ignored.html
@@ -13,9 +13,14 @@
         Won't download
         <span class="text-muted font-normal normal-case tracking-normal ml-1">· {{ ignored|length }}</span>
     </h2>
+    {# Deliberately does NOT promise what the next sync will do with a restored
+       purchase. Whether it becomes a potential-download card or is fetched
+       outright depends on link-only vs a full sync (bandcamp_hook.py) — the
+       earlier copy claimed "it doesn't download anything on its own", which
+       only holds for link-only runs. #}
     <p class="text-2xs text-muted">
-        Purchases you told Harmonist to skip. Restoring one offers it again on the
-        next sync — it doesn't download anything on its own.
+        Purchases you told Harmonist to skip — they're left out of every sync.
+        Restore clears that choice, so the next sync sees the purchase again.
     </p>
     <ul class="divide-y divide-line">
         {% for item in ignored %}


### PR DESCRIPTION
The Settings copy read:

> Purchases you told Harmonist to skip. Restoring one offers it again on the next sync — it doesn't download anything on its own.

**Two problems.** "it" had no clear referent (Restore? the sync? Harmonist?) and parsed as a denial of something Harmonist plainly does do.

**More seriously, it wasn't true.** Surfacing an unmatched purchase as a potential-download card — rather than fetching it — is gated on link-only (`bandcamp_hook.py:728`):

```python
if self._link_only and not approved:
    self._pending_this_run.append(...)
```

On a **full** sync the purchase falls through and is downloaded. So the reassurance held only for link-only runs — exactly the kind of promise that burns someone who trusted it before clicking.

**Replacement**

> Purchases you told Harmonist to skip — they're left out of every sync. Restore clears that choice, so the next sync sees the purchase again.

Says what the list is and what the button does, without predicting what the sync will then do. The same "offers it again" claim also appeared in the Restore activity message and two docstrings; those now say "considers", with a note on why the distinction matters.

No CHANGELOG entry — this corrects copy on a feature still in `[Unreleased]`.

`make check` green: 683 passed. No CSS drift.

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8