### PR TITLE
Don't pre-surrender the demo album before the first sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Demo mode no longer claims an album has no matching Bandcamp purchase before
+  you've run a sync — that verdict is now reached by the sync, as it is on a real
+  install.
 - The header status message no longer flickers — it was being re-rendered every
   1.5 seconds even when the text hadn't changed.
 - The Activity tab no longer flickers while it's open. It refreshes every couple

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -150,12 +150,21 @@ LIBRARY: list[dict[str, Any]] = [
         },
     },
     {
-        # State: NEEDS_MBID via SURRENDER — a sync couldn't match this owned
-        # purchase (withdrawn from Bandcamp), so it was dropped back with a
-        # read-only "couldn't link" candidate. Its store_url is deliberately NOT a
-        # known purchase, so a sync never re-links it. "Move to Library"
-        # (surrender_keep) accepts it as a terminal Library album — the action that
-        # must resolve without an inbox flicker (#11).
+        # State: NEEDS_SYNC before the first sync, then NEEDS_MBID via SURRENDER
+        # after it. Seeded as an ordinary tagged-but-unlinked album, NOT
+        # pre-surrendered (#87): "no matching Bandcamp purchase" is a conclusion a
+        # sync reaches by paging the whole collection, so asserting it on a fresh
+        # install told the user something Harmonist hadn't worked out yet.
+        #
+        # The surrender is EARNED by the real post-sync pass, not faked here: its
+        # store_url is deliberately not a known purchase, so the sync can't link
+        # it, and `_report_unmatched_after_sync` demotes it with the read-only
+        # "couldn't link" candidate. (Demo's result stub has no
+        # collection_checkpoint_token, so every demo sync counts as full — which
+        # is the condition that makes surrendering conclusive.)
+        #
+        # "Move to Library" (surrender_keep) then accepts it as a terminal Library
+        # album — the action that must resolve without an inbox flicker (#11).
         "artist": "Barry Jive and the Uptown Five",
         "album": "Withdrawn from Sale",
         "tracks": ["No Longer Listed", "Gone from the Store", "Yours to Keep"],
@@ -164,7 +173,8 @@ LIBRARY: list[dict[str, Any]] = [
         "sidecar": {
             "store_url": "https://barryjive.bandcamp.com/album/withdrawn-from-sale",
             "bandcamp_item_id": None,
-            "surrender": {"mb_release_id": "demo-rel-barryjive"},
+            "mb_release_id": "demo-rel-barryjive",
+            "tagged": True,
         },
     },
     {
@@ -940,30 +950,11 @@ def _build_sidecar(sc_spec: dict[str, Any], album_spec: dict[str, Any]) -> Sidec
             mistag_release_group_mbid=mistag["release_group_mbid"],
         )
 
-    # A surrendered purchase: a sync couldn't match this owned album to any
-    # purchase (e.g. withdrawn from Bandcamp), so it was dropped back to NEEDS_MBID
-    # with a read-only "couldn't link" candidate. "Move to Library" accepts it as a
-    # terminal Library album (surrender_keep).
-    if surrender := sc_spec.get("surrender"):
-        candidate = MatchCandidate(
-            mb_release_id=surrender["mb_release_id"],
-            confidence="exact",
-            file_count=len(album_spec["tracks"]),
-            track_count=len(album_spec["tracks"]),
-            track_comparisons=[
-                TrackComparison(
-                    file_name=f"{i:02d} {_safe(t)}.m4a",
-                    file_duration_ms=1000,
-                    file_title=t,
-                    mb_track_title=t,
-                    mb_track_length_ms=1000,
-                    delta_ms=0,
-                )
-                for i, t in enumerate(album_spec["tracks"], start=1)
-            ],
-            proposed_at=now,
-            unmatched_purchase=True,
-        )
+    # NOTE: there is deliberately no way to seed a pre-surrendered album (#87).
+    # A surrender is a conclusion the sync reaches by paging the whole collection
+    # and finding no matching purchase, so faking it at seed time showed the user
+    # a verdict Harmonist hadn't reached. The Barry Jive fixture is seeded as an
+    # ordinary unlinked album and surrendered by the real post-sync pass instead.
 
     tagged_at = now if sc_spec.get("tagged") else None
 

--- a/test/test_demo.py
+++ b/test/test_demo.py
@@ -286,6 +286,44 @@ def test_demo_confirm_tags_album_end_to_end(demo_client):
     assert "Gimme Some Money" not in tasks_after
 
 
+def test_withdrawn_album_is_not_surrendered_before_the_first_sync(music_dir):
+    """#87: "no matching Bandcamp purchase" is a conclusion the sync REACHES by
+    paging the whole collection. Seeding it pre-surrendered showed a fresh demo
+    install a verdict Harmonist hadn't worked out yet.
+
+    Before a sync it's an ordinary tagged-but-unlinked album; the surrender is
+    then earned by the real post-sync pass, not faked at seed time."""
+    from harmonist.web.main import _report_unmatched_after_sync
+
+    demo.install()
+    demo.seed(music_dir)
+
+    def barry():
+        return next(a for a in scanner.scan(music_dir) if "Withdrawn" in a.title)
+
+    before = barry()
+    assert before.state == AlbumState.NEEDS_SYNC
+    assert before.sidecar is not None
+    assert before.sidecar.mb_match_candidate is None  # no verdict yet
+
+    cfg = Config(
+        paths=PathsConfig(config_dir=music_dir.parent / "config", music_dir=music_dir),
+        bandcamp=BandcampConfig(),
+        server=ServerConfig(),
+        test=TestConfig(mode="fixture"),
+    )
+    demo.run_demo_sync(music_dir, link_only=True)
+    # Demo's result stub has no collection_checkpoint_token, so the runner treats
+    # every demo sync as full — the condition that makes surrendering conclusive.
+    _report_unmatched_after_sync(cfg, full_sync=True, albums=scanner.scan(music_dir))
+
+    after = barry()
+    assert after.state == AlbumState.NEEDS_MBID
+    assert after.sidecar is not None
+    assert after.sidecar.mb_match_candidate is not None
+    assert after.sidecar.mb_match_candidate.unmatched_purchase is True
+
+
 def test_demo_auto_resets_on_version_change(music_dir, monkeypatch):
     """A demo dir seeded against an older dataset should auto-reset."""
     demo.seed(music_dir)


### PR DESCRIPTION
The "Withdrawn from Sale" fixture was seeded **already carrying** an `unmatched_purchase` candidate, so a fresh demo install announced "no matching Bandcamp purchase" before any sync had run.

That's a conclusion the sync *reaches* — by paging the whole collection and still finding nothing — so asserting it up front told the user something Harmonist hadn't worked out yet. Distracting, and it misrepresents how the real product behaves.

## Fix

Seed it as an ordinary tagged-but-unlinked album (`NEEDS_SYNC`), and let the surrender be **earned** rather than faked: its `store_url` deliberately matches no known purchase, so the sync can't link it and the real `_report_unmatched_after_sync` demotes it to `NEEDS_MBID` with the read-only "couldn't link" candidate.

This works because demo only mocks the *syncer* — the post-sync logic is the production code path. And demo's result stub has no `collection_checkpoint_token`, so `full_sync` is True, which is the condition that makes surrendering conclusive.

## Verified end to end

```
BEFORE sync: state=NEEDS_SYNC  surrendered=False
AFTER  sync: state=NEEDS_MBID  surrendered=True
```

Pinned by a test that drives both halves.

## Deleted rather than left unused

The seed-time surrender machinery is removed, not just unreferenced. It was the only way to fake this state, and leaving it in would invite exactly this bug back — a note in its place explains why.

`make check` green: 697 passed.

Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8