### PR TITLE
Disable the header's global actions on Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Sync Bandcamp is disabled on the Settings page, where it would have read
+  settings you're partway through changing (#108).
+
 ### Added
 
 - Albums now have their own page at `/album/<id>`, with the full tracklist and

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -720,6 +720,16 @@ def _ctx(request: Request, **extra: Any) -> dict[str, Any]:
         "sync_link_only_default": (
             live_counts.to_status()["needs_sync"] > 0 or pending_downloads.count() > 0
         ),
+        # Why the header's global actions are inert on this page, or None if they
+        # aren't. Derived here rather than passed per-route so a new page can't
+        # forget it, and server-side because the poll JS that does the *busy*-state
+        # gating only runs on the index page.
+        "globals_off_reason": (
+            "Finish in Settings first — a sync started here would read settings you're"
+            " partway through changing."
+            if request.url.path == "/settings"
+            else None
+        ),
     }
     base.update(extra)
     return base

--- a/templates/header.html
+++ b/templates/header.html
@@ -18,9 +18,14 @@
                         hx-post="/sync"
                         hx-target="#sync-flash"
                         hx-swap="innerHTML"
-                        class="px-4 py-1.5 bg-accent hover:bg-accent-dark text-white rounded font-semibold transition">
+                        {% if globals_off_reason %}disabled title="{{ globals_off_reason }}"{% endif %}
+                        class="px-4 py-1.5 bg-accent hover:bg-accent-dark text-white rounded font-semibold transition{% if globals_off_reason %} opacity-40 cursor-not-allowed{% endif %}">
                     Sync Bandcamp
                 </button>
+                {# Suppressed entirely when the globals are off: `disabled` on the
+                   button doesn't stop :hover on this wrapper, and the popover holds
+                   a second sync trigger (its submit) that would still fire. #}
+                {% if not globals_off_reason %}
                 {# Positioned at top-full with a transparent pt-1 *bridge* (padding, not
                    margin) so moving the cursor from the button into the card never
                    crosses a dead zone that would drop :hover and close the popover. #}
@@ -53,15 +58,20 @@
                     </form>
                   </div>
                 </div>
+                {% endif %}
             </div>
             {% else %}
             {# Cookies not configured yet — prompt setup instead of syncing.
-               Doubles as a visible reminder that onboarding is incomplete. #}
+               Doubles as a visible reminder that onboarding is incomplete.
+               Inert on Settings, which carries its own Set up button in the
+               Bandcamp sync section — so this isn't a dead end, just the
+               duplicate stepping aside. #}
             <button id="bandcamp-setup-button"
                     hx-get="/bandcamp/setup"
                     hx-target="#modal"
                     hx-swap="innerHTML"
-                    class="px-4 py-1.5 border border-accent text-accent hover:bg-accent-soft rounded font-semibold transition">
+                    {% if globals_off_reason %}disabled title="Use Set up in the Bandcamp sync section below."{% endif %}
+                    class="px-4 py-1.5 border border-accent text-accent hover:bg-accent-soft rounded font-semibold transition{% if globals_off_reason %} opacity-40 cursor-not-allowed{% endif %}">
                 Set up Bandcamp sync
             </button>
             {% endif %}

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -7,6 +7,7 @@ templates render without crashing for each AlbumState.
 
 from __future__ import annotations
 
+import re
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
@@ -3262,6 +3263,44 @@ def test_settings_page_renders(client, cfg):
     # The preferences form must submit via HTMX (hx-boost) so the CSRF
     # middleware's required HX-Request header is sent — a plain POST 403s.
     assert 'action="/settings" hx-boost="true"' in r.text
+
+
+def _button_tag(html: str, button_id: str) -> str:
+    """The opening <button> tag with this id, so a test can assert on the
+    attributes of THAT button rather than anywhere in the page."""
+    m = re.search(rf'<button id="{button_id}"[^>]*>', html)
+    assert m is not None, f"no <button id={button_id}> in page"
+    return m.group(0)
+
+
+def test_settings_page_disables_the_global_sync_actions(client, cfg):
+    """Sync is inert on Settings: it would read configuration the user is
+    partway through changing (#108)."""
+    cfg.cookies_file.write_text(
+        "# Netscape HTTP Cookie File\n.bandcamp.com\tTRUE\t/\tFALSE\t0\tident\tabc\n"
+    )
+    settings = client.get("/settings")
+    assert "disabled" in _button_tag(settings.text, "sync-button")
+    # The popover carries a SECOND sync trigger (its submit) and `disabled` on
+    # the button doesn't stop :hover on the wrapper — so it must be gone, not
+    # merely covered.
+    assert 'name="link_only"' not in settings.text
+
+    # Control: the same header on the index page is live, or this test would
+    # pass against a sync button that is disabled everywhere.
+    home = client.get("/")
+    assert "disabled" not in _button_tag(home.text, "sync-button")
+    assert 'name="link_only"' in home.text
+
+
+def test_settings_page_disables_the_header_setup_button(client, cfg):
+    """The header's Set-up duplicate goes inert too — Settings has its own in
+    the Bandcamp sync section, so this is no dead end (#108)."""
+    settings = client.get("/settings")  # no cookies → header offers setup
+    assert "disabled" in _button_tag(settings.text, "bandcamp-setup-button")
+    # The escape hatch: Settings' own control, still live.
+    assert 'hx-get="/bandcamp/setup"' in settings.text
+    assert "disabled" not in _button_tag(client.get("/").text, "bandcamp-setup-button")
 
 
 def test_debug_memory_endpoint(client):


### PR DESCRIPTION
The header renders on every page, so **Sync Bandcamp** stayed live and clickable on `/settings` — where starting a sync means it reads configuration you're partway through changing.

**Approach:** gated server-side. `_ctx()` derives `globals_off_reason` from the request path, so no route can forget it. This can't ride on the existing client-side gating: the poll JS in `index.html` that disables these buttons during a sync/reconcile only runs on the index page, and `/settings` never loads it.

**Two details worth a look:**

- The sync popover is *removed*, not disabled. `disabled` on the button doesn't stop `:hover` on its wrapper `div`, and the popover carries a second sync trigger in its own submit — so covering it wouldn't have been enough.
- The header's Set-up duplicate goes inert too. That's only safe because Settings has its own Set up / Re-configure in the Bandcamp sync section, so it's not a dead end — pinned by a test, and the tooltip points there.

**Tests:** two, both verified to fail against the unfixed template. Each carries a control asserting the same button is still live on `/`, so they can't pass against a button that's disabled everywhere.

Fixes #108