### PR TITLE
Stop swallowed failures from looking like legitimate results

### DIFF
--- a/.claude/skills/error-handling/SKILL.md
+++ b/.claude/skills/error-handling/SKILL.md
@@ -27,6 +27,17 @@ The same shape, worse: `resolve_alias` returning `None` on error means "this id
 was never superseded", so `_find_album` concludes the album doesn't exist. One
 transient DB error and the user is told their album is gone.
 
+Both were real (`activity_store`, fixed in #104), and the fix is the pattern to
+copy: a **typed error for "I couldn't tell"** — `StoreUnavailableError` — raised
+by every read, caught at the route, rendered as *"History unavailable … this does
+not mean nothing was recorded"*. Three properties make it work:
+
+- The failure has its **own type**, so a caller can't confuse it with a result.
+- The route **degrades the section, not the page**: the album page still renders
+  its tracklist and actions, and the polled feed doesn't 500 in a loop.
+- A partial answer is **discarded**, not shown. Half a feed presented as the
+  whole feed is the same lie in miniature.
+
 Before writing a fallback value, ask: **can the caller tell this apart from
 success?** If not, don't return it — propagate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ versions follow [semantic versioning](https://semver.org).
   the first library scan its "Sync with these options" started a sync anyway
   (#110).
 - Syncing is refused while the first library scan is still running (#110).
+- A history store Harmonist can't read now says so, instead of showing an empty
+  Activity feed and "Nothing recorded for this album yet" (#104).
+- A broken history store no longer makes a link to an album report that the album
+  doesn't exist (#104).
+- A sidecar that can't be read is no longer silently skipped during a sync, where
+  it could offer an album you already own as a new download (#104), or quietly
+  rewritten when it should have been left alone.
+- "Erased N sidecar(s)" no longer counts sidecars it failed to delete (#104).
+- Failures that used to be invisible — a dropped activity or audit record, an
+  unreadable ignores file, a Restore that did nothing — are now logged (#104).
 
 ### Added
 

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -34,6 +34,30 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 
+# Every failure logged from THIS module carries `_activity`, which tells the
+# feed's log mirror (activity._ActivityLogHandler) not to turn it into a feed
+# entry. Two reasons: writing "the store is broken" INTO the broken store is
+# self-defeating, and the mirror's own append would fail and log again. The
+# guard makes that terminate, but the pointless round trip is worth skipping.
+_QUIET_MIRROR = {"_activity": True}
+
+
+class StoreUnavailableError(RuntimeError):
+    """A read against the store failed — the answer is unknown, not empty.
+
+    Every read here used to swallow `sqlite3.Error` and return `[]` / `{}` /
+    `None`, which the caller cannot tell from a genuine empty result. The album
+    page then renders "Nothing recorded for this album yet" over a locked or
+    corrupt database, stating as fact that Harmonist has never touched the album
+    — at the moment the user is trying to find out what it did (#104).
+
+    So reads raise this instead, and the routes turn it into a visible "history
+    unavailable" rather than a confident lie. WRITES do not raise: recording is
+    incidental to the operation being recorded and must never abort it, so they
+    log at ERROR and continue. See the error-handling skill §1 and §5.
+    """
+
+
 class Source(StrEnum):
     """Which log a stored event belongs to. The feed shows ACTIVITY; AUDIT is the
     durable forensic trail (both share this store, distinguished by this column)."""
@@ -304,7 +328,15 @@ def append(
             )
             conn.commit()
     except sqlite3.Error:
-        log.debug("activity_store append failed", exc_info=True, extra={"_activity": True})
+        # ERROR, not debug: this is the single sink for BOTH activity and audit,
+        # so a dropped row here can be the only record that Harmonist rewrote the
+        # user's tags. The audit log's whole value is "if it isn't here, it didn't
+        # happen" — dropping rows quietly makes every remaining row untrustworthy
+        # (skill §5). Still swallowed: recording must not abort what it records.
+        #
+        # `extra={"_activity": True}` is load-bearing — it stops the feed's log
+        # mirror re-entering record() and looping (activity._ActivityLogHandler).
+        log.exception("activity_store append failed", extra=_QUIET_MIRROR)
 
 
 def recent(
@@ -340,8 +372,11 @@ def recent(
         conn = _ensure()
         with _LOCK:
             rows = conn.execute(q, args).fetchall()
-    except sqlite3.Error:
-        return []
+    except sqlite3.Error as exc:
+        log.exception(
+            "activity_store recent() failed — the feed cannot be read", extra=_QUIET_MIRROR
+        )
+        raise StoreUnavailableError("could not read the activity store") from exc
     return [
         StoredEvent(
             ts=datetime.fromisoformat(ts),
@@ -375,8 +410,9 @@ def audit_by_action(action_ids: list[str]) -> dict[str, list[StoredEvent]]:
         conn = _ensure()
         with _LOCK:
             rows = conn.execute(q, [Source.AUDIT.value, *action_ids]).fetchall()
-    except sqlite3.Error:
-        return {}
+    except sqlite3.Error as exc:
+        log.exception("activity_store audit_by_action() failed", extra=_QUIET_MIRROR)
+        raise StoreUnavailableError("could not read the audit detail") from exc
     out: dict[str, list[StoredEvent]] = {}
     for ts, level, src, msg, aid, label, act in rows:
         out.setdefault(act, []).append(
@@ -416,7 +452,18 @@ def record_alias(old_id: str, new_id: str) -> None:
             )
             conn.commit()
     except sqlite3.Error:
-        log.debug("activity_store record_alias failed", exc_info=True, extra={"_activity": True})
+        # ERROR and unrecoverable: this insert is the ONLY moment the old->new
+        # pair is knowable (the superseded id is erased from the sidecar straight
+        # afterwards), so losing it orphans the album's entire pre-tag history and
+        # 404s every deep link written under the old id, permanently. Still
+        # swallowed — an identity change must not fail because the log is down.
+        log.exception(
+            "activity_store record_alias failed — %s -> %s; this album's history "
+            "before the change is now unreachable and old links to it will 404",
+            old_id,
+            new_id,
+            extra=_QUIET_MIRROR,
+        )
 
 
 def resolve_alias(album_id: str, *, max_hops: int = 20) -> str | None:
@@ -426,6 +473,11 @@ def resolve_alias(album_id: str, *, max_hops: int = 20) -> str | None:
     Walks transitively (temp_uid -> mbid -> corrected mbid). `max_hops` and the
     seen-set bound the walk: a cycle would otherwise spin forever, and while the
     schema shouldn't permit one, a log is not worth hanging a request over.
+
+    Raises `StoreUnavailableError` rather than returning None on a read failure:
+    None here means "never superseded", which sends the only caller on to a 404
+    — so one transient DB error would tell the user an album that is sitting on
+    disk, intact, does not exist (#104, skill §1).
     """
     seen = {album_id}
     current = album_id
@@ -440,8 +492,9 @@ def resolve_alias(album_id: str, *, max_hops: int = 20) -> str | None:
                     break
                 current = row[0]
                 seen.add(current)
-    except sqlite3.Error:
-        return None
+    except sqlite3.Error as exc:
+        log.exception("activity_store resolve_alias(%s) failed", album_id, extra=_QUIET_MIRROR)
+        raise StoreUnavailableError("could not follow the album alias chain") from exc
     return None if current == album_id else current
 
 
@@ -463,14 +516,18 @@ def album_history(album_id: str, limit: int = 200, *, offset: int = 0) -> list[S
         f"FROM events WHERE album_id IN ({placeholders}) "
         "ORDER BY id DESC LIMIT ? OFFSET ?"
     )
-    # Deliberately NOT caught: an empty list here renders as "Nothing recorded for
-    # this album yet", so swallowing a read failure would have the page state, as
+    # Deliberately NOT swallowed: an empty list here renders as "Nothing recorded
+    # for this album yet", so hiding a read failure would have the page state, as
     # fact, that Harmonist has never touched the album — at the moment the user is
-    # trying to find out what it did. A 500 is the honest answer. See the
-    # error-handling skill §1.
-    conn = _ensure()
-    with _LOCK:
-        rows = conn.execute(q, [*ids, limit, max(0, offset)]).fetchall()
+    # trying to find out what it did. Raised as StoreUnavailableError so the route
+    # can say "history unavailable" instead. See the error-handling skill §1.
+    try:
+        conn = _ensure()
+        with _LOCK:
+            rows = conn.execute(q, [*ids, limit, max(0, offset)]).fetchall()
+    except sqlite3.Error as exc:
+        log.exception("activity_store album_history(%s) failed", album_id, extra=_QUIET_MIRROR)
+        raise StoreUnavailableError("could not read this album's history") from exc
     return [
         StoredEvent(
             ts=datetime.fromisoformat(ts),
@@ -499,23 +556,27 @@ def _alias_ancestors(album_id: str, *, max_hops: int = 20) -> list[str]:
     found: list[str] = []
     seen = {album_id}
     frontier = [album_id]
-    # Not caught: a partial chain silently narrows the history to a subset of the
-    # album's ids, which looks exactly like a complete answer. Let it propagate to
-    # album_history's caller rather than quietly returning less than was asked
-    # for. See the error-handling skill §1.
-    conn = _ensure()
-    with _LOCK:
-        for _ in range(max_hops):
-            if not frontier:
-                break
-            placeholders = ",".join("?" * len(frontier))
-            rows = conn.execute(
-                f"SELECT old_id FROM album_aliases WHERE new_id IN ({placeholders})",
-                frontier,
-            ).fetchall()
-            frontier = [r[0] for r in rows if r[0] not in seen]
-            seen.update(frontier)
-            found.extend(frontier)
+    # Not swallowed: a partial chain silently narrows the history to a subset of
+    # the album's ids, which looks exactly like a complete answer — and the old
+    # code discarded the ids it HAD already walked on the way out. Propagate to
+    # album_history's caller instead. See the error-handling skill §1.
+    try:
+        conn = _ensure()
+        with _LOCK:
+            for _ in range(max_hops):
+                if not frontier:
+                    break
+                placeholders = ",".join("?" * len(frontier))
+                rows = conn.execute(
+                    f"SELECT old_id FROM album_aliases WHERE new_id IN ({placeholders})",
+                    frontier,
+                ).fetchall()
+                frontier = [r[0] for r in rows if r[0] not in seen]
+                seen.update(frontier)
+                found.extend(frontier)
+    except sqlite3.Error as exc:
+        log.exception("activity_store _alias_ancestors(%s) failed", album_id, extra=_QUIET_MIRROR)
+        raise StoreUnavailableError("could not read this album's identity history") from exc
     return found
 
 
@@ -533,4 +594,11 @@ def clear() -> None:
             conn.execute("DELETE FROM album_aliases")
             conn.commit()
     except sqlite3.Error:
-        pass
+        # Swallowed rather than raised: the callers are teardown paths (test
+        # fixtures, the demo reset) where failing to wipe is not the user's work
+        # and a raise would mask the real failure under a cleanup error. Loud,
+        # though — a reset that didn't reset leaves stale aliases that can
+        # mis-resolve a deep link to the wrong album.
+        log.exception(
+            "activity_store clear() failed — stored events may be stale", extra=_QUIET_MIRROR
+        )

--- a/src/harmonist/bandcamp_hook.py
+++ b/src/harmonist/bandcamp_hook.py
@@ -41,6 +41,41 @@ from .url_recovery import album_slug as album_slug  # noqa: PLC0414 (explicit re
 log = logging.getLogger(__name__)
 
 
+class _SkippedSidecars:
+    """Counts sidecars a library pass couldn't read, and says so in the log.
+
+    Skipping one silently is not cosmetic. The album drops out of the index being
+    built, so its purchase matches nothing and becomes a *potential download* —
+    re-downloading audio the user already owns is the exact harm the adoption
+    design exists to prevent, and a bare `continue` is how it used to happen
+    without a trace (#104).
+
+    First failure carries the traceback, the rest are counted: one unreadable
+    file must not bury the log under N identical stacks (skill §3). Callers pass
+    over the whole library, so `done()` at the end is what makes a partial index
+    diagnosable after the fact.
+    """
+
+    def __init__(self, pass_name: str) -> None:
+        self._pass_name = pass_name
+        self.count = 0
+
+    def skip(self, path: Path) -> None:
+        """Call from inside the `except` — it reads the live exception."""
+        self.count += 1
+        if self.count == 1:
+            log.exception("%s: skipping unreadable sidecar %s", self._pass_name, path)
+
+    def done(self) -> None:
+        if self.count:
+            log.error(
+                "%s: %d sidecar(s) unreadable and skipped — those albums are missing "
+                "from this pass, so their purchases may be offered as new downloads",
+                self._pass_name,
+                self.count,
+            )
+
+
 # Capture bandcampsync's per-file extract moves in the audit log — every file
 # written/overwritten into the library is then recorded (transparency: the data-
 # safety concern). bandcampsync's own "Moving extracted file …" lines ride its
@@ -246,10 +281,12 @@ def survey_album_links(music_dir: Path) -> tuple[dict[str, list[Path]], list[Pat
     by_slug: dict[str, list[Path]] = {}
     slugless: list[Path] = []
     linked_ids: set[int] = set()
+    skipped = _SkippedSidecars("backfill index")
     for f in music_dir.rglob(".harmonist.json"):
         try:
             sc = sidecar_mod.read(f.parent)
-        except Exception:
+        except (OSError, sidecar_mod.InvalidSidecarError):
+            skipped.skip(f)
             continue
         if sc is None or not sc.store_url:
             continue
@@ -260,6 +297,7 @@ def survey_album_links(music_dir: Path) -> tuple[dict[str, list[Path]], list[Pat
             by_slug.setdefault(slug, []).append(f.parent)
         elif is_bandcamp_url(sc.store_url):
             slugless.append(f.parent)
+    skipped.done()
     return by_slug, slugless, linked_ids
 
 
@@ -574,10 +612,12 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
         match the `©alb` title against the purchase title by word-subsequence
         (`titles_match`). Reading titles for just this (small) set is cheap."""
         index: dict[str, list[tuple[tuple[str, ...], Path]]] = {}
+        skipped = _SkippedSidecars("adopt index")
         for album_dir in slugless:
             try:
                 sc = sidecar_mod.read(album_dir)
-            except Exception:
+            except (OSError, sidecar_mod.InvalidSidecarError):
+                skipped.skip(album_dir)
                 continue
             if sc is None or not sc.store_url:
                 continue
@@ -585,6 +625,7 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
             if not host:
                 continue
             index.setdefault(host, []).append((title_words(_album_title(album_dir)), album_dir))
+        skipped.done()
         return index
 
     def _adopt_link(self, item: Any, url: str) -> bool:
@@ -686,14 +727,29 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
                 # sidecar each sync (bumping mtimes → the next scan re-reads every
                 # album's tags, the slow "finishing up") and spam the feed with
                 # "Needs Link → Library" for albums long since in the Library.
+                #
+                # An unreadable sidecar must NOT read as "not linked yet". That
+                # sends us down the write path above — rewriting a sidecar we
+                # can't even read, over an album that may well be linked already,
+                # for exactly the churn this guard exists to prevent (#104). Treat
+                # it as "leave it alone", loudly: not overwriting what we can't
+                # read is also the non-destructive answer.
+                unreadable = False
+                existing = None
                 try:
                     existing = sidecar_mod.read(existing_dir)
-                except Exception:
-                    existing = None
+                except (OSError, sidecar_mod.InvalidSidecarError):
+                    unreadable = True
+                    log.exception(
+                        "could not read the sidecar at %s while linking Bandcamp "
+                        "purchase %s — leaving it untouched",
+                        existing_dir,
+                        getattr(item, "item_id", "?"),
+                    )
                 already_linked = bool(
                     existing and existing.bandcamp and existing.bandcamp.item_id is not None
                 )
-                if not already_linked:
+                if not already_linked and not unreadable:
                     try:
                         write_sidecar_for_item(item, existing_dir, prefer_item_url=by_slug)
                         activity.record(
@@ -840,13 +896,19 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
         if not media_dir:
             return []
         linked: set[int] = set()
+        # A skip here INFLATES the unmatched set (the album's item_id is missing
+        # from `linked`), so its purchase looks unlinked to mis-tag detection and
+        # relink — the opposite direction to the index passes, same root cause.
+        skipped = _SkippedSidecars("unmatched-purchase scan")
         for f in Path(media_dir).rglob(".harmonist.json"):
             try:
                 sc = sidecar_mod.read(f.parent)
-            except Exception:
+            except (OSError, sidecar_mod.InvalidSidecarError):
+                skipped.skip(f)
                 continue
             if sc and sc.bandcamp and sc.bandcamp.item_id is not None:
                 linked.add(int(sc.bandcamp.item_id))
+        skipped.done()
         out: list[tuple[int, str, str]] = []
         for item in self.bandcamp.purchases:
             try:

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import uuid
-from contextlib import suppress
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -22,6 +22,8 @@ from .models import (
     Sidecar,
     TrackComparison,
 )
+
+log = logging.getLogger(__name__)
 
 SIDECAR_FILENAME = ".harmonist.json"
 
@@ -61,11 +63,22 @@ def delete_all(music_dir: Path) -> int:
     # One line per sidecar, so the record names exactly which albums lost one;
     # a bare count would say a nuke happened but not what it took.
     removed = 0
+    failed = 0
     for p in music_dir.rglob(SIDECAR_FILENAME):
         try:
             existing = None
-            with suppress(Exception):
+            try:
                 existing = read(p.parent)
+            except (OSError, InvalidSidecarError):
+                # Only costs us the identity FIELDS on the audit line below; the
+                # delete itself still proceeds and is still recorded against the
+                # path. Loud because a `sidecar.delete` row that can't say which
+                # album lost its identity is the one thing that line is for.
+                log.exception(
+                    "could not read %s before deleting it — its audit record will "
+                    "not name the album's identity",
+                    p,
+                )
             p.unlink()
             removed += 1
             audit.record(
@@ -75,9 +88,16 @@ def delete_all(music_dir: Path) -> int:
                 mbid=None if existing is None else existing.mb_release_id,
             )
         except OSError:
+            # A sidecar that survived the nuke. Counted and reported, or "Erased N
+            # sidecar(s)" would over-claim and the user would believe albums were
+            # reset that still carry their identity (#104).
+            failed += 1
+            log.exception("could not delete sidecar %s", p)
             continue
+    if failed:
+        log.error("%d sidecar(s) could not be deleted and are still on disk", failed)
     # No music_dir field: every path in the log is already relative to it (#98).
-    audit.record("sidecar.delete_all", removed=removed)
+    audit.record("sidecar.delete_all", removed=removed, failed=failed)
     library_index.clear()  # the sidecars are gone; the rescan refills the index
     return removed
 
@@ -106,8 +126,20 @@ def write(album_dir: Path, sidecar: Sidecar) -> None:
     """
     try:
         old = read(album_dir)  # for the audit diff — best-effort, never blocks the write
-    except Exception:
+    except (OSError, InvalidSidecarError, UnsupportedSchemaVersionError):
+        # Still doesn't block the write — but it is NOT free, so it can't be
+        # silent. `old` feeds _record_identity_alias, which returns early on None,
+        # and that alias is only knowable right now: _normalise_identity is about
+        # to erase the superseded id from disk. Losing it orphans the album's
+        # pre-tag history and 404s every old link to it, permanently. It also
+        # makes the audit below record a `sidecar.create` for what is really a
+        # modification (#104).
         old = None
+        log.exception(
+            "could not read the existing sidecar at %s before rewriting it — if this "
+            "write changes the album's identity, the link from its old id is lost",
+            album_dir,
+        )
     sidecar = _normalise_identity(sidecar, album_dir)
     assert bool(sidecar.mb_release_id) ^ bool(sidecar.temp_uid), (
         f"sidecar identity invariant violated: mb_release_id="
@@ -141,7 +173,18 @@ def album_id_for(album_dir: Path) -> str | None:
     the web layer (the reconcile runner) need it too."""
     try:
         sc = read(album_dir)
-    except Exception:
+    except (OSError, InvalidSidecarError, UnsupportedSchemaVersionError):
+        # None is also "no sidecar yet", so a caller can't tell these apart —
+        # but every caller uses this to stamp `album_id=` on a log entry, and
+        # neither propagating (a failed read must not abort the tagging run it
+        # is describing) nor guessing an id is better. So: keep the None, make
+        # the reason findable. A None here means the entry won't appear on that
+        # album's history page (#104).
+        log.exception(
+            "could not read the sidecar at %s to identify the album — records "
+            "written for it now won't appear in its history",
+            album_dir,
+        )
         return None
     return None if sc is None else _album_id_of(sc)
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1208,7 +1208,19 @@ def _find_album(request: Request, album_id: str) -> Album:
     # already sidecar'd and after every restart. The alias chain, recorded at each
     # change, does: it maps the superseded id forward to the current one (#33).
     # This is what keeps an old activity-feed deep link working.
-    current_id = activity_store.resolve_alias(album_id)
+    #
+    # A store failure here is NOT a miss: we simply couldn't check, and the album
+    # may well be on disk. Answer 503, never 404 — telling the user their album is
+    # gone because SQLite hiccuped is the failure the error-handling skill opens
+    # with (#104).
+    try:
+        current_id = activity_store.resolve_alias(album_id)
+    except activity_store.StoreUnavailableError as exc:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "can't resolve this link right now — the history store is unavailable. "
+            "The album may still be in your library; try the Library tab.",
+        ) from exc
     if current_id is not None:
         for a in albums:
             if a.id == current_id:
@@ -1414,7 +1426,15 @@ def _read_user_ignores(ignores_file: Path) -> list[dict[str, Any]]:
     for un-ignoring."""
     try:
         text = ignores_file.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []  # nothing declined yet — a genuinely empty answer
     except OSError:
+        # A permission or I/O error is NOT "you have declined nothing". Settings
+        # would show an empty list, so nothing could be restored and the user
+        # would have no way to tell why (#104).
+        log.exception(
+            "could not read ignores %s — declined purchases can't be listed", ignores_file
+        )
         return []
     user, _ = _ignores_split(text)
     out: list[dict[str, Any]] = []
@@ -1431,9 +1451,13 @@ def _remove_user_ignore(ignores_file: Path, item_id: int) -> bool:
     """Drop one id from the USER region so the next sync considers it again.
     Returns True if a line was removed. Never touches the auto-managed region —
     removing an already-downloaded id there would re-download the album."""
+    # False means "there was no such line", which the caller treats as a no-op and
+    # reports nothing. A read/write failure is a different thing entirely — the
+    # user pressed Restore and nothing happened — so it has to be loud (#104).
     try:
         text = ignores_file.read_text(encoding="utf-8")
     except OSError:
+        log.exception("could not read ignores %s — Restore did nothing", ignores_file)
         return False
     user, auto = _ignores_split(text)
     kept = [ln for ln in user if (ln.partition("#")[0].strip() or None) != str(item_id)]
@@ -1441,8 +1465,8 @@ def _remove_user_ignore(ignores_file: Path, item_id: int) -> bool:
         return False
     try:
         ignores_file.write_text("".join(kept + auto), encoding="utf-8")
-    except OSError as e:
-        log.warning("could not rewrite ignores %s: %s", ignores_file, e)
+    except OSError:
+        log.exception("could not rewrite ignores %s — Restore did nothing", ignores_file)
         return False
     return True
 
@@ -1954,16 +1978,32 @@ def _register_routes(app: FastAPI) -> None:
         """
         limit = max(1, min(limit, 200))  # clamp; defensive
         offset = max(0, offset)
-        # Ask for one MORE than needed: its presence answers "is there another
-        # page?" without a COUNT over a table that grows without bound and is
-        # re-read every couple of seconds.
-        page = activity.recent(limit + 1, offset=offset, include_audit=audit)
-        has_more = len(page) > limit
-        events = page[:limit]
-        # The audit records behind each entry, fetched for the whole page in ONE
-        # grouped query (#84) — per-entry lookups would be an N+1 across the page,
-        # re-polled every couple of seconds.
-        audit_detail = activity_store.audit_by_action([e.action_id for e in events if e.action_id])
+        # An unreadable store must render as "can't read the feed", never as an
+        # empty feed — the feed is re-polled every couple of seconds, so a silent
+        # empty page is exactly how a broken store would go unnoticed for weeks
+        # (#104). Caught rather than raised so the poll doesn't 500 on a loop.
+        events: list[activity.Event] = []
+        audit_detail: dict[str, list[activity_store.StoredEvent]] = {}
+        has_more = False
+        store_unavailable = False
+        try:
+            # Ask for one MORE than needed: its presence answers "is there another
+            # page?" without a COUNT over a table that grows without bound and is
+            # re-read every couple of seconds.
+            page = activity.recent(limit + 1, offset=offset, include_audit=audit)
+            has_more = len(page) > limit
+            events = page[:limit]
+            # The audit records behind each entry, fetched for the whole page in ONE
+            # grouped query (#84) — per-entry lookups would be an N+1 across the page,
+            # re-polled every couple of seconds.
+            audit_detail = activity_store.audit_by_action(
+                [e.action_id for e in events if e.action_id]
+            )
+        except activity_store.StoreUnavailableError:
+            # Already logged with a traceback in the store. Drop any partial page:
+            # half a feed presented as the whole feed is the same lie in miniature.
+            events, audit_detail, has_more = [], {}, False
+            store_unavailable = True
         ctx = _ctx(
             request,
             events=events,
@@ -1973,6 +2013,7 @@ def _register_routes(app: FastAPI) -> None:
             limit=limit,
             include_audit=audit,
             is_first_page=(offset == 0),
+            store_unavailable=store_unavailable,
         )
         return _templates(request).TemplateResponse(request, "partials/activity.html", ctx)
 
@@ -2257,13 +2298,24 @@ def _register_routes(app: FastAPI) -> None:
         lands here rather than 404-ing.
         """
         album = _find_album(request, album_id)
-        ctx = _ctx(
-            request,
-            album=album,
+        # The tracklist and actions don't depend on the store, so a broken store
+        # must not take the whole page down — but the history section has to say
+        # it couldn't read rather than fall through to "Nothing recorded for this
+        # album yet", which is the confident lie #104 is about.
+        history: list[activity_store.StoredEvent] = []
+        history_unavailable = False
+        try:
             # Keyed on the album's CURRENT id — album_history unions backwards
             # over the chain from there, so passing the (possibly stale) URL id
             # would find only the tail of its own history.
-            history=activity_store.album_history(album.id),
+            history = activity_store.album_history(album.id)
+        except activity_store.StoreUnavailableError:
+            history_unavailable = True  # already logged with a traceback in the store
+        ctx = _ctx(
+            request,
+            album=album,
+            history=history,
+            history_unavailable=history_unavailable,
         )
         return _templates(request).TemplateResponse(request, "album.html", ctx)
 

--- a/templates/album.html
+++ b/templates/album.html
@@ -26,11 +26,23 @@
     <section class="border border-line rounded-lg p-4 space-y-3">
         <h2 class="text-sm font-bold text-ink uppercase tracking-widest">
             History
+            {% if not history_unavailable %}
             <span class="text-muted font-normal normal-case tracking-normal ml-1">
                 · {{ history|length }}</span>
+            {% endif %}
         </h2>
 
-        {% if not history %}
+        {# "Couldn't read" and "nothing to read" are different claims, and the
+           page must not make the second one when it means the first — that's the
+           lie #104 is about. No count either: 0 would be just as wrong. #}
+        {% if history_unavailable %}
+        <p class="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+            <span class="font-bold">History unavailable.</span>
+            Harmonist couldn't read its history store, so this album's records
+            can't be shown — this does <em>not</em> mean nothing was recorded.
+            The error is in the application log.
+        </p>
+        {% elif not history %}
         <p class="text-2xs text-muted italic">
             Nothing recorded for this album yet. Entries appear here as Harmonist
             tags, links, or otherwise changes it.

--- a/templates/partials/activity.html
+++ b/templates/partials/activity.html
@@ -9,7 +9,19 @@
    poll once you've paged or while a request is in flight, because a poll
    replaces the whole container and would otherwise throw away the pages you
    loaded. #}
-{% if is_first_page and not events %}
+{# "Couldn't read the feed" must never render as "no activity". This panel is
+   re-polled every 2s, so a silently empty feed is precisely how a broken store
+   would go unnoticed for weeks on an unattended NAS (#104). #}
+{% if store_unavailable %}
+<div class="p-6 text-center border border-amber-200 bg-amber-50 rounded-lg">
+    <p class="text-amber-700">
+        <span class="font-bold">Activity unavailable.</span>
+        Harmonist couldn't read its history store, so this feed can't be shown —
+        this does <em>not</em> mean nothing has happened. The error is in the
+        application log.
+    </p>
+</div>
+{% elif is_first_page and not events %}
 <div class="p-10 text-center border border-line rounded-lg">
     <p class="text-muted italic">
         {% if include_audit %}No activity or audit records yet.

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -541,3 +541,70 @@ def test_nested_action_scopes_keep_the_outermost_id(tmp_path):
             assert inner == outer
         assert activity_store.current_action() == outer
     assert activity_store.current_action() is None
+
+
+# ---------- A broken store must not look like an empty one (#104) ----------
+
+
+@pytest.fixture
+def broken_store(monkeypatch):
+    """Make every store operation fail the way a locked/corrupt DB would.
+
+    Patching `_ensure` is enough: every read and write calls it from inside the
+    same `try`, so the error surfaces exactly where a real sqlite failure would.
+    """
+
+    def boom():
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(activity_store, "_ensure", boom)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda: activity_store.recent(), id="recent"),
+        pytest.param(lambda: activity_store.audit_by_action(["a"]), id="audit_by_action"),
+        pytest.param(lambda: activity_store.resolve_alias("some-id"), id="resolve_alias"),
+        pytest.param(lambda: activity_store.album_history("some-id"), id="album_history"),
+    ],
+)
+def test_reads_raise_rather_than_returning_an_empty_result(broken_store, call):
+    """Every read used to swallow sqlite3.Error and return []/{}/None, which the
+    caller cannot tell from a genuine empty answer — the album page then claims
+    "Nothing recorded for this album yet" over a broken database (#104)."""
+    with pytest.raises(activity_store.StoreUnavailableError):
+        call()
+
+
+def test_resolve_alias_failure_is_not_reported_as_never_superseded(broken_store):
+    """The sharpest case: None from resolve_alias means "this id was never
+    superseded", which sends its only caller on to a 404. A DB error must not be
+    able to say that about an album sitting on disk."""
+    with pytest.raises(activity_store.StoreUnavailableError):
+        activity_store.resolve_alias("old-id")
+
+
+def test_writes_stay_best_effort_but_log_at_error(broken_store, caplog):
+    """Recording must never abort the operation being recorded — but a dropped
+    audit row makes every remaining row untrustworthy, so it can't be quiet.
+    These were log.debug, i.e. invisible at default level AND below the feed
+    mirror's WARNING threshold (#104, skill §5)."""
+    caplog.set_level("DEBUG")
+    activity_store.append(message="x", level=Level.INFO, source=Source.AUDIT)
+    activity_store.record_alias("old", "new")
+    activity_store.clear()  # teardown path — swallows too, but must be loud
+
+    errors = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(errors) == 3, [r.message for r in caplog.records]
+    assert all(r.exc_info for r in errors), "no traceback — the thing you want in 3 weeks"
+
+
+def test_append_failure_does_not_re_enter_the_feed_mirror(broken_store, caplog):
+    """The `_activity` flag on the failure log is load-bearing: without it the
+    feed's WARNING+ mirror would call record() again, which fails again..."""
+    caplog.set_level("DEBUG")
+    activity_store.append(message="x", level=Level.INFO, source=Source.ACTIVITY)
+    failures = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert len(failures) == 1
+    assert getattr(failures[0], "_activity", False) is True

--- a/test/test_bandcamp_hook.py
+++ b/test/test_bandcamp_hook.py
@@ -1462,3 +1462,55 @@ def test_sync_item_does_not_short_circuit_when_no_match(monkeypatch, tmp_path):
     assert result is True
     assert parent_called == [True]
     assert sc.has_sidecar(new_dir)
+
+
+# ---------- An unreadable sidecar must not look like an unlinked album (#104) ----------
+
+
+def test_sync_item_leaves_an_unreadable_sidecar_alone(monkeypatch, tmp_path, caplog):
+    """A sidecar we can't read used to read as `existing = None`, hence "not
+    linked yet" — sending the sync down the write path, rewriting a sidecar it
+    couldn't even read, over an album that may already be linked. That bumps the
+    mtime (forcing a full tag re-read next scan) and duplicates the feed entry,
+    which is exactly what the guard above it exists to prevent (#104)."""
+    album_dir = tmp_path / "Artist" / "Album"
+    album_dir.mkdir(parents=True)
+    url = "https://x.bandcamp.com/album/y"
+    sc.write(album_dir, Sidecar(store_url=url, bandcamp=BandcampInfo(item_id=1)))
+    before = sc.sidecar_path(album_dir).read_text()
+
+    s = _bare_syncer()
+    s.local_media.media_dir = str(tmp_path)
+    s.local_media.get_path_for_purchase = MagicMock(return_value=album_dir)
+    monkeypatch.setattr(library_index, "dir_for_url", lambda _u: album_dir)
+
+    def unreadable(_dir):
+        raise OSError("I/O error")
+
+    monkeypatch.setattr("harmonist.bandcamp_hook.sidecar_mod.read", unreadable)
+
+    item = _StubItem(item_id=1, url_hints={"subdomain": "x", "slug": "y"})
+    with caplog.at_level("ERROR"):
+        assert s.sync_item(item) is False  # still "already on disk", no download
+
+    assert sc.sidecar_path(album_dir).read_text() == before, "rewrote what it couldn't read"
+    assert any("leaving it untouched" in r.message for r in caplog.records)
+
+
+def test_backfill_index_logs_the_sidecars_it_skips(tmp_path, caplog):
+    """A skipped sidecar drops its album out of the index, so its purchase
+    matches nothing and becomes a potential download — re-downloading audio the
+    user already owns. Silently, before #104."""
+    good = tmp_path / "Artist" / "Good"
+    good.mkdir(parents=True)
+    sc.write(good, Sidecar(store_url="https://x.bandcamp.com/album/good"))
+    bad = tmp_path / "Artist" / "Bad"
+    bad.mkdir(parents=True)
+    sc.sidecar_path(bad).write_text("{ this is not json")
+
+    with caplog.at_level("ERROR"):
+        by_slug, _slugless, _linked = survey_album_links(tmp_path)
+
+    assert "album/good" in by_slug  # the readable one still indexed
+    assert any("unreadable sidecar" in r.message for r in caplog.records)
+    assert any("offered as new downloads" in r.message for r in caplog.records)

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -11,6 +11,7 @@ import re
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -3491,6 +3492,33 @@ def test_erase_sidecars_is_audited_per_album(client, cfg):
     assert any(m.startswith("sidecar.delete_all") and "removed=2" in m for m in rows)
 
 
+def test_erase_sidecars_counts_and_reports_ones_it_could_not_delete(cfg, caplog):
+    """The "Erased N sidecar(s)" count must not over-report. A sidecar that fails to
+    unlink was skipped silently and left out of the count, so the user believed
+    the nuke was complete while that album kept its identity (#104)."""
+    from harmonist import sidecar as scmod
+
+    a = _make_album(cfg, "Deletable")
+    b = _make_album(cfg, "Stubborn")
+    scmod.write(a, Sidecar(mb_release_id="rel-a"))
+    scmod.write(b, Sidecar(mb_release_id="rel-b"))
+
+    stubborn = scmod.sidecar_path(b)
+    real_unlink = Path.unlink
+
+    def selective_unlink(self, *args, **kwargs):
+        if self == stubborn:
+            raise OSError("permission denied")
+        return real_unlink(self, *args, **kwargs)
+
+    with mock.patch.object(Path, "unlink", selective_unlink), caplog.at_level("ERROR"):
+        removed = scmod.delete_all(cfg.paths.music_dir)
+
+    assert removed == 1, "the undeletable sidecar must not be counted as erased"
+    assert scmod.sidecar_path(b).exists()
+    assert any("could not be deleted" in r.message for r in caplog.records)
+
+
 def test_erase_sidecars_removes_only_sidecars(client, cfg):
     from harmonist import sidecar as scmod
 
@@ -4394,3 +4422,72 @@ def test_reconcile_gives_each_album_its_own_action(cfg):
     ids = {e.action_id for e in activity.recent(20) if "New →" in e.message}
     assert len(ids) == 2, "the two albums should not share one action id"
     assert None not in ids
+
+
+# ---------- A broken history store must not render as an empty one (#104) ----------
+
+
+@pytest.fixture
+def broken_store(monkeypatch):
+    """Every activity_store operation fails, as a locked or corrupt DB would."""
+    import sqlite3
+
+    from harmonist import activity_store
+
+    def boom():
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(activity_store, "_ensure", boom)
+
+
+def test_activity_feed_says_unavailable_rather_than_empty(client, broken_store):
+    """The feed is re-polled every 2s, so rendering a store failure as "No
+    activity yet" is how a broken store goes unnoticed for weeks on a NAS."""
+    r = client.get("/activity")
+    assert r.status_code == 200  # a polling panel must not 500 on a loop
+    assert "Activity unavailable" in r.text
+    assert "No activity yet" not in r.text
+
+
+def test_album_page_says_history_unavailable_rather_than_nothing_recorded(client, cfg):
+    """The sharpest form of the lie: the page would state as fact that Harmonist
+    has never touched the album, at the moment the user asks what it did."""
+    d = _make_album(cfg, "BrokenHistory")
+    sc.write(d, sc.Sidecar(store_url="https://x.bandcamp.com/album/y"))
+    album_id = sc.album_id_for(d)
+    assert album_id
+
+    # Control first: with a working store the page renders real history (the
+    # sidecar write above audited itself) and no unavailable notice.
+    ok = client.get(f"/album/{album_id}")
+    assert ok.status_code == 200
+    assert "sidecar.create" in ok.text
+    assert "History unavailable" not in ok.text
+
+    from harmonist import activity_store
+
+    def boom(*a, **k):
+        raise activity_store.StoreUnavailableError("nope")
+
+    with mock.patch.object(activity_store, "album_history", boom):
+        r = client.get(f"/album/{album_id}")
+    assert r.status_code == 200  # tracklist and actions don't need the store
+    assert "History unavailable" in r.text
+    assert "Nothing recorded for this album yet" not in r.text
+    assert "sidecar.create" not in r.text  # no half-history presented as whole
+
+
+def test_unresolvable_link_is_503_not_404_when_the_store_is_broken(client, cfg, broken_store):
+    """resolve_alias returning None means "never superseded", which sends
+    _find_album to a 404. One DB hiccup must not tell the user an album that is
+    sitting on disk does not exist."""
+    r = client.get("/album/some-id-that-is-not-in-the-snapshot")
+    assert r.status_code == 503
+    assert "history store is unavailable" in r.text
+
+
+def test_a_genuine_miss_is_still_404(client, cfg):
+    """Control for the test above — a working store must still 404 an id that
+    really isn't there, or the 503 would just be masking every miss."""
+    r = client.get("/album/some-id-that-is-not-in-the-snapshot")
+    assert r.status_code == 404


### PR DESCRIPTION
Steps 1-5 of the #104 audit. Step 6 is split out as #112 — it needs a design decision on how the scanner represents an unreadable track, which the audit itself says belongs last.

The theme throughout: **a failure that returns an empty list is indistinguishable from a genuine empty result**, and on an unattended NAS nobody is watching a log to tell the difference.

## activity_store

Every read swallowed `sqlite3.Error` and returned `[]` / `{}` / `None`. They now raise a typed `StoreUnavailableError`, and the routes render **"Activity unavailable"** / **"History unavailable"** instead of "No activity yet" / "Nothing recorded for this album yet".

Three properties, which are the reusable part:

- the failure has its **own type**, so a caller can't confuse it with a result;
- the route **degrades the section, not the page** — the album page still renders its tracklist and actions, and the polled feed still answers 200 so it can't 500 in a loop;
- a partial answer is **discarded**, not shown. Half a feed presented as the whole feed is the same lie in miniature.

`resolve_alias` was the sharpest case: `None` means *"never superseded"*, which sends its only caller on to a 404. A locked database could therefore tell the user an album sitting on disk did not exist. `_find_album` now answers **503** and names the way out.

The two writes stay best-effort — recording must not abort what it records — but move from `log.debug`, which is invisible at default level *and* below the feed mirror's WARNING threshold, to `log.exception`. `append()` is the single sink for every audit row; a dropped alias is unrecoverable, being the only moment the old→new id pair is knowable.

## bandcamp_hook

Three index passes counted and reported the sidecars they skipped instead of `except Exception: continue`. A skipped sidecar drops its album out of the index, so its purchase matches nothing and is offered as a **new download** — re-downloading audio the user already owns is the exact harm adoption exists to prevent.

The fourth site is a behaviour fix rather than logging: an unreadable sidecar read as "not linked yet" and sent the sync down the **write** path, rewriting a sidecar it couldn't read, over an album that may already be linked.

## Category A

`delete_all` no longer under-reports "Erased N sidecar(s)"; `_read_user_ignores` distinguishes a missing file from an I/O error; Restore says something when it silently did nothing.

## Testing

14 new tests, **all 13 behavioural ones verified to fail against the unfixed `src/`** (the 14th is a control asserting a genuine miss still 404s, so the new 503 isn't just masking every miss). Store failures are simulated by patching `_ensure`, which every read and write calls from inside the same `try` — so the error surfaces exactly where a real sqlite failure would.

Note the existing 717 tests passed unchanged throughout, which is the point: none of these paths had coverage.

**Not visually verified in demo mode** — `activity_store.init()` deliberately degrades a bad database file to an in-memory store (the correct §6 behaviour), so a persistently-broken store can't be produced by corrupting the file. The broken state is a runtime failure — a locked DB, a volume unmounted mid-run — which is what the tests simulate.

The `error-handling` skill is updated too: it cited `resolve_alias` as a live bad example, which this fixes.

Fixes #104