### PR TITLE
Morph the activity feed instead of rebuilding it every 2s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- The Activity tab no longer flickers while it's open. It refreshes every couple
+  of seconds, and was rebuilding the whole list each time; it now updates only
+  what actually changed, so the list stays put and text selection survives.
+
 ### Added
 
 - Activity entries now carry a "what changed" disclosure showing exactly what

--- a/templates/index.html
+++ b/templates/index.html
@@ -114,10 +114,15 @@
     </div>
 
     <div id="panel-activity" class="hidden">
+        {# morph, not innerHTML: this re-polls every 2s, and a plain swap tears
+           down and rebuilds all 100 rows each time — visible flicker, and any
+           text selection is lost. Morphing patches only what actually changed,
+           so unchanged rows keep their DOM nodes (#91). The inbox has swapped
+           this way since #11; the feed never got the same treatment. #}
         <div id="activity-feed"
              hx-get="/activity"
              hx-trigger="load, every 2s[!document.querySelector('#panel-activity')?.classList.contains('hidden')], tasks-changed from:body"
-             hx-swap="innerHTML">
+             hx-swap="morph:innerHTML">
             <div class="text-center py-6 text-muted italic text-sm">Loading activity…</div>
         </div>
     </div>

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,0 +1,89 @@
+"""Shared fixtures for the opt-in browser (e2e) suite.
+
+Opt-in: requires playwright (`pip install -e .[e2e]` + `playwright install
+chromium`) and RUN_E2E=1, so `make test` / `make check` stay browser-free.
+Run via `make e2e`.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1", reason="e2e disabled (set RUN_E2E=1)"
+)
+playwright_sync = pytest.importorskip("playwright.sync_api")
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture(scope="module")
+def demo_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Uvicorn in demo mode against throwaway dirs; yields the base URL."""
+    root = tmp_path_factory.mktemp("e2e")
+    port = _free_port()
+    env = os.environ | {
+        "HARMONIST_DEMO_MODE": "1",
+        "HARMONIST_MUSIC_DIR": str(root / "music"),
+        "HARMONIST_CONFIG_DIR": str(root / "config"),
+    }
+    (root / "music").mkdir()
+    (root / "config").mkdir()
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "harmonist.web.main:app", "--port", str(port)],
+        env=env,
+        cwd=Path(__file__).resolve().parents[2],
+    )
+    base = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
+                    break
+            except OSError:
+                time.sleep(0.3)
+        else:
+            pytest.fail("demo server did not come up")
+
+        # Demo mode IGNORES HARMONIST_MUSIC_DIR: it always sandboxes the sample
+        # library at a fixed $TMPDIR/harmonist-demo, shared by every run on this
+        # machine. These tests mutate albums (a rematch sends one out of the
+        # Library for good), so without a reset each run permanently consumes
+        # part of the fixture and the suite eventually fails on an empty Library
+        # — which looks exactly like a product bug. Reset so runs are repeatable.
+        _reset_demo_library(base)
+        yield base
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def _reset_demo_library(base: str) -> None:
+    """Re-seed the shared demo library, then wait for the rescan to surface it."""
+    req = urllib.request.Request(
+        f"{base}/demo/reset", method="POST", headers={"HX-Request": "true"}
+    )
+    with urllib.request.urlopen(req, timeout=30):
+        pass
+    # The reset kicks a rescan; the Library is empty until it lands.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        with urllib.request.urlopen(f"{base}/library", timeout=10) as r:
+            if 'data-total-done="0"' not in r.read().decode():
+                return
+        time.sleep(0.5)
+    pytest.fail("demo library did not re-seed with terminal albums")

