### PR TITLE
Audit tag writes and sidecar erasure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ versions follow [semantic versioning](https://semver.org).
 ### Added
 
 - Activity entries now carry a "what changed" disclosure showing exactly what
-  Harmonist did underneath — the sidecar rewrites and file moves that action
-  produced. Entries with nothing to show are unchanged.
+  Harmonist did underneath — the tracks it re-tagged, the sidecar rewrites and
+  the file moves that action produced. Entries with nothing to show are unchanged.
+- Tagging and erasing sidecars are now recorded in the audit log. Tagging notes
+  the release and every track it wrote; erasing names each album that lost its
+  sidecar, so the most destructive action in the app leaves a trail.
 
 ## [1.2.0] - 2026-08-02
 

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from contextlib import suppress
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -55,13 +56,27 @@ def delete_all(music_dir: Path) -> int:
     """
     if not music_dir.exists():
         return 0
+    # The most destructive thing Harmonist does — every album's identity, match
+    # candidate and purchase link goes at once — and it had NO audit record.
+    # One line per sidecar, so the record names exactly which albums lost one;
+    # a bare count would say a nuke happened but not what it took.
     removed = 0
     for p in music_dir.rglob(SIDECAR_FILENAME):
         try:
+            existing = None
+            with suppress(Exception):
+                existing = read(p.parent)
             p.unlink()
             removed += 1
+            audit.record(
+                "sidecar.delete",
+                album_id=None if existing is None else _album_id_of(existing),
+                album=p.parent,
+                mbid=None if existing is None else existing.mb_release_id,
+            )
         except OSError:
             continue
+    audit.record("sidecar.delete_all", music_dir=music_dir, removed=removed)
     library_index.clear()  # the sidecars are gone; the rescan refills the index
     return removed
 

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -16,7 +16,8 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-from . import formats
+from . import audit, formats
+from . import sidecar as sidecar_mod
 from .formats import TagSet
 from .formats.m4a import (  # noqa: F401 — back-compat re-exports
     ATOM_ALBUM,
@@ -164,9 +165,34 @@ def tag_album(
         cover = None
     media_total = len(release.get("medium-list", [])) or 1
 
+    # Tag writing replaces information in every audio file, so it belongs in the
+    # audit log — it was the one core mutation with no record at all. The album
+    # line is written BEFORE the loop so a crash part-way leaves evidence of what
+    # was attempted, not silence.
+    #
+    # This is deliberately coarse for now: which tracks were rewritten, not which
+    # individual TAGS changed. Per-field before/after diffs (Picard-style) need a
+    # read-compare-write pass that doesn't exist yet — see #86.
+    album_id = sidecar_mod.album_id_for(album_dir)
+    audit.record(
+        "tag.album",
+        album_id=album_id,
+        album=album_dir,
+        release=release.get("id"),
+        tracks=len(pairs),
+        art="embedded" if cover is not None else "preserved",
+        mode="incomplete" if incomplete else "full",
+    )
     for file_path, (medium, track_pos_in_medium, track) in pairs:
         tagset = _build_tagset(release, medium, track_pos_in_medium, track, media_total)
         formats.write_tags(file_path, tagset, cover)
+        audit.record(
+            "tag.track",
+            album_id=album_id,
+            file=file_path.name,
+            track=track_pos_in_medium,
+            title=_track_title(track),
+        )
 
     return len(files)
 

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -125,6 +125,49 @@ def _atom_strs(audio: MP4, atom: str) -> list[str]:
     return [v.decode("utf-8") for v in audio[atom]]
 
 
+def test_tag_album_writes_audit_records(album_with_tracks, tmp_path):
+    """Tag writing replaces information in every audio file, so the review gate's
+    audit rule covers it — yet it produced no records at all until #86. One album
+    line naming what was attempted, then one per track actually written."""
+    from harmonist import activity_store
+    from harmonist.activity_store import Source
+
+    activity_store.init(tmp_path / "audit.db")
+    album_dir = album_with_tracks(2)
+    tagger.tag_album(album_dir, _release_2_tracks())
+
+    rows = [e.message for e in activity_store.recent(50, source=Source.AUDIT)]
+    album_line = next(m for m in rows if m.startswith("tag.album"))
+    assert "release=rel-aaa" in album_line
+    assert "tracks=2" in album_line
+    assert "mode=full" in album_line
+
+    tracks = [m for m in rows if m.startswith("tag.track")]
+    assert len(tracks) == 2
+    assert any("01 Track 1.m4a" in m for m in tracks)
+
+
+def test_tag_album_audits_the_album_line_before_writing(album_with_tracks, tmp_path, monkeypatch):
+    """Recorded BEFORE the loop, per the gate's "before/as it acts": a crash
+    part-way must leave evidence of what was attempted, not silence."""
+    from harmonist import activity_store, formats
+    from harmonist.activity_store import Source
+
+    activity_store.init(tmp_path / "audit.db")
+    album_dir = album_with_tracks(2)
+
+    def boom(*a, **kw):
+        raise OSError("disk died mid-write")
+
+    monkeypatch.setattr(formats, "write_tags", boom)
+    with pytest.raises(OSError):
+        tagger.tag_album(album_dir, _release_2_tracks())
+
+    rows = [e.message for e in activity_store.recent(50, source=Source.AUDIT)]
+    assert any(m.startswith("tag.album") for m in rows), "no evidence of the attempt"
+    assert not [m for m in rows if m.startswith("tag.track")]  # nothing was written
+
+
 def test_tag_album_writes_all_album_atoms(album_with_tracks):
     album_dir = album_with_tracks(2)
     tagger.tag_album(album_dir, _release_2_tracks())

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3138,6 +3138,30 @@ def test_app_attribute_is_memoized(monkeypatch):
     assert len(calls) == 1
 
 
+def test_erase_sidecars_is_audited_per_album(client, cfg):
+    """Erasing sidecars is the most destructive thing Harmonist does — every
+    album's identity, match candidate and purchase link at once — and it had no
+    audit record. One line per sidecar names which albums lost one; a bare count
+    would say a nuke happened but not what it took."""
+    from harmonist import activity_store
+    from harmonist import sidecar as scmod
+    from harmonist.activity_store import Source
+
+    a = _make_album(cfg, "NukedOne")
+    b = _make_album(cfg, "NukedTwo")
+    scmod.write(a, Sidecar(mb_release_id="rel-a"))
+    scmod.write(b, Sidecar(mb_release_id="rel-b"))
+    activity_store.clear()
+
+    assert client.post("/settings/erase-sidecars").status_code == 200
+
+    rows = [e.message for e in activity_store.recent(50, source=Source.AUDIT)]
+    deletes = [m for m in rows if m.startswith("sidecar.delete ")]
+    assert len(deletes) == 2
+    assert any("rel-a" in m for m in deletes) and any("rel-b" in m for m in deletes)
+    assert any(m.startswith("sidecar.delete_all") and "removed=2" in m for m in rows)
+
+
 def test_erase_sidecars_removes_only_sidecars(client, cfg):
     from harmonist import sidecar as scmod
 


### PR DESCRIPTION
Two operations that replace or destroy user information had **no audit record at all** — a gate item 1 violation each. Both surfaced while surveying coverage for #84's "what changed" disclosure.

## Tag writes

The core mutation Harmonist exists to perform — it rewrites the tags in every audio file of an album — and it recorded nothing. (This is also why my first #84 coverage test failed: a re-tag to the same MBID audited *nothing*, because only sidecar identity changes were logged.)

Now: one `tag.album` line (release, track count, art mode, complete/incomplete) plus one `tag.track` per file.

The album line is emitted **before** the write loop, per the gate's *"before/as it acts"* — a crash part-way must leave evidence of what was attempted, not silence. There's a test that kills `write_tags` mid-run and asserts exactly that.

## Erasing sidecars

The most destructive thing in the app — every album's identity, match candidate and purchase link go at once — and it was silent. Now one `sidecar.delete` per album, naming the album and the MBID it carried, plus a `sidecar.delete_all` summary. A bare count would record that a nuke happened but not what it took.

## Deliberately coarse

For tagging this records *which tracks were rewritten*, not *which tags changed*. Per-field before/after diffs need a read-compare-write pass that doesn't exist — `tag_album` never reads current tags — and raises real questions about cost, noise and storage. Written up as **#86** rather than guessed at here.

## Remaining gaps

The same survey found more, filed as **#88**: demotions and surrenders (both named explicitly in the gate), cover-art writes, and the fact that sidecar rewrites are audited **only when identity changes** — so `tagged_at`, `notes`, `purchase_unavailable` and `mb_match_candidate` move silently.

`make check` green: 694 passed.

Toward #86, #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8