### PR TITLE
Stop re-rendering the header status pill on every poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- The header status message no longer flickers — it was being re-rendered every
+  1.5 seconds even when the text hadn't changed.
 - The Activity tab no longer flickers while it's open. It refreshes every couple
   of seconds, and was rebuilding the whole list each time; it now updates only
   what actually changed, so the list stays put and text selection survives.

--- a/templates/index.html
+++ b/templates/index.html
@@ -198,14 +198,22 @@ document.addEventListener('DOMContentLoaded', function () {
         document.body.dispatchEvent(new Event('library-refresh'));
     }
 
+    // Last string actually written, so an unchanged status isn't re-rendered.
+    // This runs from the 1.5s /status poll, and assigning innerHTML destroys and
+    // rebuilds the children even when the markup is byte-identical — which flickers
+    // the pill 40 times a minute for as long as any message is showing, and
+    // `latestActionMessage` persists after any action (#93). Same family as #91;
+    // here the fix is simply not to write, which is cheaper and exact — morphing
+    // would be overkill for one small fragment.
+    let lastStatusHtml = null;
+
     function renderStatus() {
         const el = document.getElementById(STATUS_EL_ID);
         if (!el) return;
-        if (syncDisplay) { el.innerHTML = syncDisplay; return; }
-        if (reconcileDisplay) { el.innerHTML = reconcileDisplay; return; }
-        if (scanDisplay) { el.innerHTML = scanDisplay; return; }
-        if (latestActionMessage) { el.innerHTML = latestActionMessage; return; }
-        el.innerHTML = '';
+        const html = syncDisplay || reconcileDisplay || scanDisplay || latestActionMessage || '';
+        if (html === lastStatusHtml) return;
+        lastStatusHtml = html;
+        el.innerHTML = html;
     }
 
     // Preserve <details> group open-state across inbox re-swaps. A rescan (e.g.
@@ -313,8 +321,15 @@ document.addEventListener('DOMContentLoaded', function () {
         if (data.counts) {
             const ib = document.getElementById('inbox-count');
             const lb = document.getElementById('library-count');
-            if (ib) ib.textContent = data.counts.inbox;
-            if (lb) lb.textContent = data.counts.library;
+            // Only write when the number actually changed — assigning textContent
+            // replaces the text node even when the value is identical, and this
+            // runs every 1.5s (#93).
+            if (ib && ib.textContent !== String(data.counts.inbox)) {
+                ib.textContent = data.counts.inbox;
+            }
+            if (lb && lb.textContent !== String(data.counts.library)) {
+                lb.textContent = data.counts.library;
+            }
             // Link-only default derives from the live inbox (see the popover block).
             const cb = document.getElementById('sync-link-only');
             if (cb && !syncLinkOnlyTouched) {

--- a/test/e2e/test_activity_feed.py
+++ b/test/e2e/test_activity_feed.py
@@ -21,6 +21,41 @@ pytestmark = pytest.mark.skipif(
 playwright_sync = pytest.importorskip("playwright.sync_api")
 
 
+def test_status_pill_is_not_rebuilt_when_unchanged(demo_server: str) -> None:
+    """#93: the header status pill must not be re-rendered on every 1.5s poll.
+
+    `renderStatus()` assigned innerHTML unconditionally, which destroys and
+    rebuilds the children even when the markup is byte-identical — 40 rebuilds a
+    minute for as long as any message shows, and `latestActionMessage` persists
+    after any action. Same node-identity check as the feed test below, for the
+    same reason: the rendered HTML is identical either way.
+    """
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        page.goto(demo_server)
+
+        # Fire the event the action routes emit, so a pill exists to watch.
+        page.evaluate(
+            "document.body.dispatchEvent(new CustomEvent('harmonist-status',"
+            "{detail:{verb:'Probe', details:'holding steady', level:'info'}}))"
+        )
+        pill = page.locator("#harmonist-status > *").first
+        pill.wait_for(state="attached")
+        page.evaluate(
+            "window.__pill = document.querySelector('#harmonist-status').firstElementChild"
+        )
+
+        page.wait_for_timeout(3500)  # more than two 1.5s status polls
+
+        same_node = page.evaluate(
+            "document.querySelector('#harmonist-status').firstElementChild === window.__pill"
+        )
+        assert same_node, "the status pill was rebuilt despite unchanged content"
+
+        browser.close()
+
+
 def test_feed_poll_patches_the_dom_instead_of_rebuilding_it(demo_server: str) -> None:
     """#91: the 2s re-poll must morph, not replace.
 


### PR DESCRIPTION
The faint flicker left over after #91 — reported during dogfooding, and **not imagination**: it's the same family of bug in a second place.

## Cause

`renderStatus()` runs from the 1.5s `/status` poll and assigned `innerHTML` unconditionally. That destroys and rebuilds the children even when the markup is byte-identical. `latestActionMessage` persists after any action (and after a completed sync via `sync.finished_at`), so once you've done anything at all the pill rebuilds **40 times a minute**.

Confirmed by node identity *before* writing a fix: stash a reference to the pill, wait two polls, and it's a different element.

## Fix

Unlike #91 this doesn't want morphing — it's a single small fragment, so simply **not writing** when the string is unchanged is cheaper and exact.

The tab count badges get the same guard: assigning `textContent` replaces the text node even when the value is identical, and that also runs every 1.5s.

## Test

Same node-identity technique as the feed test, for the same reason — the rendered HTML is identical either way, so no assertion on markup can distinguish them. Mutation-checked: dropping the guard fails it.

`make check` green: 696 passed. `make e2e` green: 6 passed.

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8