--- a/test/e2e/test_activity_feed.py
+++ b/test/e2e/test_activity_feed.py
@@ -1,0 +1,54 @@
+"""Browser tests for the Activity feed's live-update behaviour.
+
+The feed re-polls every 2s while visible. Whether that swap *replaces* the DOM
+or *patches* it is invisible to the Python suite — both produce identical HTML —
+but it's the whole difference between a steady list and one that flickers, drops
+text selection, and slams open disclosures shut.
+
+Opt-in: requires playwright (`pip install -e .[e2e]` + `playwright install
+chromium`) and RUN_E2E=1. Run via `make e2e`.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1", reason="e2e disabled (set RUN_E2E=1)"
+)
+playwright_sync = pytest.importorskip("playwright.sync_api")
+
+
+def test_feed_poll_patches_the_dom_instead_of_rebuilding_it(demo_server: str) -> None:
+    """#91: the 2s re-poll must morph, not replace.
+
+    Asserted by node IDENTITY — the only thing that actually distinguishes the
+    two, since both produce identical HTML. Stash a reference to a live row, wait
+    for a poll to land, and check the row in the DOM is still the SAME element.
+    Under `hx-swap="innerHTML"` it is a freshly built node, which is the flicker.
+
+    Deliberately not asserted via a `data-*` attribute: idiomorph SYNCS
+    attributes, so one absent from the incoming HTML is stripped even when the
+    node itself is preserved — that check fails on a working morph.
+    """
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        page.goto(demo_server)
+        page.click('[data-tab="activity"]')
+
+        row = page.locator("#activity-feed li").first
+        row.wait_for(state="visible")
+        page.evaluate("window.__firstRow = document.querySelector('#activity-feed li')")
+
+        # Wait for at least one poll cycle (2s) to land.
+        page.wait_for_timeout(3000)
+
+        same_node = page.evaluate(
+            "document.querySelector('#activity-feed li') === window.__firstRow"
+        )
+        assert same_node, "the feed rebuilt its rows instead of morphing them"
+
+        browser.close()

--- a/test/e2e/test_modal_smoke.py
+++ b/test/e2e/test_modal_smoke.py
@@ -14,13 +14,6 @@ a browser. Run via `make e2e`.
 from __future__ import annotations
 
 import os
-import socket
-import subprocess
-import sys
-import time
-import urllib.request
-from collections.abc import Iterator
-from pathlib import Path
 
 import pytest
 
@@ -28,71 +21,6 @@ pytestmark = pytest.mark.skipif(
     os.environ.get("RUN_E2E") != "1", reason="e2e disabled (set RUN_E2E=1)"
 )
 playwright_sync = pytest.importorskip("playwright.sync_api")
-
-
-def _free_port() -> int:
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return int(s.getsockname()[1])
-
-
-@pytest.fixture(scope="module")
-def demo_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
-    """Uvicorn in demo mode against throwaway dirs; yields the base URL."""
-    root = tmp_path_factory.mktemp("e2e")
-    port = _free_port()
-    env = os.environ | {
-        "HARMONIST_DEMO_MODE": "1",
-        "HARMONIST_MUSIC_DIR": str(root / "music"),
-        "HARMONIST_CONFIG_DIR": str(root / "config"),
-    }
-    (root / "music").mkdir()
-    (root / "config").mkdir()
-    proc = subprocess.Popen(
-        [sys.executable, "-m", "uvicorn", "harmonist.web.main:app", "--port", str(port)],
-        env=env,
-        cwd=Path(__file__).resolve().parents[2],
-    )
-    base = f"http://127.0.0.1:{port}"
-    try:
-        deadline = time.monotonic() + 30
-        while time.monotonic() < deadline:
-            try:
-                with socket.create_connection(("127.0.0.1", port), timeout=1):
-                    break
-            except OSError:
-                time.sleep(0.3)
-        else:
-            pytest.fail("demo server did not come up")
-
-        # Demo mode IGNORES HARMONIST_MUSIC_DIR: it always sandboxes the sample
-        # library at a fixed $TMPDIR/harmonist-demo, shared by every run on this
-        # machine. These tests mutate albums (a rematch sends one out of the
-        # Library for good), so without a reset each run permanently consumes
-        # part of the fixture and the suite eventually fails on an empty Library
-        # — which looks exactly like a product bug. Reset so runs are repeatable.
-        _reset_demo_library(base)
-        yield base
-    finally:
-        proc.terminate()
-        proc.wait(timeout=10)
-
-
-def _reset_demo_library(base: str) -> None:
-    """Re-seed the shared demo library, then wait for the rescan to surface it."""
-    req = urllib.request.Request(
-        f"{base}/demo/reset", method="POST", headers={"HX-Request": "true"}
-    )
-    with urllib.request.urlopen(req, timeout=30):
-        pass
-    # The reset kicks a rescan; the Library is empty until it lands.
-    deadline = time.monotonic() + 30
-    while time.monotonic() < deadline:
-        with urllib.request.urlopen(f"{base}/library", timeout=10) as r:
-            if 'data-total-done="0"' not in r.read().decode():
-                return
-        time.sleep(0.5)
-    pytest.fail("demo library did not re-seed with terminal albums")
 
 
 def test_deep_link_opens_album_dialog_without_clobbering_saved_tab(demo_server: str) -> None:


### PR DESCRIPTION
**One attribute.** The Activity tab re-polls every 2s with `hx-swap="innerHTML"`, which destroys and recreates all 100 rows on every poll even when nothing changed — that's the flicker, and why text selection vanishes mid-read.

The infrastructure was already here and already in use: idiomorph is loaded in `base.html`, `hx-ext="morph"` is on `<body>`, and `#task-list` has swapped this way since #11. The feed never got the same treatment.

## How it's proved

By **node identity** — the only thing that distinguishes a morph from a replace, since both emit identical HTML. The test stashes a reference to a live row, waits a poll cycle, and asserts the row in the DOM is still the *same element*. Mutation-checked: reverting to `innerHTML` fails it.

Worth recording: **my first version of that test failed against a working morph.** It stamped a `data-*` attribute, and idiomorph *syncs attributes* — so one absent from the incoming markup is stripped even when the node itself is preserved. Anyone writing another test of this shape will hit the same trap.

That's also exactly why the open-state tracker for #84's disclosures is still needed: the server renders `<details>` without `open`, so morph would close an open one.

## Also

- e2e fixtures move to `test/e2e/conftest.py` so the suite can hold more than one file — `test_modal_smoke.py` was carrying them and is modal-specific.
- `#library-rows` still uses plain `innerHTML`, but it isn't on a timer (load/refresh events only), so it's far less visible. Left alone deliberately rather than swept in.

`make check` green: 696 passed. `make e2e` green: 5 passed.

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8