### PR TITLE
Only record a discovery for an album Harmonist hasn't touched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
-- Albums are recorded when Harmonist first sees them, so an album's history
-  starts at when it turned up rather than the first time a sidecar was written —
-  the only answer to "where did this come from?" for an album you already owned
-  (#107).
+- Albums Harmonist has never touched are recorded the first time it sees them,
+  so an album you already owned has a start to its history rather than beginning
+  at whatever first wrote a sidecar (#107).
 
 ### Fixed
 

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -426,26 +426,6 @@ def already_discovered(album_ids: list[str]) -> set[str]:
     return {r[0] for r in rows}
 
 
-def any_discovery_recorded() -> bool:
-    """Whether ANY album has ever been recorded as discovered.
-
-    False means this is the first scan since the feature arrived, so the albums
-    it finds predate the ledger — Harmonist doesn't know when they appeared and
-    must not claim they turned up just now.
-    """
-    try:
-        conn = _ensure()
-        with _LOCK:
-            row = conn.execute(
-                "SELECT 1 FROM events WHERE source = ? AND message LIKE ? LIMIT 1",
-                (Source.AUDIT.value, f"{DISCOVERY_EVENT} %"),
-            ).fetchone()
-    except sqlite3.Error as exc:
-        log.exception("activity_store any_discovery_recorded() failed", extra=_QUIET_MIRROR)
-        raise StoreUnavailableError("could not read the discovery records") from exc
-    return row is not None
-
-
 def audit_by_action(action_ids: list[str]) -> dict[str, list[StoredEvent]]:
     """Audit rows for each of `action_ids`, grouped — the "what changed" detail
     under an activity entry (#84).

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -211,8 +211,9 @@ class Album:
 
     `id` is the album's stable URL id. The scanner assigns it from the
     sidecar's `mb_release_id` (preferred) or `temp_uid` (fallback). For
-    NEW albums with no sidecar, the scanner mints a per-process UUID via
-    `id_registry`. No path-derived ids exist anywhere — that's the point.
+    albums with no sidecar it comes from `id_registry`, which derives it
+    from the path relative to the library root — so it survives a restart
+    and records written against such an album stay attached to it (#114).
     """
 
     id: str

--- a/src/harmonist/web/scan_runner.py
+++ b/src/harmonist/web/scan_runner.py
@@ -304,11 +304,11 @@ class ScanRunner:
                 log.exception("on-first-scan-complete callback failed")
 
     def _announce_discoveries(self, albums: list[Album]) -> None:
-        """Record albums the scanner has never met before (#107).
+        """Record albums Harmonist has never touched before (#107).
 
         ONE activity entry per scan, with an audit row per album inside its action
-        scope. That gives both readings from one write: the feed says "a scan
-        found 12 albums", and each row's `album_id` puts it on that album's own
+        scope. That gives both readings from one write: the feed says "started
+        tracking 12", and each row's `album_id` puts it on that album's own
         history page — answering "where did this album even come from?", which for
         an ADOPTED album nothing else could.
 
@@ -320,27 +320,30 @@ class ScanRunner:
         which is only possible because a sidecar-less album's id now derives from
         its path (#114) and so survives a restart.
 
+        The wording deliberately claims nothing about WHEN an album arrived. A
+        sidecar-less album might have turned up ten minutes ago or ten years ago,
+        and Harmonist cannot tell which — all it knows is when it started keeping
+        records for it (#116).
+
         Bookkeeping about a scan, so it must never fail one — hence the broad
         catch. Loud, though: silence here would mean albums quietly never getting
         the record, which is the bug this fixes.
         """
         try:
-            # First scan since this feature arrived: whatever it finds was already
-            # in the library, and Harmonist has no idea when it arrived. Recorded
-            # (so later scans have their baseline) but announced as what it is —
-            # claiming the user's existing collection turned up just now would be
-            # a lie about every album they already had.
-            adopting = not activity_store.any_discovery_recorded()
-            known = activity_store.already_discovered([a.id for a in albums])
-            fresh = [a for a in albums if a.id not in known]
+            # A sidecar means Harmonist has written to this album before, so it
+            # already HAS history and needs no start marker. Recording one anyway
+            # put an `album.discovered` row above an album's own download and
+            # tagging rows, dated a day later — true, useless, and misleading
+            # (#116). This leaves the record doing only the job it exists for:
+            # the adopted album nothing else can account for.
+            candidates = [a for a in albums if a.sidecar is None]
+            known = activity_store.already_discovered([a.id for a in candidates])
+            fresh = [a for a in candidates if a.id not in known]
             if not fresh:
                 return
             with activity_store.action():
                 activity.info(
-                    f"Started tracking {len(fresh)} album{'s' if len(fresh) != 1 else ''} "
-                    "already in your library"
-                    if adopting
-                    else f"Found {len(fresh)} new album{'s' if len(fresh) != 1 else ''}"
+                    f"Started tracking {len(fresh)} album{'s' if len(fresh) != 1 else ''}"
                 )
                 for a in fresh:
                     # `album` (the path) rather than only the id, so the row still

--- a/test/test_scan_runner.py
+++ b/test/test_scan_runner.py
@@ -205,11 +205,10 @@ def _discovery_rows() -> list:
     ]
 
 
-def test_first_scan_adopts_the_existing_library_rather_than_claiming_it_is_new(tmp_path):
-    """Albums present on the first scan after this feature arrived predate the
-    ledger — Harmonist has no idea when they turned up, so announcing them as
-    found-just-now would be a lie about the user's whole existing collection
-    (#107). They're still recorded, so later scans have their baseline."""
+def test_untouched_albums_are_recorded_without_claiming_when_they_arrived(tmp_path):
+    """A sidecar-less album might have turned up ten minutes ago or ten years
+    ago, and Harmonist cannot tell which. So the entry says what it actually
+    knows — when it started keeping records — and nothing about arrival (#116)."""
     from harmonist import activity, activity_store, id_registry
 
     music = tmp_path / "music"
@@ -227,13 +226,47 @@ def test_first_scan_adopts_the_existing_library_rather_than_claiming_it_is_new(t
 
     asyncio.run(go())
 
+    # Exact, not a substring: the old wording ("…already in your library") also
+    # contained this, and the whole point is that the sentence stops here.
     entries = [e.message for e in activity.recent(20)]
-    assert any("Started tracking 2 albums already in your library" in m for m in entries), entries
-    assert not any(m.startswith("Found ") for m in entries), entries
+    assert "Started tracking 2 albums" in entries, entries
 
 
-def test_an_album_added_later_is_announced_as_new_and_only_once(tmp_path):
+def test_an_album_with_a_sidecar_is_never_recorded_as_discovered(tmp_path):
+    """A sidecar means Harmonist has written to this album before, so it already
+    HAS history. Recording a discovery anyway put an `album.discovered` row above
+    the album's own download and tagging rows, dated later (#116)."""
     from harmonist import activity, activity_store, id_registry
+    from harmonist import sidecar as scmod
+    from harmonist.models import Sidecar
+
+    music = tmp_path / "music"
+    known = _album(music, "AlreadyKnown")
+    _album(music, "Untouched")
+    activity_store.init(tmp_path / "activity.db")
+    id_registry.set_library_root(music)
+    scmod.write(known, Sidecar(mb_release_id="rel-known"))
+    activity_store.clear()  # forget the sidecar.create the write just audited
+    runner = ScanRunner(music)
+
+    async def go() -> None:
+        runner.attach_loop()
+        await _wait(runner.has_completed)
+        await _wait(lambda: len(_discovery_rows()) == 1)
+        await asyncio.sleep(0.05)  # give a wrong second row time to appear
+
+    asyncio.run(go())
+
+    rows = _discovery_rows()
+    assert len(rows) == 1, [r.message for r in rows]
+    assert "Untouched" in rows[0].message
+    assert not any("AlreadyKnown" in r.message for r in rows)
+    entries = [e.message for e in activity.recent(20)]
+    assert any("Started tracking 1 album" in m for m in entries), entries
+
+
+def test_an_album_added_later_is_recorded_once_and_only_once(tmp_path):
+    from harmonist import activity_store, id_registry
 
     music = tmp_path / "music"
     _album(music, "Existing")
@@ -244,7 +277,7 @@ def test_an_album_added_later_is_announced_as_new_and_only_once(tmp_path):
 
     async def go() -> None:
         runner.attach_loop()
-        await _wait(lambda: len(_discovery_rows()) == 1)  # the adopt pass
+        await _wait(lambda: len(_discovery_rows()) == 1)
         _album(music, "Arrived")
         runner.request_scan()
         await _wait(lambda: len(_discovery_rows()) == 2)
@@ -257,8 +290,6 @@ def test_an_album_added_later_is_announced_as_new_and_only_once(tmp_path):
     asyncio.run(go())
 
     assert len(_discovery_rows()) == 2
-    entries = [e.message for e in activity.recent(20)]
-    assert any("Found 1 new album" in m for m in entries), entries
 
 
 def test_a_discovered_album_reaches_its_own_history_page(tmp_path):


### PR DESCRIPTION
Dogfood feedback on #107: the first scan added an `album.discovered` row to albums that already had a full history, so it sat above the album's own download and tagging rows, dated a day later.

```
2026-08-04 18:50   album.discovered album="Viul & Benoit Pioulard/Konec" state=complete tracks=12
2026-08-03 10:29   Tagged — match found via Recheck
2026-08-03 10:25   Synced — no MusicBrainz match yet
2026-08-03 10:25   download item_id=3742021971 fmt=alac path="…/Konec"
```

Technically true — that scan *was* the first to record meeting the album — and useless.

**Fix:** skip any album that already has a sidecar. A sidecar means Harmonist has written to it before, so it already has history and needs no start marker. `Album.sidecar` is on the scanned object already, so this is a filter, not a lookup. What's left is the record doing only the job it was added for — the adopted album nothing else can account for.

**The first-pass wording goes with it.** It distinguished *"Started tracking N already in your library"* from *"Found N new"* via `any_discovery_recorded()`, and that signal breaks under the new filter: on an established install almost every album is skipped, so no discovery row is ever written, the flag stays False, and the *next* genuinely-new album would get the bootstrap wording.

The distinction was never recoverable anyway — a sidecar-less album might have arrived ten minutes ago or ten years ago, and Harmonist cannot tell which. So the entry now claims only what it knows: **"Started tracking N albums"**. `any_discovery_recorded()` is deleted.

Also corrects `models.Album`'s docstring, which still said *"No path-derived ids exist anywhere — that's the point"* after #114 made exactly that the point.

**Testing:** the new sidecar test and the reworded one both verified to fail against the pre-fix code — the wording one asserts the message *exactly*, since the old text contained the new text as a substring and would otherwise have passed either way. The idempotence test (third scan adds nothing) is untouched and still passes. 744 green.

Fixes #116