### PR TITLE
Record audit paths relative to the library root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ versions follow [semantic versioning](https://semver.org).
 - The Activity feed can now page back through older history instead of stopping
   at the most recent entries, and a "Technical detail" toggle shows the raw audit
   records alongside it.
+- File paths in the audit records are now shown relative to your music library
+  (`Artist/Album/01 Track.m4a`) instead of as full paths — under Docker the
+  leading part was a container path that meant nothing anyway.
 - Downloads, purchase links and possible mis-tags now name and link their album
   in the feed, like the rest of the entries — and each expands to show what it
   changed, including the Bandcamp purchase id a link recorded.

--- a/src/harmonist/audit.py
+++ b/src/harmonist/audit.py
@@ -19,11 +19,30 @@ outcomes (``source="activity"``) and does not show audit rows.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from . import activity_store
 from .activity_store import Level, Source
 
 log = logging.getLogger("harmonist.audit")
+
+# The library root, so recorded paths are relative to it (#98). An absolute path
+# is mostly noise: under Docker the prefix is a container path (`/music`) that
+# means nothing to the user, and on any install the same prefix repeats on every
+# line while the part that identifies the album is the tail.
+#
+# Set once at startup and read HERE rather than threaded through call sites,
+# because the writers — sidecar.py, cover_art.py, tagger.py, bandcamp_hook.py —
+# have no idea where the library is and shouldn't need to. `_fmt` is the single
+# point every audit value passes through.
+_library_root: Path | None = None
+
+
+def set_library_root(path: Path | None) -> None:
+    """Record paths relative to `path`. None (the default) keeps them absolute,
+    which is what tests and any pre-startup write get."""
+    global _library_root
+    _library_root = path
 
 
 def record(event: str, *, album_id: str | None = None, **fields: object) -> None:
@@ -47,5 +66,22 @@ def _detail(fields: dict[str, object]) -> str:
 def _fmt(value: object) -> str:
     if value is None:
         return "-"
-    s = str(value)
+    s = _rel(value) if isinstance(value, Path) else str(value)
     return f'"{s}"' if (not s or any(c.isspace() for c in s)) else s
+
+
+def _rel(p: Path) -> str:
+    """`p` relative to the library root, else unchanged.
+
+    Only `Path` values are rewritten — a string that happens to look like a path
+    is left alone, since guessing would risk mangling ordinary field values.
+    Anything outside the library (or the root itself) stays absolute: a relative
+    path that escapes upward would be less readable, not more."""
+    root = _library_root
+    if root is None:
+        return str(p)
+    try:
+        rel = p.relative_to(root)
+    except ValueError:
+        return str(p)  # outside the library — absolute is the honest rendering
+    return str(rel) if rel.parts else str(p)

--- a/src/harmonist/bandcamp_hook.py
+++ b/src/harmonist/bandcamp_hook.py
@@ -51,7 +51,9 @@ if not getattr(_bcsync.move_file, "__harmonist_audited__", False):
 
     def _audited_move_file(src: Any, dst: Any) -> Any:
         with contextlib.suppress(Exception):
-            audit.record("move", src=src, dst=dst, overwrite=Path(dst).exists())
+            # Coerced to Path so the audit formatter can make them relative
+            # to the library (#98); bandcampsync hands us str or Path.
+            audit.record("move", src=Path(src), dst=Path(dst), overwrite=Path(dst).exists())
         return _orig_move_file(src, dst)
 
     _audited_move_file.__harmonist_audited__ = True  # type: ignore[attr-defined]

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -76,7 +76,8 @@ def delete_all(music_dir: Path) -> int:
             )
         except OSError:
             continue
