### PR TITLE
Close the remaining audit-coverage gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ versions follow [semantic versioning](https://semver.org).
 - Activity entries now carry a "what changed" disclosure showing exactly what
   Harmonist did underneath — the tracks it re-tagged, the sidecar rewrites and
   the file moves that action produced. Entries with nothing to show are unchanged.
+- Surrendering an album ("Move to Library" when there's no purchase to link) and
+  saving cover art are now recorded in the audit log, alongside tagging and
+  erasing sidecars.
 - Tagging and erasing sidecars are now recorded in the audit log. Tagging notes
   the release and every track it wrote; erasing names each album that lost its
   sidecar, so the most destructive action in the app leaves a trail.

--- a/src/harmonist/cover_art.py
+++ b/src/harmonist/cover_art.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import httpx
 
-from . import formats
+from . import audit, formats
 
 CAA_BASE = "https://coverartarchive.org"
 DEFAULT_TIMEOUT = 30.0
@@ -71,7 +71,14 @@ def _extract_embedded_cover(album_dir: Path) -> Path | None:
         data, mime = result
         name = "cover.png" if "png" in mime.lower() else "cover.jpg"
         target = album_dir / name
+        # Writing into the user's album dir, and possibly over an existing
+        # cover.* they put there themselves — audited like any other file
+        # overwrite (#88). `overwrote` distinguishes creating from replacing.
+        overwrote = target.exists()
         target.write_bytes(data)
+        audit.record(
+            "cover.write", album=album_dir, file=target.name, source="embedded", overwrote=overwrote
+        )
         log.debug("cover: extracted embedded art from %s -> %s", path.name, target.name)
         return target
     return None
@@ -106,7 +113,17 @@ def _fetch_to_disk(
                 continue
             if resp.is_success:
                 target = album_dir / _filename_for(resp)
+                overwrote = target.exists()
                 target.write_bytes(resp.content)
+                audit.record(
+                    "cover.write",
+                    album=album_dir,
+                    file=target.name,
+                    source="caa",
+                    mbid=mbid,
+                    bytes=len(resp.content),
+                    overwrote=overwrote,
+                )
                 log.debug("CAA: wrote %s (%d bytes)", target, len(resp.content))
                 return target
             raise CoverArtError(f"CAA returned status {resp.status_code} for {url}")

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -120,7 +120,7 @@ def write(album_dir: Path, sidecar: Sidecar) -> None:
         f.flush()
         os.fsync(f.fileno())
     os.replace(tmp, target)
-    _audit_identity_change(album_dir, old, sidecar)
+    _audit_sidecar_change(album_dir, old, sidecar)
     _record_identity_alias(old, sidecar)
     # The ONE place the in-memory index learns of a sidecar change (link, demote,
     # tag, download, reconcile all land here) — so sync-time dedup never re-reads.
@@ -176,9 +176,28 @@ def _record_identity_alias(old: Sidecar | None, new: Sidecar) -> None:
         activity_store.record_alias(old_id, new_id)
 
 
-def _audit_identity_change(album_dir: Path, old: Sidecar | None, new: Sidecar) -> None:
-    """Audit a sidecar write that creates a sidecar or changes its load-bearing
-    identity (MBID / Bandcamp item_id / store_url). No-op re-writes don't log.
+def _audit_sidecar_change(album_dir: Path, old: Sidecar | None, new: Sidecar) -> None:
+    """Audit a sidecar write that creates a sidecar or changes a LOAD-BEARING
+    field. No-op re-writes don't log.
+
+    Load-bearing means "changes what the scanner derives, or records a decision
+    the user can't easily undo":
+
+      * identity — MBID / Bandcamp item_id / store_url
+      * `purchase_unavailable` — a surrender. Permanent: the scanner then treats
+        the album as terminal despite having no purchase link, and no future sync
+        re-surrenders it. Named in the review gate; it moved silently until #88.
+      * `track_count_expected` — splits COMPLETE from INCOMPLETE, so changing it
+        reclassifies the album.
+
+    Deliberately NOT audited, so the narrowness here is a choice rather than an
+    oversight:
+
+      * `mb_match_candidate` — a suggestion, not a decision, and it is rewritten
+        on every Recheck. Auditing it would bury real changes in churn.
+      * `tagged_at` / `added_at` / `downloaded_at` — bookkeeping timestamps; the
+        events they date are audited in their own right (see tagger.tag_album).
+      * `notes` — free text with no derived consequence.
 
     Rows carry the album's id AFTER the write; when the id itself changes (an MBID
     rewrite), the `mbid` field records both sides so the two ids can be linked."""
@@ -204,6 +223,10 @@ def _audit_identity_change(album_dir: Path, old: Sidecar | None, new: Sidecar) -
         changes["item_id"] = f"{old_item}->{new_item}"
     if old.store_url != new.store_url:
         changes["store_url"] = f"{old.store_url}->{new.store_url}"
+    if old.purchase_unavailable != new.purchase_unavailable:
+        changes["purchase_unavailable"] = f"{old.purchase_unavailable}->{new.purchase_unavailable}"
+    if old.track_count_expected != new.track_count_expected:
+        changes["track_count_expected"] = f"{old.track_count_expected}->{new.track_count_expected}"
     if changes:
         audit.record("sidecar.update", album_id=album_id, album=album_dir, **changes)
 

--- a/test/test_cover_art.py
+++ b/test/test_cover_art.py
@@ -55,6 +55,29 @@ def test_cached_cover_returns_none_when_absent(tmp_path):
     assert cached_cover(tmp_path) is None
 
 
+def test_caa_cover_write_is_audited(tmp_path):
+    """#88: fetching cover art writes into the user's album dir, and can land on
+    a cover.* they put there themselves — a file write like any other, so it's
+    audited. `overwrote` distinguishes creating from replacing."""
+    from harmonist import activity_store
+    from harmonist.activity_store import Source
+
+    activity_store.init(tmp_path / "audit.db")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"imagebytes", headers={"content-type": "image/jpeg"})
+
+    album = tmp_path / "album"
+    album.mkdir()
+    assert ensure_cover(album, "rel-1", client=_client(handler)) == album / "cover.jpg"
+
+    rows = [e.message for e in activity_store.recent(10, source=Source.AUDIT)]
+    line = next(m for m in rows if m.startswith("cover.write"))
+    assert "source=caa" in line
+    assert "overwrote=False" in line  # created, not replaced
+    assert "bytes=10" in line
+
+
 def test_ensure_cover_uses_cache_without_network(tmp_path):
     (tmp_path / "cover.jpg").write_bytes(b"existing")
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -577,6 +577,39 @@ def test_surrender_card_renders_readonly_with_tools(client, cfg):
     assert "Look up releases at this URL" not in r.text
 
 
+def test_surrender_is_audited(client, cfg):
+    """#88: a surrender is named in the review gate. Setting the MBID from the
+    candidate was already audited as an identity change, but
+    `purchase_unavailable` — the defining, PERMANENT part of the decision — moved
+    silently. The scanner then treats the album as terminal forever."""
+    from harmonist import activity_store, scanner
+    from harmonist.activity_store import Source
+
+    d = _make_album(cfg, "Surrendered", mbid="rel-sur")
+    sc.write(
+        d,
+        Sidecar(
+            store_url="https://x.bandcamp.com/album/sur",
+            mb_release_id=None,
+            mb_match_candidate=MatchCandidate(
+                mb_release_id="rel-sur",
+                confidence="exact",
+                file_count=1,
+                track_count=1,
+                unmatched_purchase=True,
+            ),
+        ),
+    )
+    a = next(x for x in scanner.scan(cfg.paths.music_dir) if x.path == d)
+    activity_store.clear()
+
+    assert client.post(f"/surrender/{a.id}/keep").status_code == 200
+
+    rows = [e.message for e in activity_store.recent(50, source=Source.AUDIT)]
+    upd = next(m for m in rows if m.startswith("sidecar.update"))
+    assert "purchase_unavailable=False->True" in upd
+
+
 def test_surrender_keep_marks_purchase_unavailable_and_completes(client, cfg):
     """'Move to Library' restores the release id from the surrender candidate, flags
     the purchase unavailable, and the album classifies COMPLETE — and STAYS complete
@@ -4004,7 +4037,7 @@ def test_request_scope_correlates_the_action_with_its_audit_records(client, cfg,
     nothing about requests. This is what the contextvar buys."""
     from harmonist import activity, activity_store
 
-    # Confirm, not re-tag: _audit_identity_change only records when identity
+    # Confirm, not re-tag: _audit_sidecar_change only records when a load-bearing
     # actually moves, so re-tagging to the SAME mbid audits nothing and would
     # make this pass vacuously. Confirming moves temp_uid -> mbid.
     d = _make_album(cfg, "Correlated")


### PR DESCRIPTION
Finishes the survey started in #89. **Two of this issue's claims were wrong**, found by tracing the code rather than grepping for a literal `audit.record` inside each function.

## Demotions were already audited

`_demote_to_needs_mbid` clears `mb_release_id` — an identity change — so `sidecar.write` already emitted `sidecar.update mbid=rel-x->None`. My grep looked inside the function instead of following the write.

## Surrenders were only *half* audited — worse than reported

Setting the MBID from the candidate was recorded as an identity change, which is exactly what made the gap invisible: there *was* a record, so it looked covered. But `purchase_unavailable` — the defining, **permanent** half of the decision — moved silently. After it the scanner treats the album as terminal despite having no purchase link, and no future sync re-surrenders it.

## So the real gap was one level up

Not "these operations aren't audited" but **"sidecar rewrites are audited only when *identity* changes"**. Fixed there rather than by sprinkling calls at call sites:

`_audit_identity_change` → `_audit_sidecar_change`, now also diffing:

- **`purchase_unavailable`** — a permanent decision (the surrender)
- **`track_count_expected`** — splits COMPLETE from INCOMPLETE, so changing it reclassifies the album

One place, covering every writer including future ones. Demotion now also records `track_count_expected=9->None` as a bonus.

**Exclusions are now documented as choices**, rather than left looking accidental: `mb_match_candidate` is a suggestion rewritten on every Recheck and would bury real changes in churn; `tagged_at`/`added_at`/`downloaded_at` are bookkeeping whose events are audited in their own right; `notes` has no derived consequence.

## Cover art

Audited with `overwrote` distinguishing creating from replacing — these writes land in the user's album dir and can land on a `cover.*` they put there themselves.

`make check` green: 696 passed.

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8