### PR TITLE
Show the inbox card's path relative to the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Inbox cards show the album's path relative to your music library, like the
+  rest of the UI, instead of in full (#121).
 - The Activity feed no longer greys itself out every couple of seconds, and an
   unchanged feed is no longer re-sent — on a large library that was 154 KB every
   2 seconds (#118).

--- a/templates/partials/_album_header.html
+++ b/templates/partials/_album_header.html
@@ -27,7 +27,12 @@
         <div class="flex-grow min-w-0">
             <h3 class="text-lg font-bold text-ink truncate">{{ album.title }}</h3>
             <p class="text-muted text-sm truncate">{{ album.artist }} · {{ album.track_count }} track{{ 's' if album.track_count != 1 else '' }}{% if album.audio_format %} · {{ album.audio_format }}{% endif %}</p>
-            <p class="text-muted text-2xs truncate">{{ album.path }}</p>
+            {# Relative to the library, same as the detail panel and the audit log
+               (#98): under Docker the prefix is a container path that means
+               nothing to the user, and the tail is what identifies the album.
+               Absolute stays one hover away. #}
+            <p class="text-muted text-2xs truncate"
+               title="{{ album.path }}">{{ rel_path(album.path, cfg.paths.music_dir) }}</p>
         </div>
     </div>
     {% if _lk_mbid or _lk_store %}

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -218,6 +218,39 @@ def test_inbox_card_lazy_loads_cover_when_present(client, cfg):
     assert 'loading="lazy"' in r.text
 
 
+def test_inbox_card_shows_the_path_relative_to_the_library(client, cfg):
+    """Under Docker the library prefix is a container path that means nothing to
+    the user, and the tail is what identifies the album — the reason audit
+    records went relative in #98. The inbox card was the last place still
+    printing it in full (#121). Absolute stays available on hover."""
+    d = _make_album(cfg, "RelativeMe")
+    body = client.get("/tasks").text
+
+    assert f'title="{d}"' in body  # absolute, one hover away
+    rel = str(d.relative_to(cfg.paths.music_dir))
+    assert f">{rel}</p>" in body
+    # The visible text must not be the absolute path. Checked on the rendered
+    # <p> rather than the whole page, since `title` legitimately carries it.
+    assert f">{d}</p>" not in body
+
+
+def test_no_template_renders_a_bare_library_path(cfg):
+    """A guard for the whole class, not just the card #121 fixed: `{{ album.path }}`
+    is the absolute path, and every place showing it to the user wants
+    `rel_path(...)`. Cheap to keep, and it fails on the next one added."""
+    import re
+    from pathlib import Path
+
+    offenders = []
+    for tpl in (Path(__file__).resolve().parents[1] / "templates").rglob("*.html"):
+        for n, line in enumerate(tpl.read_text().splitlines(), 1):
+            # `{{ album.path }}` used as content. A `title="{{ album.path }}"`
+            # attribute is the intended escape hatch and is exempt.
+            if re.search(r"(?<!title=\")\{\{\s*album\.path\s*\}\}(?!\")", line):
+                offenders.append(f"{tpl.name}:{n}")
+    assert not offenders, f"render these via rel_path(...): {offenders}"
+
+
 def test_consolidated_status_endpoint(client):
     """One poll returns sync + reconcile + scan + counts, replacing separate polls."""
     r = client.get("/status")


### PR DESCRIPTION
An inbox card rendered the full path:

```
/music/Galán | Spieth | Guentner/Obreel
```

Under Docker the `/music` prefix is a container path that means nothing to the user, and the tail is what identifies the album — the reason audit records went relative in #98. The album detail panel already renders `rel_path(...)` with the absolute in a `title`; `_album_header.html` was the last place still printing it raw.

Absolute stays one hover away, same as the detail panel.

**Also adds a guard for the class, not just the instance:** a test that fails if any template renders `{{ album.path }}` as content, with `title="{{ album.path }}"` exempt as the intended escape hatch. It's cheap to keep and catches the next one added rather than waiting for it to be spotted in a screenshot.

Both tests verified to fail against the unfixed template. 751 green, no CSS drift.

Fixes #121