### PR TITLE
Record albums when the scanner first meets them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Albums are recorded when Harmonist first sees them, so an album's history
+  starts at when it turned up rather than the first time a sidecar was written —
+  the only answer to "where did this come from?" for an album you already owned
+  (#107).
+
+### Fixed
+
+- An album with no sidecar keeps the same id across restarts, so what Harmonist
+  records about it stays attached to it (#114).
+- Demo downloads are recorded in the audit log like real ones, so a demo album's
+  history no longer begins mid-story (#107).
+
 ## [1.4.0] - 2026-08-04
 
 ### Added

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -391,6 +391,61 @@ def recent(
     ]
 
 
+#: The audit type written when the scanner first meets an album (#107). Also
+#: serves as the "have we met?" marker — see `already_discovered`.
+DISCOVERY_EVENT = "album.discovered"
+
+
+def already_discovered(album_ids: list[str]) -> set[str]:
+    """Which of `album_ids` already have a discovery record.
+
+    The record IS the ledger, so there is no separate table to keep in step: an
+    album has been met iff a row says so. That only works because a sidecar-less
+    album's id is now derived from its path and so is stable across restarts
+    (#114) — with the old per-process UUIDs this question was unanswerable.
+
+    One indexed query per scan regardless of library size; the scan runs
+    constantly, so a per-album lookup would be the expensive part.
+    """
+    if not album_ids:
+        return set()
+    placeholders = ",".join("?" * len(album_ids))
+    q = (
+        f"SELECT DISTINCT album_id FROM events WHERE album_id IN ({placeholders}) "
+        "AND source = ? AND message LIKE ?"
+    )
+    try:
+        conn = _ensure()
+        with _LOCK:
+            rows = conn.execute(
+                q, [*album_ids, Source.AUDIT.value, f"{DISCOVERY_EVENT} %"]
+            ).fetchall()
+    except sqlite3.Error as exc:
+        log.exception("activity_store already_discovered() failed", extra=_QUIET_MIRROR)
+        raise StoreUnavailableError("could not read the discovery records") from exc
+    return {r[0] for r in rows}
+
+
+def any_discovery_recorded() -> bool:
+    """Whether ANY album has ever been recorded as discovered.
+
+    False means this is the first scan since the feature arrived, so the albums
+    it finds predate the ledger — Harmonist doesn't know when they appeared and
+    must not claim they turned up just now.
+    """
+    try:
+        conn = _ensure()
+        with _LOCK:
+            row = conn.execute(
+                "SELECT 1 FROM events WHERE source = ? AND message LIKE ? LIMIT 1",
+                (Source.AUDIT.value, f"{DISCOVERY_EVENT} %"),
+            ).fetchone()
+    except sqlite3.Error as exc:
+        log.exception("activity_store any_discovery_recorded() failed", extra=_QUIET_MIRROR)
+        raise StoreUnavailableError("could not read the discovery records") from exc
+    return row is not None
+
+
 def audit_by_action(action_ids: list[str]) -> dict[str, list[StoredEvent]]:
     """Audit rows for each of `action_ids`, grouped — the "what changed" detail
     under an activity entry (#84).

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -32,7 +32,7 @@ from typing import Any
 
 from mutagen.mp4 import MP4
 
-from . import activity, activity_store, pending_downloads
+from . import activity, activity_store, audit, id_registry, pending_downloads
 from . import sidecar as sidecar_mod
 from .formats.m4a import (
     ATOM_ALBUM,
@@ -651,11 +651,25 @@ def _download(
         with contextlib.suppress(Exception):
             progress_callback(f"{spec['artist']} / {spec['album']}")
     time.sleep(STEP_DELAY_SECONDS)
+    album_dir = music_dir / _safe(spec["artist"]) / _safe(spec["album"])
     # Scoped so the sidecar audit _materialise writes attaches to this entry as
     # its "what changed" (#97), and labelled so the entry links to the album.
     with activity_store.action():
+        # Mirrors the real download path (bandcamp_hook.sync_item): mint the id
+        # BEFORE the sidecar exists, so the `download` row can be attached to the
+        # album, and sidecar.write's identity normalisation then adopts the same
+        # registry UUID as `temp_uid`. Without this row the demo album's history
+        # starts at `sidecar.create` and looks like it appeared from nowhere —
+        # demo is where people form their first impression of the feature (#107).
+        album_id = id_registry.get_or_mint(album_dir)
+        audit.record(
+            "download",
+            album_id=album_id,
+            item_id=_purchase_item_id(spec),
+            fmt="alac",
+            path=album_dir,
+        )
         _materialise(music_dir, spec)
-        album_dir = music_dir / _safe(spec["artist"]) / _safe(spec["album"])
         activity.info(
             "Downloaded from Bandcamp",
             album_id=sidecar_mod.album_id_for(album_dir),

--- a/src/harmonist/id_registry.py
+++ b/src/harmonist/id_registry.py
@@ -1,62 +1,89 @@
-"""Per-process path → UUID registry for albums without a sidecar.
+"""Stable ids for albums that have no sidecar to read one from.
 
 The sidecar JSON is the long-term source of truth for an album's id (via
-`mb_release_id` when matched, `temp_uid` when not). But NEW albums — dirs
-the scanner has seen but for which no sidecar has been written yet — have
-no on-disk record to read a UUID from. The inbox UI still needs *some* id
-to wire its Reconcile/Recover/Manual buttons.
+`mb_release_id` when matched, `temp_uid` when not). But albums the scanner has
+seen and for which no sidecar has been written yet have no on-disk record to
+read a UUID from, and the UI still needs *some* id to wire its
+Reconcile/Recover/Manual buttons to.
 
-This module owns that gap: per-process, keyed by absolute path, mints a
-UUID once and returns the same UUID on subsequent lookups. When the first
-sidecar gets written for a path, `sidecar.write()` consults the registry
-so the persisted `temp_uid` matches what the UI has already shown — the
-URL stays the same across the NEW → sidecar'd transition.
+This module owns that gap. The id is a **hash of the album's path relative to
+the library root** — deterministic, so the same directory always yields the same
+id, on this run and every future one.
 
-In-memory only. Server restart clears the registry; NEW albums get fresh
-UUIDs on next scan, which is fine because nobody bookmarks inbox URLs. A
-directory rename of a NEW album (before any sidecar exists) drops the old
-mapping and mints a new UUID for the new path — acceptable since NEW is a
-transient state, usually resolved by auto-reconcile within seconds.
+It used to be a random UUID held in a per-process dict, which was fine while the
+id only had to survive one session ("nobody bookmarks inbox URLs"). It stopped
+being fine once history became per-album: everything recorded against a
+sidecar-less album was orphaned by the next restart, because the album came back
+with a different id. That is not an edge case — `reconcile` writes no sidecar at
+all for an album with no MBID and no recoverable store URL, so such an album
+stays sidecar-less indefinitely (#114).
+
+Two consequences worth knowing:
+
+* **Relative to the library root**, not absolute, so re-pointing a bind-mount at
+  the same library doesn't re-identify every album in it. `set_library_root()`
+  is called once at startup, mirroring `audit.set_library_root()`.
+* **A rename re-identifies** a sidecar-less album, since the path is the input.
+  Unavoidable without a durable marker on disk, and mild: an album with a
+  sidecar carries its id inside the file, which moves with the directory.
+
+Hashed rather than used raw because the id goes in URL path segments, and most
+routes carry a further segment after it (`/library/{album_id}/detail`) — a value
+containing slashes can't sit there, and `%2F` is routinely mangled by reverse
+proxies.
 """
 
 from __future__ import annotations
 
-import uuid
+import hashlib
 from pathlib import Path
 
-_uids: dict[Path, str] = {}
+# Set once at startup. Until then ids derive from the absolute path, which keeps
+# unit tests and non-web callers working — they just aren't portable across a
+# different mount point, which no test cares about.
+_library_root: Path | None = None
+
+# Long enough that a collision across a library is not a practical concern,
+# short enough to stay readable in a URL.
+_ID_LENGTH = 32
+
+
+def set_library_root(root: Path | None) -> None:
+    """Point id derivation at the configured music dir (once, at startup)."""
+    global _library_root
+    _library_root = root
+
+
+def _key(path: Path) -> str:
+    """The string an album's id is derived from: its path relative to the library
+    root, or the absolute path when it lies outside (or no root is set yet)."""
+    if _library_root is not None:
+        try:
+            return str(path.relative_to(_library_root))
+        except ValueError:
+            pass
+    return str(path)
 
 
 def get_or_mint(path: Path) -> str:
-    """Return the UUID for this path, minting a new one if none is known."""
-    if path not in _uids:
-        _uids[path] = uuid.uuid4().hex
-    return _uids[path]
+    """This album directory's id. Deterministic — the name is kept for the
+    call sites, but nothing is minted or stored any more."""
+    return hashlib.sha256(_key(path).encode("utf-8")).hexdigest()[:_ID_LENGTH]
 
 
 def peek(path: Path) -> str | None:
-    """Return the UUID for this path if one has been minted, else None.
+    """Same as `get_or_mint`; retained because `sidecar.write()` reads it to
+    persist an album's existing id as its `temp_uid`, so the id doesn't change
+    when the first sidecar appears."""
+    return get_or_mint(path)
 
-    Used by sidecar.write() to preserve the registry UUID when persisting
-    a sidecar for the first time, without minting a fresh one.
+
+def path_for(uid: str, candidates: list[Path]) -> Path | None:
+    """Reverse lookup: which of `candidates` has this id.
+
+    A hash can't be inverted, so the caller supplies the paths to check — in
+    practice the current scan's albums, which is the same linear pass the old
+    dict-based lookup did. Used by `_find_album` when a rendered URL holds the
+    pre-sidecar id of an album whose canonical id has since changed.
     """
-    return _uids.get(path)
-
-
-def path_for(uid: str) -> Path | None:
-    """Reverse lookup: given a UUID, return the path it was minted for.
-
-    Used by _find_album as a fallback when an inbox-rendered URL holds a
-    registry UUID for an album whose canonical id has since changed
-    (e.g. auto-reconcile wrote a sidecar between page render and the
-    user's click).
-    """
-    for path, registered in _uids.items():
-        if registered == uid:
-            return path
-    return None
-
-
-def clear() -> None:
-    """Drop all registrations. Test helper."""
-    _uids.clear()
+    return next((p for p in candidates if get_or_mint(p) == uid), None)

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -31,6 +31,7 @@ from harmonist import (
     audit,
     cover_art,
     formats,
+    id_registry,
     live_counts,
     mb_lookup,
     mb_search,
@@ -218,6 +219,10 @@ def create_app(
     # Audit paths are recorded relative to the library (#98). Demo mode already
     # has its sandbox substituted into cfg, so this follows it automatically.
     audit.set_library_root(cfg.paths.music_dir)
+    # A sidecar-less album's id derives from its path relative to the same root,
+    # so re-pointing a bind-mount at the same library doesn't re-identify all of
+    # it (#114).
+    id_registry.set_library_root(cfg.paths.music_dir)
     activity.install_log_handler()
 
     sync_runner = SyncRunner(runner_fn=lambda: None)  # placeholder, replaced below
@@ -1187,25 +1192,23 @@ def _find_album(request: Request, album_id: str) -> Album:
     URLs to sidecar'd albums are stable across directory renames (the
     UUID lives in the sidecar JSON which moves with the directory).
     """
-    from harmonist import id_registry
-
     albums = _albums(request)
     for a in albums:
         if a.id == album_id:
             return a
-    # Race fallback: the rendered page may hold a registry UUID for an
-    # album whose canonical id has since changed (auto-reconcile beat the
-    # user). The registry remembers the original path → UUID, so look up
-    # by path.
-    legacy_path = id_registry.path_for(album_id)
+    # Race fallback: the rendered page may hold the pre-sidecar id of an album
+    # whose canonical id has since changed (auto-reconcile beat the user). That
+    # id derives from the album's path, so re-derive it for each album on disk
+    # and see which one matches.
+    legacy_path = id_registry.path_for(album_id, [a.path for a in albums])
     if legacy_path is not None:
         for a in albums:
             if a.path == legacy_path:
                 return a
     # Durable fallback: the album's identity has since MOVED (tagging replaced its
     # temp_uid with an MBID, a re-match rewrote the MBID). The registry can't help
-    # — it's in-memory and only knows ids it minted, so it's empty for anything
-    # already sidecar'd and after every restart. The alias chain, recorded at each
+    # — it only derives the pre-sidecar id, so it can't answer for anything whose
+    # identity has moved on since. The alias chain, recorded at each
     # change, does: it maps the superseded id forward to the current one (#33).
     # This is what keeps an old activity-feed deep link working.
     #

--- a/src/harmonist/web/scan_runner.py
+++ b/src/harmonist/web/scan_runner.py
@@ -29,7 +29,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
-from harmonist import library_index, live_counts, scanner
+from harmonist import activity, activity_store, audit, library_index, live_counts, scanner
 from harmonist.models import Album
 
 log = logging.getLogger(__name__)
@@ -275,6 +275,7 @@ class ScanRunner:
 
         scanner.prune_cache(self._cache, {a.path for a in results})
         self._albums = results
+        self._announce_discoveries(results)
         # Reset the authoritative live counts from this fresh snapshot — the
         # self-healing baseline that transitions (live_counts.move) adjust between
         # scans. This snapshot IS what the UI reads, so the counts now match it.
@@ -301,3 +302,56 @@ class ScanRunner:
                 self._on_first_complete()
             except Exception:
                 log.exception("on-first-scan-complete callback failed")
+
+    def _announce_discoveries(self, albums: list[Album]) -> None:
+        """Record albums the scanner has never met before (#107).
+
+        ONE activity entry per scan, with an audit row per album inside its action
+        scope. That gives both readings from one write: the feed says "a scan
+        found 12 albums", and each row's `album_id` puts it on that album's own
+        history page — answering "where did this album even come from?", which for
+        an ADOPTED album nothing else could.
+
+        One entry per scan rather than per album is also what keeps the volume
+        honest: dropping a large collection in adds a line to the feed, not
+        thousands.
+
+        The audit rows ARE the ledger — an album has been met iff a row says so —
+        which is only possible because a sidecar-less album's id now derives from
+        its path (#114) and so survives a restart.
+
+        Bookkeeping about a scan, so it must never fail one — hence the broad
+        catch. Loud, though: silence here would mean albums quietly never getting
+        the record, which is the bug this fixes.
+        """
+        try:
+            # First scan since this feature arrived: whatever it finds was already
+            # in the library, and Harmonist has no idea when it arrived. Recorded
+            # (so later scans have their baseline) but announced as what it is —
+            # claiming the user's existing collection turned up just now would be
+            # a lie about every album they already had.
+            adopting = not activity_store.any_discovery_recorded()
+            known = activity_store.already_discovered([a.id for a in albums])
+            fresh = [a for a in albums if a.id not in known]
+            if not fresh:
+                return
+            with activity_store.action():
+                activity.info(
+                    f"Started tracking {len(fresh)} album{'s' if len(fresh) != 1 else ''} "
+                    "already in your library"
+                    if adopting
+                    else f"Found {len(fresh)} new album{'s' if len(fresh) != 1 else ''}"
+                )
+                for a in fresh:
+                    # `album` (the path) rather than only the id, so the row still
+                    # names which album it was about if that album is later moved
+                    # and re-identified.
+                    audit.record(
+                        activity_store.DISCOVERY_EVENT,
+                        album_id=a.id,
+                        album=a.path,
+                        state=a.state,
+                        tracks=a.track_count,
+                    )
+        except Exception:
+            log.exception("could not record newly-discovered albums")

--- a/test/test_bandcamp_hook.py
+++ b/test/test_bandcamp_hook.py
@@ -108,14 +108,13 @@ def test_url_returns_none_with_garbage_hints():
 
 
 def test_download_audit_id_matches_the_albums_sidecar_id(tmp_path):
-    """A download is audited before any sidecar exists, so the album id is minted
-    from the registry. The sidecar written straight after must adopt that SAME id
-    as its temp_uid — otherwise the download rows would be orphaned from the
-    album's later history (#33)."""
+    """A download is audited before any sidecar exists, so the album id comes from
+    id_registry. The sidecar written straight after must adopt that SAME id as its
+    temp_uid — otherwise the download rows would be orphaned from the album's
+    later history (#33)."""
     from harmonist import activity_store, audit, id_registry
     from harmonist.activity_store import Source
 
-    id_registry.clear()
     activity_store.init(tmp_path / "activity.db")
     activity_store.clear()
 

--- a/test/test_demo.py
+++ b/test/test_demo.py
@@ -318,6 +318,32 @@ def test_sync_download_and_link_entries_name_and_link_their_album(music_dir, tmp
     assert any("item_id=None->" in r.message for r in rows)
 
 
+def test_demo_download_is_audited_and_reaches_the_album_history(music_dir, tmp_path):
+    """#107: demo downloads wrote the sidecar directly and never went through the
+    download audit path, so a demo album's history began at `sidecar.create` and
+    looked like it appeared from nowhere. Real installs don't have this gap, but
+    demo is where people form their first impression of the feature."""
+    from harmonist import activity_store
+
+    activity_store.init(tmp_path / "audit.db")
+    demo.install()
+    demo.seed(music_dir)
+    activity_store.clear()
+
+    demo.run_demo_sync(music_dir, link_only=False)
+
+    downloaded = next(a for a in scanner.scan(music_dir) if a.title == "Straight Outta Lowcash")
+    history = [e.message for e in activity_store.album_history(downloaded.id)]
+
+    # Reaches the album's OWN page — which is the point. The row is written
+    # before any sidecar exists, so it only gets here via the id the sidecar
+    # then adopts as its temp_uid.
+    assert any(m.startswith("download ") for m in history), history
+    assert any("item_id=2001" in m for m in history)
+    # …and it is the FIRST thing that happened, not a footnote after the sidecar.
+    assert history[-1].startswith("download "), history
+
+
 def test_withdrawn_album_is_not_surrendered_before_the_first_sync(music_dir):
     """#87: "no matching Bandcamp purchase" is a conclusion the sync REACHES by
     paging the whole collection. Seeding it pre-surrendered showed a fresh demo

--- a/test/test_id_registry.py
+++ b/test/test_id_registry.py
@@ -1,0 +1,90 @@
+"""Tests for path-derived album ids (#114).
+
+The id for an album with no sidecar used to be a random UUID in a per-process
+dict, so it changed on every restart and everything recorded against such an
+album was orphaned. It is now a hash of the album's path relative to the library
+root — stable by construction, with nothing persisted.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from harmonist import id_registry
+
+
+@pytest.fixture(autouse=True)
+def _no_root():
+    """Each test sets its own root; don't leak one into the next."""
+    id_registry.set_library_root(None)
+    yield
+    id_registry.set_library_root(None)
+
+
+def test_the_same_directory_always_gets_the_same_id(tmp_path):
+    id_registry.set_library_root(tmp_path)
+    album = tmp_path / "Artist" / "Album"
+    assert id_registry.get_or_mint(album) == id_registry.get_or_mint(album)
+
+
+def test_the_id_survives_a_restart(tmp_path):
+    """The point of #114. Re-importing the module is as complete a restart as a
+    unit test can stage — it discards any module-level state, which is exactly
+    what the old per-process dict relied on."""
+    id_registry.set_library_root(tmp_path)
+    album = tmp_path / "Artist" / "Album"
+    before = id_registry.get_or_mint(album)
+
+    reloaded = importlib.reload(id_registry)
+    reloaded.set_library_root(tmp_path)
+
+    assert reloaded.get_or_mint(album) == before
+
+
+def test_different_albums_get_different_ids(tmp_path):
+    id_registry.set_library_root(tmp_path)
+    a = id_registry.get_or_mint(tmp_path / "Artist" / "One")
+    b = id_registry.get_or_mint(tmp_path / "Artist" / "Two")
+    assert a != b
+
+
+def test_the_id_is_url_safe(tmp_path):
+    """It goes in a URL path segment, and most routes carry a further segment
+    after it — so it must contain no slashes and need no escaping."""
+    id_registry.set_library_root(tmp_path)
+    weird = tmp_path / "Ártist & Co." / "Album (Deluxe) #2 / Part 1"
+    album_id = id_registry.get_or_mint(weird)
+    assert album_id.isalnum() and album_id.isascii()
+
+
+def test_the_id_is_relative_to_the_library_root(tmp_path):
+    """A re-pointed bind-mount presents the same library at a different absolute
+    path. Deriving from the absolute path would re-identify every album in it."""
+    lib_a, lib_b = tmp_path / "mnt" / "music", tmp_path / "volume1" / "music"
+    id_registry.set_library_root(lib_a)
+    from_a = id_registry.get_or_mint(lib_a / "Artist" / "Album")
+    id_registry.set_library_root(lib_b)
+    from_b = id_registry.get_or_mint(lib_b / "Artist" / "Album")
+    assert from_a == from_b
+
+
+def test_a_path_outside_the_root_still_gets_an_id(tmp_path):
+    """Shouldn't happen, but it must not raise — a stable string is all that's
+    needed, so the absolute path is the honest fallback."""
+    id_registry.set_library_root(tmp_path / "music")
+    outside = Path("/elsewhere/Artist/Album")
+    assert id_registry.get_or_mint(outside) == id_registry.get_or_mint(outside)
+
+
+def test_path_for_finds_the_album_a_stale_url_refers_to(tmp_path):
+    """A hash can't be inverted, so the reverse lookup re-derives over the
+    scanned albums — what _find_album's race fallback needs."""
+    id_registry.set_library_root(tmp_path)
+    wanted = tmp_path / "Artist" / "Wanted"
+    others = [tmp_path / "Artist" / "Other", wanted, tmp_path / "Artist" / "Third"]
+
+    assert id_registry.path_for(id_registry.get_or_mint(wanted), others) == wanted
+    assert id_registry.path_for("not-an-id", others) is None

--- a/test/test_scan_runner.py
+++ b/test/test_scan_runner.py
@@ -189,3 +189,123 @@ def test_scan_runner_rescan_picks_up_new_album(tmp_path):
 
     asyncio.run(go())
     assert {a.path.name for a in runner.albums()} == {"A", "B"}
+
+
+# ---------- Discovery records (#107) ----------
+
+
+def _discovery_rows() -> list:
+    from harmonist import activity_store
+    from harmonist.activity_store import Source
+
+    return [
+        e
+        for e in activity_store.recent(200, source=Source.AUDIT)
+        if e.message.startswith(activity_store.DISCOVERY_EVENT)
+    ]
+
+
+def test_first_scan_adopts_the_existing_library_rather_than_claiming_it_is_new(tmp_path):
+    """Albums present on the first scan after this feature arrived predate the
+    ledger — Harmonist has no idea when they turned up, so announcing them as
+    found-just-now would be a lie about the user's whole existing collection
+    (#107). They're still recorded, so later scans have their baseline."""
+    from harmonist import activity, activity_store, id_registry
+
+    music = tmp_path / "music"
+    _album(music, "A")
+    _album(music, "B")
+    activity_store.init(tmp_path / "activity.db")
+    activity_store.clear()
+    id_registry.set_library_root(music)
+    runner = ScanRunner(music)
+
+    async def go() -> None:
+        runner.attach_loop()
+        await _wait(runner.has_completed)
+        await _wait(lambda: len(_discovery_rows()) == 2)
+
+    asyncio.run(go())
+
+    entries = [e.message for e in activity.recent(20)]
+    assert any("Started tracking 2 albums already in your library" in m for m in entries), entries
+    assert not any(m.startswith("Found ") for m in entries), entries
+
+
+def test_an_album_added_later_is_announced_as_new_and_only_once(tmp_path):
+    from harmonist import activity, activity_store, id_registry
+
+    music = tmp_path / "music"
+    _album(music, "Existing")
+    activity_store.init(tmp_path / "activity.db")
+    activity_store.clear()
+    id_registry.set_library_root(music)
+    runner = ScanRunner(music)
+
+    async def go() -> None:
+        runner.attach_loop()
+        await _wait(lambda: len(_discovery_rows()) == 1)  # the adopt pass
+        _album(music, "Arrived")
+        runner.request_scan()
+        await _wait(lambda: len(_discovery_rows()) == 2)
+        # A third scan with nothing new must add nothing — the scan runs
+        # constantly, so a per-scan repeat would bury the feed.
+        runner.request_scan()
+        await _wait(lambda: runner.status()["seq"] >= 3)
+        await asyncio.sleep(0.05)
+
+    asyncio.run(go())
+
+    assert len(_discovery_rows()) == 2
+    entries = [e.message for e in activity.recent(20)]
+    assert any("Found 1 new album" in m for m in entries), entries
+
+
+def test_a_discovered_album_reaches_its_own_history_page(tmp_path):
+    """The point of the record: for an ADOPTED album — no download, no sidecar —
+    this is the only thing that answers "where did this come from?"."""
+    from harmonist import activity_store, id_registry
+
+    music = tmp_path / "music"
+    _album(music, "Adopted")
+    activity_store.init(tmp_path / "activity.db")
+    activity_store.clear()
+    id_registry.set_library_root(music)
+    runner = ScanRunner(music)
+
+    async def go() -> None:
+        runner.attach_loop()
+        await _wait(lambda: len(_discovery_rows()) == 1)
+
+    asyncio.run(go())
+
+    album = runner.albums()[0]
+    assert not (album.path / ".harmonist.json").exists()  # no sidecar: id is path-derived
+    history = [e.message for e in activity_store.album_history(album.id)]
+    assert any(m.startswith(activity_store.DISCOVERY_EVENT) for m in history), history
+
+
+def test_the_discovery_entry_carries_its_albums_as_what_changed(tmp_path):
+    """One activity entry per scan, audit rows inside its action scope — so the
+    feed says "a scan found N" while each row lands on its own album's page."""
+    from harmonist import activity, activity_store, id_registry
+
+    music = tmp_path / "music"
+    _album(music, "A")
+    _album(music, "B")
+    activity_store.init(tmp_path / "activity.db")
+    activity_store.clear()
+    id_registry.set_library_root(music)
+    runner = ScanRunner(music)
+
+    async def go() -> None:
+        runner.attach_loop()
+        await _wait(lambda: len(_discovery_rows()) == 2)
+
+    asyncio.run(go())
+
+    entry = next(e for e in activity.recent(20) if "Started tracking" in e.message)
+    assert entry.action_id, "discovery entry ran outside an action scope"
+    detail = activity_store.audit_by_action([entry.action_id])[entry.action_id]
+    assert len(detail) == 2  # one line per album, not one entry per album
+    assert all(r.message.startswith(activity_store.DISCOVERY_EVENT) for r in detail)

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2389,7 +2389,7 @@ def test_action_records_an_id_that_still_resolves_after_tagging(client, cfg, mon
     registry fallback can't help. Recording that id produced a permanently dead
     link. `_flash_response` now re-derives the id from disk AFTER the mutation.
     """
-    from harmonist import activity, id_registry
+    from harmonist import activity
 
     # A sidecar'd but untagged album: its id is the sidecar's temp_uid.
     d = _make_album(cfg, "Relinked")
@@ -2402,7 +2402,6 @@ def test_action_records_an_id_that_still_resolves_after_tagging(client, cfg, mon
             ),
         ),
     )
-    id_registry.clear()  # as after a restart: nothing registry-minted
     aid = _id_for(cfg, d)
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
@@ -2453,23 +2452,20 @@ def test_successful_deep_link_keeps_the_url_parameter(client, cfg):
 
 
 def test_deep_link_resolves_through_the_alias_chain_after_a_restart(client, cfg):
-    """#33's payoff, and the case the registry CANNOT cover.
+    """#33's payoff, and the case the path-derived id CANNOT cover.
 
-    An album that already had a sidecar was never registry-minted, and the
-    registry is in-memory anyway — so after a restart it knows nothing. When
-    tagging then moves the album's identity (temp_uid dropped for the MBID), a
-    deep link written under the old id has no way home. The durable alias chain,
-    recorded at the moment of the change, is what rescues it.
+    id_registry only answers for an album with no sidecar. Once tagging moves an
+    album's identity (temp_uid dropped for the MBID), a deep link written under
+    the old id has no way home — the old id is erased from disk and isn't
+    derivable from the path either. The durable alias chain, recorded at the
+    moment of the change, is what rescues it.
     """
-    from harmonist import id_registry
-
     d = _make_album(cfg, "Aliased")
     sc.write(d, Sidecar(store_url="https://x.bandcamp.com/album/aliased"))
     old_id = _id_for(cfg, d)
 
     # Tag it: identity moves to the MBID and temp_uid is erased from disk.
     sc.write(d, Sidecar(store_url="https://x.bandcamp.com/album/aliased", mb_release_id="rel-al"))
-    id_registry.clear()  # as after a restart — the in-memory fallback is empty
     assert sc.read(d).temp_uid is None
     assert _id_for(cfg, d) == "rel-al"
 


### PR DESCRIPTION
Closes both halves of #107, plus #114 which it turned out to need first.

## The problem

An album's history began at whatever first wrote a sidecar — usually reconcile. For an album that was **adopted** rather than downloaded, which is the case the whole coexistence design exists for, nothing said when or how it appeared. The album page couldn't answer the question it exists to answer.

## #114 — path-derived ids (first commit)

The blocker. `id_registry` minted a random UUID per path, in memory, discarded on restart, so a sidecar-less album came back with a different id every start and everything recorded against it was orphaned.

Not an edge case: `reconcile._reconcile_untagged` writes **no sidecar at all** when there's no MBID and no recoverable store URL (`reconcile.py:120`), so such an album stays sidecar-less indefinitely — a fresh id on every restart, forever. Exactly the population where "where did this come from?" is worth answering.

The id is now `sha256` of the album's path relative to the library root. Stable by construction — **nothing persisted, no migration**. Relative, or a moved bind-mount would re-identify the library; hashed rather than raw because the id sits in a URL path segment and 19 routes carry a further segment after it, so slashes can't go there and `%2F` gets mangled by proxies.

**Safe on upgrade.** `_normalise_identity` mints a `temp_uid` only when there is neither an MBID nor an existing one, so albums with either keep their id exactly. Only sidecar-less albums change, and their old ids were per-process and already discarded every restart. `album_aliases` untouched.

Bonus: the id no longer changes at the NEW → sidecar'd transition at all, since `sidecar.write` adopts the registry value as `temp_uid` and that value is already the path-hash. A restart in that window used to lose the link silently.

## #107 — the discovery record (second commit)

One activity entry per scan, an audit row per newly-met album inside its action scope — the shape agreed on the issue. The feed says "found N"; each row's `album_id` puts it on that album's own page.

**No ledger table.** The audit rows *are* the ledger: an album has been met iff a row says so. That only works because the id now survives a restart — with the old UUIDs a table would have been papering over an unanswerable question. (I built the table first and deleted it; deriving is better.)

**The first scan after upgrade** finds a library that predates the record. Those albums are recorded — later scans need the baseline — but announced as *"Started tracking N albums already in your library"*, not "found". Claiming the user's existing collection arrived today would be a lie about every album they own.

Also closes the demo half: demo downloads wrote the sidecar directly and never went through the download audit path, so a demo album's history started at `sidecar.create`.

## Testing

11 new tests, all verified to fail against the unfixed `src/`. The idempotence one matters most — the scan runs constantly, so there's a test that runs a third scan and asserts no new rows.

743 pytest + 10 e2e green. Verified in demo: one feed line for the whole library, ten `album.discovered` rows folded under "what changed", and the record reaching an individual album's history page.

Fixes #107
Fixes #114