### PR TITLE
Stop the activity feed announcing non-events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- The Activity feed no longer announces non-events: starting a sync writes one
+  entry instead of two, and it now says whether the sync is link-only (drains
+  Needs Link, downloads nothing) or full. A reconcile that finds nothing to do
+  says nothing at all, rather than three lines reporting that nothing happened.
+
 - Demo mode no longer claims an album has no matching Bandcamp purchase before
   you've run a sync — that verdict is now reached by the sync, as it is on a real
   install.

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -241,6 +241,11 @@ def create_app(
             sync_runner.link_only_override = None
             auto = live_counts.to_status()["needs_sync"] > 0 or pending_downloads.count() > 0
             link_only = override if override is not None else auto
+            activity.info(
+                "Sync started (link-only) — downloads are paused this sync."
+                if link_only
+                else "Sync started (full) — new purchases will be downloaded."
+            )
             result = demo.run_demo_sync(
                 cfg.paths.music_dir,
                 link_only=link_only,
@@ -297,11 +302,16 @@ def create_app(
             link_only = override if override is not None else pending_links > 0
             if link_only and pending_links == 0:
                 _clear_bandcampsync_checkpoint(cfg.paths.music_dir)
+            # The ONE sync-start entry, written here because this is where the
+            # mode is decided — the runner's generic "started" line fired before
+            # this point and so could never name it (#101).
             if link_only:
                 activity.info(
-                    f"Linking your library — {pending_links} album(s) to match. "
+                    f"Sync started (link-only) — {pending_links} album(s) to match. "
                     "Downloads are paused this sync and resume on the next one.",
                 )
+            else:
+                activity.info("Sync started (full) — new purchases will be downloaded.")
             result = _run_bandcamp_sync(
                 cfg,
                 progress_callback=sync_runner.set_current_item,
@@ -2117,7 +2127,11 @@ def _register_routes(app: FastAPI) -> None:
                 tasks_changed=False,
                 status_code=status.HTTP_409_CONFLICT,
             )
-        return _flash_response("Sync started", "watch the inbox", tasks_changed=False)
+        # No activity entry here: the runner writes the single sync-start line
+        # once it knows link-only vs full (#101). This is just the status flash.
+        return _flash_response(
+            "Sync started", "watch the inbox", tasks_changed=False, record_activity=False
+        )
 
     @app.get("/bandcamp/setup", response_class=HTMLResponse)
     def bandcamp_setup(request: Request) -> Response:
@@ -2855,6 +2869,7 @@ def _flash_response(
     status_code: int = 200,
     extra_triggers: dict[str, Any] | None = None,
     album: Album | None = None,
+    record_activity: bool = True,
 ) -> HTMLResponse:
     """Standard action response: flash HTML body + HX-Trigger events.
 
@@ -2880,7 +2895,11 @@ def _flash_response(
     message = verb if not details else f"{verb} — {details}"
     album_id, album_label = (None, None) if album is None else _live_album_ref(album)
     # Every action outcome is also an activity-log entry (the Activity tab).
-    activity.record(message, level, album_id=album_id, album_label=album_label)
+    # `record_activity=False` is for the rare case where a background worker
+    # writes the authoritative entry itself — starting a sync, where only the
+    # runner knows link-only vs full — and this would just duplicate it (#101).
+    if record_activity:
+        activity.record(message, level, album_id=album_id, album_label=album_label)
     triggers: dict[str, Any] = {
         "harmonist-status": {
             "verb": verb,

--- a/src/harmonist/web/reconcile_runner.py
+++ b/src/harmonist/web/reconcile_runner.py
@@ -212,10 +212,10 @@ def reconcile_pending_orphans(
     if albums is None:
         # No snapshot handed in — walk the library ourselves. This can take a
         # while on a large tree, so announce it (the feed would be silent).
-        activity.info("Reconcile started — scanning the library for albums to reconcile…")
+        # Phrased as progress, not a start: the "Reconcile started — N to check"
+        # line below is the start, and two "started" entries read as a bug.
+        activity.info("Reconcile: scanning the library…")
         albums = scanner.scan(music_dir)
-    else:
-        activity.record("Reconcile started")
     # NEW: derive a sidecar. TAGGING: the sidecar's MBID disagrees with the file
     # tags (an external Picard re-tag) — adopt the files. Both are reconcile's job.
     pending = [
@@ -258,11 +258,22 @@ def reconcile_pending_orphans(
     if status_updater:
         status_updater(total=total)
     _report()  # publish the base (all-zero deltas) before the first album
-    activity.record(
-        f"Reconcile: {total} album(s) to check"
-        if total
-        else "Reconcile: nothing to reconcile (no new albums on disk)"
-    )
+    if not total:
+        # Nothing to do. Reconcile runs on startup and after every sync, so
+        # announcing a no-op made it the feed's most frequent content — three
+        # lines to report that nothing happened (#101). Still logged, so it
+        # stays greppable when someone asks "did reconcile run?".
+        log.info("Reconcile: nothing to reconcile (no new albums on disk)")
+        return {
+            "total": 0,
+            "reconciled_bandcamp": 0,
+            "reconciled_manual": 0,
+            "recovered_url": 0,
+            "adopted": 0,
+            "skipped": 0,
+            "errors": 0,
+        }
+    activity.record(f"Reconcile started — {total} album(s) to check")
 
     for album in pending:
         # One action scope per ALBUM (#84): reconcile writes a sidecar and an

--- a/src/harmonist/web/sync_runner.py
+++ b/src/harmonist/web/sync_runner.py
@@ -100,7 +100,10 @@ class SyncRunner:
         return self._status
 
     def _run(self) -> None:
-        activity.info("Bandcamp sync started")
+        # No "started" entry here: it fired before runner_fn decides link-only
+        # vs full, so it could never name the mode. The runner writes the single
+        # authoritative line once it knows (#101).
+        log.info("sync started")
         new_items = 0
         remaining = 0
         error: str | None = None

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -704,6 +704,32 @@ def test_post_sync_starts_runner(client):
     assert "Sync started" in r.text
 
 
+def test_sync_route_does_not_duplicate_the_start_entry(client):
+    """#101: starting a sync wrote TWO feed entries — the route's flash and the
+    runner's generic line — and neither said whether it was link-only. The route
+    keeps its status-bar flash but no longer writes an entry; the runner writes
+    the single authoritative one once it knows the mode."""
+    import time
+
+    from harmonist import activity
+
+    runner = client.app.state.sync_runner
+    runner._runner_fn = lambda: None
+    activity.clear()
+
+    r = client.post("/sync")
+    assert r.status_code == 200
+    assert "Sync started" in r.text  # the status-bar flash still fires
+
+    for _ in range(50):  # let the runner thread finish
+        if runner.status()["state"] == "idle":
+            break
+        time.sleep(0.02)
+
+    starts = [e.message for e in activity.recent(20) if "ync started" in e.message]
+    assert starts == [], f"the route should write no start entry, got {starts}"
+
+
 def test_post_sync_409_when_already_running(client):
     runner = client.app.state.sync_runner
     # Manually flag as running so the second POST hits the 409 branch
@@ -2410,6 +2436,43 @@ def test_post_sync_auto_tag_entry_links_to_the_album(cfg, monkeypatch):
     assert _id_for(cfg, d) == entry.album_id
     # The name is no longer duplicated inside the message.
     assert "AutoTagged" not in entry.message
+
+
+def test_reconcile_with_nothing_to_do_is_silent_in_the_feed(cfg, caplog):
+    """#101: reconcile runs on startup and after every sync, and used to report a
+    no-op with three entries — making "nothing happened" the feed's most frequent
+    content. It stays in the server log so it's still greppable."""
+    import logging
+
+    from harmonist import activity
+    from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+    cfg.paths.music_dir.mkdir(parents=True, exist_ok=True)
+    activity.clear()
+
+    with caplog.at_level(logging.INFO):
+        reconcile_pending_orphans(cfg.paths.music_dir, fetch_urls=lambda m: [], albums=[])
+
+    assert activity.recent(10) == []
+    assert any("nothing to reconcile" in r.message for r in caplog.records)
+
+
+def test_reconcile_with_work_announces_once(cfg):
+    """One start line naming the count, then the summary — not a separate
+    "started" and "N to check"."""
+    from harmonist import activity
+    from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+    _make_album(cfg, "NeedsReconcile", mbid="rel-nr")
+    activity.clear()
+
+    reconcile_pending_orphans(cfg.paths.music_dir, fetch_urls=lambda m: [])
+
+    msgs = [e.message for e in activity.recent(10)]
+    starts = [m for m in msgs if m.startswith("Reconcile started")]
+    assert len(starts) == 1, f"expected exactly one start line, got {starts}"
+    assert "1 album(s) to check" in starts[0]
+    assert any(m.startswith("Reconcile done") for m in msgs)
 
 
 def test_reconcile_entries_link_to_their_album(cfg):


### PR DESCRIPTION
Two duplicates found dogfooding.

## Sync wrote two start entries

`Sync started — watch the inbox` (the route's flash) and `Bandcamp sync started` (the runner) — and **neither said whether the sync was link-only**, which is the one thing worth knowing at that moment: link-only drains Needs Link and downloads nothing, a full sync fetches.

The runner's line *couldn't* say it — it fired **before** `runner_fn` decides the mode, so the entry had to move to where the decision is made. Now one entry, written in each `runner_fn`, naming the mode:

```
Sync started (link-only) — 3 album(s) to match. Downloads are paused this sync…
Sync started (full) — new purchases will be downloaded.
```

The route keeps its status-bar flash via a new `record_activity=False`: the flash and the feed entry come from the same helper, and only the feed half was redundant.

## Reconcile reported a no-op with three entries

```
Reconcile started
Reconcile: nothing to reconcile (no new albums on disk)
Reconcile done: 0 reconciled (0 → Needs Link, 0 → Library, 0 → Needs MBID), 0 unchanged, 0 failed
```

Reconcile runs on startup and after every sync, which made *"nothing happened"* the feed's most frequent content. It now returns early and says nothing, keeping the line at INFO in the **server log** so it's still greppable when someone asks "did reconcile run?".

With work to do it announces once, then summarises:

```
Reconcile started — 2 album(s) to check
New → Needs Link (reconciled from tags)
Reconcile done: 1 reconciled (1 → Needs Link, …), 1 unchanged, 0 failed
```

## One extra duplicate found on the way

The library-scan note read `Reconcile started — scanning…`, which collided with the new start line — two "started" entries in sequence read as a bug. Reworded to `Reconcile: scanning the library…`, since it's progress, not a start, and only fires when reconcile has no snapshot and must walk the tree itself.

`make check` green: 707 passed.

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNCe5QW9qhe7ASgfKmL7k8