-    audit.record("sidecar.delete_all", music_dir=music_dir, removed=removed)
+    # No music_dir field: every path in the log is already relative to it (#98).
+    audit.record("sidecar.delete_all", removed=removed)
     library_index.clear()  # the sidecars are gone; the rescan refills the index
     return removed
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -215,6 +215,9 @@ def create_app(
         activity_store.init_memory()
     else:
         activity_store.init(cfg.paths.config_dir / "activity.db")
+    # Audit paths are recorded relative to the library (#98). Demo mode already
+    # has its sandbox substituted into cfg, so this follows it automatically.
+    audit.set_library_root(cfg.paths.music_dir)
     activity.install_log_handler()
 
     sync_runner = SyncRunner(runner_fn=lambda: None)  # placeholder, replaced below

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,6 +46,19 @@ def clear_activity():
     activity.clear()
 
 
+@pytest.fixture(autouse=True)
+def reset_audit_library_root():
+    """`create_app` sets a process-level library root for relativising audit
+    paths (#98). Reset it after every test, or a test that built an app would
+    leave its tmp_path as the root and quietly change how a LATER test's audit
+    paths render — tests run in random order, so that would be a puzzling
+    intermittent failure rather than an obvious one."""
+    from harmonist import audit
+
+    yield
+    audit.set_library_root(None)
+
+
 @pytest.fixture
 def album_with_tracks(tmp_path):
     """Factory: build an album dir with N copies of the sine fixture, named NN Title.m4a."""

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -79,6 +79,49 @@ def test_audit_record_stores_as_audit_and_is_absent_from_the_feed():
     assert activity.recent() == []
 
 
+def test_audit_paths_are_recorded_relative_to_the_library(tmp_path):
+    """#98: an absolute path is mostly noise — under Docker the prefix is a
+    container path that means nothing to the user, and the part identifying the
+    album is the tail. Relativised centrally in `_fmt`, so the writers (sidecar,
+    tagger, cover_art, bandcamp_hook) never need to know where the library is."""
+    from pathlib import Path
+
+    music = tmp_path / "music"
+    audit.set_library_root(music)
+
+    audit.record("tag.album", album=music / "Artist" / "Album")
+    assert (
+        activity_store.recent(1, source=Source.AUDIT)[0].message == "tag.album album=Artist/Album"
+    )
+
+    # Outside the library, absolute is the honest rendering.
+    audit.record("checkpoint.clear", path=Path("/etc/elsewhere.json"))
+    assert (
+        activity_store.recent(1, source=Source.AUDIT)[0].message
+        == "checkpoint.clear path=/etc/elsewhere.json"
+    )
+
+    # The root itself has no meaningful relative form, so it stays absolute
+    # rather than rendering as a bare ".".
+    audit.record("scan", dir=music)
+    assert str(music) in activity_store.recent(1, source=Source.AUDIT)[0].message
+
+    # Strings are left alone — guessing which ones are paths would risk
+    # mangling ordinary field values.
+    audit.record("note", detail="/music/not-a-path-field")
+    assert "/music/not-a-path-field" in activity_store.recent(1, source=Source.AUDIT)[0].message
+
+
+def test_audit_paths_stay_absolute_before_a_library_root_is_set():
+    """Default is unset, so anything recorded before startup wiring — or in a
+    test — renders exactly as it always did."""
+    from pathlib import Path
+
+    audit.set_library_root(None)
+    audit.record("move", src=Path("/music/a.m4a"))
+    assert activity_store.recent(1, source=Source.AUDIT)[0].message == "move src=/music/a.m4a"
+
+
 def test_level_roundtrips_as_enum():
     activity_store.append(message="boom", level=Level.ERROR, source=Source.ACTIVITY)
     e = activity_store.recent()[0]


### PR DESCRIPTION
An absolute path is mostly noise: under Docker the prefix is a container path (`/music`) that means nothing to the user, and on any install the same prefix repeats on every line while the part identifying the album is the tail.

```
before:  sidecar.update album="/var/folders/…/T/tmpX/music/Dingoes Ate My Baby/Little Bit o' Hoot…"
after:   sidecar.update album="Dingoes Ate My Baby/Little Bit o' Hoot, Whole Lotta Nanny" item_id=None->1004
```

## Why it's genuinely small

Done centrally in `audit._fmt` rather than at the ~10 call sites, because the writers — `sidecar.py`, `cover_art.py`, `tagger.py`, `bandcamp_hook.py` — have no idea where the library is and shouldn't need to. `_fmt` is the single point every audit value already passes through, so it's one function plus one line of startup wiring.

## Deliberate edges

- **Only `Path` values are rewritten.** A string that happens to look like a path is left alone — guessing would risk mangling ordinary field values. The `move` wrapper coerces bandcampsync's `str | Path` arguments so they relativise.
- **Outside the library stays absolute**, as does the root itself: a relative path escaping upward would be *less* readable, and the root has no meaningful relative form (a bare `.` would be worse).
- Drops the now-redundant `music_dir` field from `sidecar.delete_all` — every path in the log is relative to it, and it would have rendered as `.`.

## One hazard worth flagging

The library root is **process-level state**, so `conftest` resets it after every test. Without that, a test building an app would leave its `tmp_path` as the root and silently change how a *later* test's paths render — and since tests run in random order, that would surface as a puzzling intermittent failure rather than an obvious one.

`make check` green: 704 passed. `make e2e` green: 7 passed.

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8