### PR TITLE
Link the sync-path activity entries to their album

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ versions follow [semantic versioning](https://semver.org).
 - The Activity feed can now page back through older history instead of stopping
   at the most recent entries, and a "Technical detail" toggle shows the raw audit
   records alongside it.
-
+- Downloads, purchase links and possible mis-tags now name and link their album
+  in the feed, like the rest of the entries — and each expands to show what it
+  changed, including the Bandcamp purchase id a link recorded.
 - Activity entries now carry a "what changed" disclosure showing exactly what
   Harmonist did underneath — the tracks it re-tagged, the sidecar rewrites and
   the file moves that action produced. Entries with nothing to show are unchanged.

--- a/src/harmonist/bandcamp_hook.py
+++ b/src/harmonist/bandcamp_hook.py
@@ -605,33 +605,49 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
             return False  # 0 = no confident match; ≥2 = ambiguous → manual review
         album_dir = avail[0]
         self._adopt_consumed.add(album_dir)
-        if write_sidecar_for_item(item, album_dir, prefer_item_url=True):
-            # Show BOTH titles when they differ (the match was by word-subsequence,
-            # e.g. MB "…" vs Bandcamp "… EP") so a loose auto-link is auditable.
-            purchase_title = str(getattr(item, "item_title", "?"))
-            disk_title = _album_title(album_dir)
-            matched = (
-                f" → on-disk “{disk_title}”" if disk_title and disk_title != purchase_title else ""
-            )
-            activity.record(
-                f"{getattr(item, 'band_name', '?')} — {purchase_title}: "
-                f"Needs Link → Library (auto-linked to Bandcamp purchase "
-                f"{getattr(item, 'item_id', '?')} by artist + title{matched})"
-            )
+        # One action scope, so the sidecar audit this write produces (which
+        # records item_id=None->N — the Bandcamp id) attaches to the entry below
+        # as its "what changed" (#97). Without it that row has no action_id and
+        # can only be found via the Technical detail toggle.
+        with activity_store.action():
+            if write_sidecar_for_item(item, album_dir, prefer_item_url=True):
+                # Show BOTH titles when they differ (the match was by
+                # word-subsequence, e.g. MB "…" vs Bandcamp "… EP") so a loose
+                # auto-link is auditable.
+                purchase_title = str(getattr(item, "item_title", "?"))
+                disk_title = _album_title(album_dir)
+                matched = (
+                    f" → on-disk “{disk_title}”"
+                    if disk_title and disk_title != purchase_title
+                    else ""
+                )
+                activity.record(
+                    f"Needs Link → Library (auto-linked to Bandcamp purchase "
+                    f"{getattr(item, 'item_id', '?')} by artist + title{matched})",
+                    album_id=sidecar_mod.album_id_for(album_dir),
+                    album_label=f"{getattr(item, 'band_name', '?')} — {purchase_title}",
+                )
         if not self.ignores.is_ignored(item):
             self.ignores.add(item)
         return True
 
     def _link(self, album_dir: Path, item: Any) -> None:
         try:
-            if write_sidecar_for_item(item, album_dir, prefer_item_url=True):
-                # A linked album leaves Needs Link for the Library. Record the
-                # transition in the Activity feed (and server log).
-                activity.record(
-                    f"{getattr(item, 'band_name', '?')} — {getattr(item, 'item_title', '?')}: "
-                    f"Needs Link → Library (linked to Bandcamp purchase "
-                    f"{getattr(item, 'item_id', '?')})"
-                )
+            # Scoped so the sidecar audit (item_id=None->N, i.e. the Bandcamp id)
+            # attaches to the activity entry as its "what changed" (#97).
+            with activity_store.action():
+                if write_sidecar_for_item(item, album_dir, prefer_item_url=True):
+                    # A linked album leaves Needs Link for the Library. Record the
+                    # transition in the Activity feed (and server log).
+                    activity.record(
+                        f"Needs Link → Library (linked to Bandcamp purchase "
+                        f"{getattr(item, 'item_id', '?')})",
+                        album_id=sidecar_mod.album_id_for(album_dir),
+                        album_label=(
+                            f"{getattr(item, 'band_name', '?')} — "
+                            f"{getattr(item, 'item_title', '?')}"
+                        ),
+                    )
         except Exception as e:
             log.warning(
                 "could not backfill ignored purchase %s: %s",

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -32,7 +32,7 @@ from typing import Any
 
 from mutagen.mp4 import MP4
 
-from . import activity, pending_downloads
+from . import activity, activity_store, pending_downloads
 from . import sidecar as sidecar_mod
 from .formats.m4a import (
     ATOM_ALBUM,
@@ -651,8 +651,16 @@ def _download(
         with contextlib.suppress(Exception):
             progress_callback(f"{spec['artist']} / {spec['album']}")
     time.sleep(STEP_DELAY_SECONDS)
-    _materialise(music_dir, spec)
-    activity.info(f"Downloaded {spec['artist']} / {spec['album']}")
+    # Scoped so the sidecar audit _materialise writes attaches to this entry as
+    # its "what changed" (#97), and labelled so the entry links to the album.
+    with activity_store.action():
+        _materialise(music_dir, spec)
+        album_dir = music_dir / _safe(spec["artist"]) / _safe(spec["album"])
+        activity.info(
+            "Downloaded from Bandcamp",
+            album_id=sidecar_mod.album_id_for(album_dir),
+            album_label=f"{spec['artist']} — {spec['album']}",
+        )
 
 
 def _purchase_item_id(spec: dict[str, Any]) -> int:
@@ -727,9 +735,14 @@ def _fill_in_existing_item_ids(
             track_count_expected=sc.track_count_expected,
             notes=sc.notes,
         )
-        sidecar_mod.write(album_dir, new_sc)
+        with activity_store.action():
+            sidecar_mod.write(album_dir, new_sc)
+            activity.info(
+                "Linked to its Bandcamp purchase",
+                album_id=sidecar_mod.album_id_for(album_dir),
+                album_label=f"{album_dir.parent.name} — {album_dir.name}",
+            )
         patched += 1
-        activity.info(f"Linked {album_dir.parent.name} / {album_dir.name} to its Bandcamp purchase")
         if progress_callback:
             with contextlib.suppress(Exception):
                 progress_callback(f"Linked: {album_dir.parent.name} / {album_dir.name}")

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1008,10 +1008,15 @@ def _detect_mistags_after_sync(
         # must NOT also show as a potential download. `replace_all` already ran
         # during the sync, so remove the now-claimed id.
         pending_downloads.remove(owned_item_id)
+        # Id read back AFTER _demote_to_needs_mbid rewrote the sidecar — that
+        # write clears the MBID, so a pre-demote id is already dead (#65).
+        mistag_id, mistag_label = _live_album_ref(album)
         activity.warning(
-            f"Possible mis-tag: {album.artist} — {album.title}. You own “{label}” on "
-            f"Bandcamp ({url}) — the same release group but a different release than it's "
-            f"tagged as. Moved to Needs MBID with {owned_mbid} suggested; confirm to re-tag."
+            f"Possible mis-tag. You own “{label}” on Bandcamp ({url}) — the same "
+            f"release group but a different release than it's tagged as. Moved to "
+            f"Needs MBID with {owned_mbid} suggested; confirm to re-tag.",
+            album_id=mistag_id,
+            album_label=mistag_label,
         )
 
 

--- a/test/test_demo.py
+++ b/test/test_demo.py
@@ -286,6 +286,38 @@ def test_demo_confirm_tags_album_end_to_end(demo_client):
     assert "Gimme Some Money" not in tasks_after
 
 
+def test_sync_download_and_link_entries_name_and_link_their_album(music_dir, tmp_path):
+    """#97: "Downloaded …" and "Linked … to its Bandcamp purchase" were plain
+    text — no album name, no "what changed". Each now carries its album AND runs
+    in an action scope, so the sidecar audit it produces (which records the
+    Bandcamp item_id) attaches to the entry instead of floating unreachable."""
+    from harmonist import activity, activity_store
+
+    activity_store.init(tmp_path / "audit.db")
+    demo.install()
+    demo.seed(music_dir)
+    activity_store.clear()
+
+    demo.run_demo_sync(music_dir, link_only=False)
+
+    entries = [e for e in activity.recent(40) if e.message.startswith(("Downloaded", "Linked to"))]
+    assert entries, "no download/link entries were recorded"
+    for e in entries:
+        assert e.album_id, f"{e.message!r} has no album to link to"
+        assert e.album_label and " — " in e.album_label
+        assert e.message.count(e.album_label) == 0  # name lives in the column, not the text
+        assert e.action_id, f"{e.message!r} ran outside an action scope"
+        assert activity_store.audit_by_action([e.action_id]).get(e.action_id), (
+            f"{e.message!r} has no correlated audit detail"
+        )
+
+    # The Bandcamp id is what makes a link auditable — check it actually lands.
+    linked = next(e for e in entries if e.message.startswith("Linked to"))
+    assert linked.action_id
+    rows = activity_store.audit_by_action([linked.action_id])[linked.action_id]
+    assert any("item_id=None->" in r.message for r in rows)
+
+
 def test_withdrawn_album_is_not_surrendered_before_the_first_sync(music_dir):
     """#87: "no matching Bandcamp purchase" is a conclusion the sync REACHES by
     paging the whole collection. Seeding it pre-surrendered showed a fresh demo

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -1197,6 +1197,13 @@ def test_detect_mistag_by_release_group_demotes_with_suggestion(cfg):
     assert album.state == AlbumState.NEEDS_MBID
     msgs = [e.message for e in activity.recent(10)]
     assert any("Possible mis-tag" in m and "Cell / Live in Corfu" in m for m in msgs)
+    # #97: the warning names and links its album. The id is read back AFTER the
+    # demote rewrote the sidecar (which clears the MBID), so it still resolves.
+    entry = next(e for e in activity.recent(10) if "Possible mis-tag" in e.message)
+    assert entry.album_id == _id_for(cfg, d)
+    # Named from the album ON DISK, not the MusicBrainz release — the feed should
+    # call it what the user's library calls it.
+    assert entry.album_label == album.title
 
 
 def test_detect_mistag_no_action_when_no_owned_sibling(cfg):


### PR DESCRIPTION
Found dogfooding #96. `Downloaded …`, `Linked … to its Bandcamp purchase` and `Possible mis-tag …` were still plain text — no album name, no "what changed" disclosure. #75 wired the reconcile and post-sync-resolve paths; these are the sync-path writers it didn't reach.

## Two things were missing, not one

1. **`album_id` / `album_label`** on the entry, so it names and links the album. Every site had the album to hand (an `album_dir`, or an `Album`).
2. **An action scope.** These ran *outside* one, so the audit records they produce had no `action_id` and couldn't attach to the entry — reachable only via the Technical detail toggle.

## On auditing successful links

The audit record **already existed**: `_audit_sidecar_change` diffs `item_id`, so a link emits `sidecar.update item_id=None->12345`, carrying the Bandcamp id. What was missing was purely the correlation — without a scope, that row couldn't be shown under the "Linked…" entry it belongs to.

Verified end to end in demo:

```
Dingoes Ate My Baby — Little Bit…   Linked to its Bandcamp   yes   1 audit row(s)
Mouse Rat — The Awesome Album       Downloaded from Bandca   yes   1 audit row(s)
CB4 — Straight Outta Lowcash        Downloaded from Bandca   yes   1 audit row(s)
Autobahn — Nagelbett                Downloaded from Bandca   yes   1 audit row(s)

linked entry audit detail:
    sidecar.update album="…/Little Bit o' Hoot…" item_id=None->1004
```

Messages drop the embedded album name, as in #75, since the column carries it.

## One judgement call

The mis-tag entry is labelled from the album **on disk**, not the MusicBrainz release — the feed should call it what the user's library calls it. Its id is read back *after* the demote rewrote the sidecar, since that write clears the MBID.

`make check` green: 702 passed.

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8