### PR TITLE
Add the disk-vs-MusicBrainz comparison model

### DIFF
--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -30,6 +30,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # keeps this module free of runtime imports — it stays pure
+    from .formats.types import TagSet, TrackTags
 
 # Emphasis is dropped only when a change is BOTH large and scattered. Size alone
 # is the wrong test: "2019" -> "2019-03-15" changes 60% of the characters and is
@@ -257,6 +261,61 @@ def compare_field(
         mb_runs=mb_runs,
         consensus=disk,
     )
+
+
+#: The album-level fields the page shows, in display order, as
+#: `(label, TrackTags attribute, TagSet attribute, kind)`.
+#:
+#: `comment` is here with no MusicBrainz counterpart on purpose: it carries the
+#: recovered Bandcamp URL, MusicBrainz has no opinion on it, and comparing would
+#: invent a difference. Absent from this table entirely would be worse — the
+#: user can't see a tag Harmonist is keeping for them.
+_ALBUM_FIELDS: tuple[tuple[str, str, str | None, Kind], ...] = (
+    ("Album", "album", "album", Kind.TEXT),
+    ("Album artist", "album_artist", "album_artist", Kind.TEXT),
+    ("Date", "date", "date", Kind.SCALAR),
+    ("Label", "label", "label", Kind.TEXT),
+    ("Cat. no.", "catalog_number", "catalog_number", Kind.SCALAR),
+    ("Barcode", "barcode", "barcode", Kind.SCALAR),
+    ("Media", "media", "media", Kind.SCALAR),
+    ("Genre", "genre", None, Kind.TEXT),
+    ("Comment", "comment", None, Kind.TEXT),
+)
+
+
+def album_fields(
+    tracks: Sequence[tuple[str, TrackTags]],
+    mb: TagSet | None,
+) -> tuple[FieldComparison, ...]:
+    """Compare an album's per-track tags against what tagging would write.
+
+    `tracks` is `(file_name, tags)` in track order — per-track rather than a
+    single album value because the tracks are what actually exist, and their
+    agreement is itself information.
+
+    `mb` is any one track's TagSet: every field here is album-level, so they're
+    identical across tracks. None when there's no MusicBrainz release to compare
+    against, which leaves every field ONLY_DISK rather than pretending MB
+    disagrees.
+    """
+    unreadable = all(t.unreadable for _, t in tracks) if tracks else False
+    out: list[FieldComparison] = []
+    for label, disk_attr, mb_attr, kind in _ALBUM_FIELDS:
+        # Unreadable files contribute no value — they'd otherwise vote "absent"
+        # and drag a field to ONLY_MB, reporting a tag as missing when the truth
+        # is that Harmonist couldn't look (#112).
+        values = [(name, getattr(t, disk_attr)) for name, t in tracks if not t.unreadable]
+        mb_value = getattr(mb, mb_attr) if (mb is not None and mb_attr) else None
+        out.append(
+            compare_field(
+                label,
+                kind=kind,
+                disk=consensus(values),
+                mb=mb_value or None,
+                unreadable=unreadable,
+            )
+        )
+    return tuple(out)
 
 
 @dataclass(frozen=True)

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -1,0 +1,276 @@
+"""Comparing an album's on-disk tags against its MusicBrainz release (#106).
+
+Pure functions over values — no I/O, no mutagen, no MusicBrainz client. The web
+layer gathers the values and renders the result; the audit log (#86) wants the
+same comparison rendered differently, so the model lives here rather than inside
+either of them.
+
+Three ideas, in the order they matter:
+
+**Agreement is the answer, not a diff.** Harmonist's job is to say what differs,
+and most fields don't. A field that matches carries no runs, no emphasis, and
+renders as one plain line. The register is deliberately not a code diff: most
+real differences here are formatting (a Bandcamp `Artist A | Artist B` credit vs
+MusicBrainz's join phrases, a featured credit MB keeps out of the title), and
+calling those errors would be wrong.
+
+**A per-album field is really N per-track fields.** They usually agree; when they
+don't there is no single on-disk value, so `consensus()` reports what most tracks
+say, how many, and which disagree — and refuses to pick on a tie rather than
+inventing an answer.
+
+**"Couldn't read it" is a third state** (#112), distinct from both "matches" and
+"differs". A file Harmonist failed to open must not be reported as untagged.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from enum import StrEnum
+
+# Emphasis is dropped only when a change is BOTH large and scattered. Size alone
+# is the wrong test: "2019" -> "2019-03-15" changes 60% of the characters and is
+# precisely the case worth marking, while "Kaskade" -> "Rainbow Connection"
+# changes a similar proportion across half a dozen fragments and is unreadable.
+# What makes it confetti is fragmentation, so both conditions must hold.
+MAX_EMPHASIS_RATIO = 0.34
+MAX_CHANGED_RUNS = 2
+
+# Changed runs closer together than this are merged. Character-level diffing of
+# "Galán | Spieth" against "Galán, Spieth" otherwise yields a scatter of
+# one-character fragments that reads worse than the difference it marks.
+_MERGE_GAP = 3
+
+
+class Agreement(StrEnum):
+    """What the comparison found for one field."""
+
+    MATCHES = "matches"
+    DIFFERS = "differs"
+    #: Absent from the files, present on MusicBrainz (label, catalogue number).
+    #: Rendered exactly like a change — a lone MusicBrainz line. It is not a
+    #: conflict and must not be dressed as one.
+    ONLY_MB = "only_mb"
+    #: On disk with no MusicBrainz counterpart — the comment carrying the
+    #: Bandcamp URL, and eventually arbitrary tags. MusicBrainz has no opinion,
+    #: so offering a comparison would invent a difference.
+    ONLY_DISK = "only_disk"
+    #: Harmonist could not read the file(s) (#112). NOT the same as "no value":
+    #: an unreadable file reported as untagged is how a failing disk gets an
+    #: album re-tagged.
+    UNREADABLE = "unreadable"
+    #: The tracks disagree with no majority — a 4/4 split. There is no on-disk
+    #: value to compare, and picking one would be a quiet lie.
+    NO_CONSENSUS = "no_consensus"
+
+
+class Kind(StrEnum):
+    """How the field wants to be shown. Long text stacks (both values flush
+    left, one above the other); short scalars sit inline with an arrow."""
+
+    TEXT = "text"
+    SCALAR = "scalar"
+
+
+@dataclass(frozen=True)
+class Run:
+    """A slice of a value, flagged as differing or not — for in-value emphasis."""
+
+    text: str
+    changed: bool
+
+
+@dataclass(frozen=True)
+class Consensus:
+    """What the album's tracks say about one field.
+
+    `value` is None when the tracks disagree with no majority; `outliers` names
+    the files that don't carry `value`, so the UI can show them on demand
+    without re-reading anything.
+    """
+
+    value: str | None
+    agreeing: int
+    total: int
+    outliers: tuple[tuple[str, str | None], ...] = ()
+    #: How many distinct non-empty values the tracks carry. Load-bearing: it is
+    #: the only thing separating "no track has this field" (0 — the field is
+    #: simply absent) from "the tracks disagree with no majority" (2+ on a tie).
+    #: Both leave `value` None, and treating them the same would report an
+    #: untagged album as inconsistent.
+    distinct: int = 0
+
+    @property
+    def is_unanimous(self) -> bool:
+        return self.total > 0 and self.agreeing == self.total
+
+
+@dataclass(frozen=True)
+class FieldComparison:
+    """One row of the album's tag comparison."""
+
+    label: str
+    kind: Kind
+    agreement: Agreement
+    disk: str | None = None
+    mb: str | None = None
+    #: Empty unless the difference is small enough to mark in place — see
+    #: MAX_EMPHASIS_RATIO. Callers render plain text when these are empty.
+    disk_runs: tuple[Run, ...] = ()
+    mb_runs: tuple[Run, ...] = ()
+    consensus: Consensus | None = None
+
+    @property
+    def differs(self) -> bool:
+        """Whether this row is something the user should look at. ONLY_DISK is
+        excluded on purpose: a Bandcamp URL in the comment is not a finding."""
+        return self.agreement in (
+            Agreement.DIFFERS,
+            Agreement.ONLY_MB,
+            Agreement.UNREADABLE,
+            Agreement.NO_CONSENSUS,
+        )
+
+
+def consensus(values: Sequence[tuple[str, str | None]]) -> Consensus:
+    """What most tracks say for one field, from `(file_name, value)` pairs.
+
+    Returns `value=None` on a tie. A 4/4 split has no most-common value, and
+    silently choosing one would state something false about the album.
+
+    Tracks with no value at all are counted in `total` but can't win: a field
+    present on six of eight tracks is "what the album says", with two outliers,
+    not a field with no value.
+    """
+    total = len(values)
+    if total == 0:
+        return Consensus(value=None, agreeing=0, total=0)
+    counts = Counter(v for _, v in values if v is not None)
+    if not counts:
+        return Consensus(value=None, agreeing=0, total=total, distinct=0)
+    ranked = counts.most_common()
+    top_count = ranked[0][1]
+    if len([c for _, c in ranked if c == top_count]) > 1:
+        # A tie. Deliberately no winner — see the docstring.
+        return Consensus(value=None, agreeing=0, total=total, distinct=len(counts))
+    winner = ranked[0][0]
+    outliers = tuple((name, v) for name, v in values if v != winner)
+    return Consensus(
+        value=winner, agreeing=top_count, total=total, outliers=outliers, distinct=len(counts)
+    )
+
+
+def diff_runs(a: str, b: str) -> tuple[tuple[Run, ...], tuple[Run, ...]]:
+    """Split two values into runs, marking what differs between them.
+
+    Returns empty tuples when the change is too large to mark usefully — the
+    caller then renders both values plain. Character-level, because the
+    differences worth marking here are punctuation and separators that a
+    word-level diff would swallow whole ("2019" vs "2019-03-15" marks exactly
+    "-03-15").
+    """
+    if a == b:
+        return (), ()
+    matcher = SequenceMatcher(None, a, b, autojunk=False)
+    opcodes = matcher.get_opcodes()
+    edits = [op for op in opcodes if op[0] != "equal"]
+    changed = sum(max(i2 - i1, j2 - j1) for _, i1, i2, j1, j2 in edits)
+    if len(edits) > MAX_CHANGED_RUNS and changed > max(len(a), len(b)) * MAX_EMPHASIS_RATIO:
+        return (), ()
+    a_runs: list[Run] = []
+    b_runs: list[Run] = []
+    for tag, i1, i2, j1, j2 in opcodes:
+        equal = tag == "equal"
+        if i2 > i1:
+            a_runs.append(Run(a[i1:i2], not equal))
+        if j2 > j1:
+            b_runs.append(Run(b[j1:j2], not equal))
+    return _merge(a_runs), _merge(b_runs)
+
+
+def _merge(runs: list[Run]) -> tuple[Run, ...]:
+    """Fold short unchanged gaps into the surrounding change, then join
+    neighbours that ended up with the same flag."""
+    for i in range(1, len(runs) - 1):
+        bridges_a_change = runs[i - 1].changed and runs[i + 1].changed
+        if not runs[i].changed and len(runs[i].text) < _MERGE_GAP and bridges_a_change:
+            runs[i] = Run(runs[i].text, True)
+    out: list[Run] = []
+    for run in runs:
+        if out and out[-1].changed == run.changed:
+            out[-1] = Run(out[-1].text + run.text, run.changed)
+        else:
+            out.append(run)
+    return tuple(out)
+
+
+def compare_field(
+    label: str,
+    *,
+    kind: Kind = Kind.TEXT,
+    disk: Consensus | None = None,
+    mb: str | None = None,
+    unreadable: bool = False,
+) -> FieldComparison:
+    """Build one comparison row.
+
+    `disk` is a `Consensus` rather than a bare value so the row can report both
+    what the album says and how united it is about it.
+    """
+    if unreadable:
+        return FieldComparison(label, kind, Agreement.UNREADABLE, mb=mb, consensus=disk)
+
+    disk_value = disk.value if disk else None
+    # `distinct` is what separates a tie from a field no track carries. Without
+    # it an untagged album reports every field as "inconsistent".
+    tracks_disagree = disk is not None and disk_value is None and disk.distinct > 1
+    if tracks_disagree:
+        # Some tracks may still carry values; there is just no majority. The row
+        # says so rather than showing one arbitrarily.
+        return FieldComparison(label, kind, Agreement.NO_CONSENSUS, mb=mb, consensus=disk)
+
+    if disk_value is None and mb is None:
+        return FieldComparison(label, kind, Agreement.MATCHES, consensus=disk)
+    if disk_value is None:
+        return FieldComparison(label, kind, Agreement.ONLY_MB, mb=mb, consensus=disk)
+    if mb is None:
+        return FieldComparison(label, kind, Agreement.ONLY_DISK, disk=disk_value, consensus=disk)
+    if disk_value == mb:
+        return FieldComparison(
+            label, kind, Agreement.MATCHES, disk=disk_value, mb=mb, consensus=disk
+        )
+    disk_runs, mb_runs = diff_runs(disk_value, mb)
+    return FieldComparison(
+        label,
+        kind,
+        Agreement.DIFFERS,
+        disk=disk_value,
+        mb=mb,
+        disk_runs=disk_runs,
+        mb_runs=mb_runs,
+        consensus=disk,
+    )
+
+
+@dataclass(frozen=True)
+class AlbumComparison:
+    """Every field of one album, plus the headline the section needs."""
+
+    fields: tuple[FieldComparison, ...] = field(default_factory=tuple)
+
+    @property
+    def differing(self) -> tuple[FieldComparison, ...]:
+        return tuple(f for f in self.fields if f.differs)
+
+    @property
+    def summary(self) -> str:
+        """The line beside the MusicBrainz hexagon."""
+        n = len(self.differing)
+        if not self.fields:
+            return "nothing to compare"
+        if n == 0:
+            return f"all {len(self.fields)} fields match"
+        return f"{n} of {len(self.fields)} fields differ"

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -62,9 +62,6 @@ class Agreement(StrEnum):
     #: an unreadable file reported as untagged is how a failing disk gets an
     #: album re-tagged.
     UNREADABLE = "unreadable"
-    #: The tracks disagree with no majority — a 4/4 split. There is no on-disk
-    #: value to compare, and picking one would be a quiet lie.
-    NO_CONSENSUS = "no_consensus"
 
 
 class Kind(StrEnum):
@@ -131,19 +128,23 @@ class FieldComparison:
             Agreement.DIFFERS,
             Agreement.ONLY_MB,
             Agreement.UNREADABLE,
-            Agreement.NO_CONSENSUS,
         )
 
 
 def consensus(values: Sequence[tuple[str, str | None]]) -> Consensus:
-    """What most tracks say for one field, from `(file_name, value)` pairs.
+    """What most tracks say for one field, from `(file_name, value)` pairs, in
+    track order.
 
-    Returns `value=None` on a tie. A 4/4 split has no most-common value, and
-    silently choosing one would state something false about the album.
+    On a tie — a 4/4 split, with no most-common value — **the first track with a
+    value wins**. Deliberately a rule that fits in one sentence: "when your
+    tracks disagree evenly, Harmonist shows what track 1 says." The count beside
+    it (`4 of 8`) already tells the user this isn't the album's settled answer
+    and the outliers are one hover away, so an arbitrary-looking pick is less
+    confusing than a field that refuses to show anything at all.
 
-    Tracks with no value at all are counted in `total` but can't win: a field
-    present on six of eight tracks is "what the album says", with two outliers,
-    not a field with no value.
+    Tracks with no value are counted in `total` but can't win: a field present
+    on six of eight tracks is "what the album says", with two outliers, not a
+    field with no value. `value` is None only when NO track has one.
     """
     total = len(values)
     if total == 0:
@@ -153,10 +154,17 @@ def consensus(values: Sequence[tuple[str, str | None]]) -> Consensus:
         return Consensus(value=None, agreeing=0, total=total, distinct=0)
     ranked = counts.most_common()
     top_count = ranked[0][1]
-    if len([c for _, c in ranked if c == top_count]) > 1:
-        # A tie. Deliberately no winner — see the docstring.
-        return Consensus(value=None, agreeing=0, total=total, distinct=len(counts))
-    winner = ranked[0][0]
+    tied = [v for v, c in ranked if c == top_count]
+    if len(tied) > 1:
+        # Tie broken by track order: the first track carrying one of the joint-
+        # winning values. `Counter.most_common` orders ties by first insertion,
+        # which is close but not the same thing — it ranks by first *occurrence
+        # of that value*, which coincides here only because we scan in order.
+        # Being explicit costs a line and means the rule is the documented one.
+        winner = next(v for _, v in values if v in tied)
+    else:
+        winner = ranked[0][0]
+    top_count = counts[winner]
     outliers = tuple((name, v) for name, v in values if v != winner)
     return Consensus(
         value=winner, agreeing=top_count, total=total, outliers=outliers, distinct=len(counts)
@@ -223,15 +231,11 @@ def compare_field(
     if unreadable:
         return FieldComparison(label, kind, Agreement.UNREADABLE, mb=mb, consensus=disk)
 
+    # `value` is None only when no track carries the field at all — a tie is
+    # resolved in `consensus`, so uneven tagging never suppresses the row. How
+    # united the tracks are travels alongside on `consensus`, for the UI to
+    # annotate; it doesn't change which comparison is made.
     disk_value = disk.value if disk else None
-    # `distinct` is what separates a tie from a field no track carries. Without
-    # it an untagged album reports every field as "inconsistent".
-    tracks_disagree = disk is not None and disk_value is None and disk.distinct > 1
-    if tracks_disagree:
-        # Some tracks may still carry values; there is just no majority. The row
-        # says so rather than showing one arbitrarily.
-        return FieldComparison(label, kind, Agreement.NO_CONSENSUS, mb=mb, consensus=disk)
-
     if disk_value is None and mb is None:
         return FieldComparison(label, kind, Agreement.MATCHES, consensus=disk)
     if disk_value is None:

--- a/src/harmonist/formats/__init__.py
+++ b/src/harmonist/formats/__init__.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from types import ModuleType
 
 from . import flac, m4a, mp3, ogg, opus
-from .types import ScanFields, TagSet, UnsupportedFormatError
+from .types import ScanFields, TagSet, TrackTags, UnsupportedFormatError
 
 _MODULES: tuple[ModuleType, ...] = (m4a, mp3, flac, ogg, opus)
 
@@ -87,6 +87,22 @@ def read_scan_fields(path: Path) -> ScanFields:
     return fields
 
 
+def read_tags(path: Path) -> TrackTags:
+    """Everything the album comparison needs from one file, in a single open
+    (#106). Unlike `read_scan_fields` this reads the album-level metadata a user
+    would recognise — label, catalogue number, date — not just what the scanner
+    needs to derive state.
+
+    An unsupported extension is not a read failure, so it comes back empty
+    rather than flagged: nothing was wrong, there is simply nothing to read.
+    """
+    mod = _module_for(path)
+    if mod is None:
+        return TrackTags()
+    tags: TrackTags = mod.read_tags(path)
+    return tags
+
+
 def read_cover(path: Path) -> tuple[bytes, str] | None:
     """Extract the file's embedded cover art as (image_bytes, mime_type), or
     None when there's no cover / no module for the extension."""
@@ -110,6 +126,7 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> None:
 __all__ = [
     "ScanFields",
     "TagSet",
+    "TrackTags",
     "UnsupportedFormatError",
     "describe",
     "is_supported",
@@ -120,6 +137,7 @@ __all__ = [
     "read_cover",
     "read_duration_ms",
     "read_scan_fields",
+    "read_tags",
     "read_track_title",
     "supported_extensions",
     "write_tags",

--- a/src/harmonist/formats/_vorbis.py
+++ b/src/harmonist/formats/_vorbis.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from mutagen.flac import Picture
 
-from .types import ScanFields, TagSet
+from .types import ScanFields, TagSet, TrackTags
 
 # Vorbis comment keys (uppercase by convention; lookups are case-insensitive).
 KEY_ALBUM_ID = "MUSICBRAINZ_ALBUMID"
@@ -54,6 +54,9 @@ KEY_BARCODE = "BARCODE"
 KEY_ASIN = "ASIN"
 KEY_MEDIA = "MEDIA"
 KEY_COMMENT = "COMMENT"
+# Read-only: Harmonist doesn't write a genre (that's #12), but files tagged
+# elsewhere carry one and the album comparison should show it.
+KEY_GENRE = "GENRE"
 KEY_DESCRIPTION = "DESCRIPTION"
 
 # Keys this tagger manages on write (cleared then rewritten). COMMENT /
@@ -183,6 +186,39 @@ class VorbisTagger:
             codec=codec,
             has_cover=has_cover,
             album_artist=first(KEY_ALBUM_ARTIST),
+        )
+
+    def read_tags(self, path: Path) -> TrackTags:
+        """Everything the album comparison needs from one file, in one open."""
+        audio = self._open(path)
+        if audio is None:
+            return TrackTags(unreadable=True)
+        duration = round(audio.info.length * 1000) if audio.info.length else None
+        tags = audio.tags
+        if tags is None:
+            # Opened fine, carries no tag block: genuinely untagged, not
+            # unreadable. The duration is still real.
+            return TrackTags(duration_ms=duration)
+
+        def first(key: str) -> str | None:
+            values = tags.get(key)
+            return (str(values[0]) or None) if values else None
+
+        track_num = first(KEY_TRACK_NUMBER)
+        return TrackTags(
+            album=first(KEY_ALBUM),
+            album_artist=first(KEY_ALBUM_ARTIST),
+            date=first(KEY_DATE),
+            label=first(KEY_LABEL),
+            catalog_number=first(KEY_CATALOG),
+            barcode=first(KEY_BARCODE),
+            media=first(KEY_MEDIA),
+            genre=first(KEY_GENRE),
+            title=first(KEY_TITLE),
+            artist=first(KEY_ARTIST),
+            track_num=int(track_num.split("/")[0]) if track_num else None,
+            duration_ms=duration,
+            comment=first(KEY_COMMENT),
         )
 
     def read_cover(self, path: Path) -> tuple[bytes, str] | None:

--- a/src/harmonist/formats/_vorbis.py
+++ b/src/harmonist/formats/_vorbis.py
@@ -164,7 +164,9 @@ class VorbisTagger:
         (a constant per Vorbis container — FLAC/Vorbis/Opus)."""
         audio = self._open(path)
         if audio is None:
-            return ScanFields(None, None, None, codec)
+            # Flagged, not silently blank: an unopenable file must not read as
+            # an untagged one (#112).
+            return ScanFields(None, None, None, codec, unreadable=True)
         has_cover = _has_embedded_cover(audio)
         tags = audio.tags
         if tags is None:

--- a/src/harmonist/formats/flac.py
+++ b/src/harmonist/formats/flac.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from mutagen.flac import FLAC
 
 from . import _vorbis
-from .types import ScanFields
+from .types import ScanFields, TrackTags
 
 EXTENSIONS = (".flac",)
 
@@ -46,3 +46,7 @@ read_cover = _impl.read_cover
 
 def read_scan_fields(path: Path) -> ScanFields:
     return _impl.read_scan_fields(path, "FLAC")
+
+
+def read_tags(path: Path) -> TrackTags:
+    return _impl.read_tags(path)

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -151,7 +151,9 @@ def read_scan_fields(path: Path) -> ScanFields:
     """All scanner-needed fields in one open (album, MB album id, artist, codec)."""
     audio = _open(path)
     if audio is None:
-        return ScanFields(None, None, None, None)
+        # Flagged, not silently blank: an unopenable file must not read as an
+        # untagged one (#112).
+        return ScanFields(None, None, None, None, unreadable=True)
     return ScanFields(
         album_title=_text_atom(audio, ATOM_ALBUM),
         album_id=_binary_atom_str(audio, ATOM_MB_ALBUM_ID),

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from mutagen.mp4 import MP4, MP4Cover
 
-from .types import ScanFields, TagSet
+from .types import ScanFields, TagSet, TrackTags
 
 EXTENSIONS = (".m4a", ".mp4")
 
@@ -161,6 +161,30 @@ def read_scan_fields(path: Path) -> ScanFields:
         codec=_codec_label(audio),
         has_cover=bool(audio.get(ATOM_COVER)),
         album_artist=_text_atom(audio, ATOM_ALBUM_ARTIST),
+    )
+
+
+def read_tags(path: Path) -> TrackTags:
+    """Everything the album comparison needs from one file, in a single open."""
+    audio = _open(path)
+    if audio is None:
+        return TrackTags(unreadable=True)
+    trkn = audio.get(ATOM_TRACK_NUM) or []
+    return TrackTags(
+        album=_text_atom(audio, ATOM_ALBUM),
+        album_artist=_text_atom(audio, ATOM_ALBUM_ARTIST),
+        date=_text_atom(audio, ATOM_DATE),
+        # Freeform (----) atoms, so they come back as bytes.
+        label=_binary_atom_str(audio, ATOM_LABEL),
+        catalog_number=_binary_atom_str(audio, ATOM_CATALOG),
+        barcode=_binary_atom_str(audio, ATOM_BARCODE),
+        media=_binary_atom_str(audio, ATOM_MEDIA),
+        genre=_text_atom(audio, ATOM_GENRE),
+        title=_text_atom(audio, ATOM_TITLE),
+        artist=_text_atom(audio, ATOM_ARTIST),
+        track_num=trkn[0][0] if trkn and trkn[0] else None,
+        duration_ms=int(audio.info.length * 1000) if audio.info else None,
+        comment=_text_atom(audio, ATOM_COMMENT),
     )
 
 

--- a/src/harmonist/formats/mp3.py
+++ b/src/harmonist/formats/mp3.py
@@ -140,7 +140,9 @@ def read_scan_fields(path: Path) -> ScanFields:
     """All scanner-needed fields in one open (album, MB album id, artist, codec)."""
     audio = _open(path)
     if audio is None:
-        return ScanFields(None, None, None, "MP3")
+        # Flagged, not silently blank: an unopenable file must not read as an
+        # untagged one (#112).
+        return ScanFields(None, None, None, "MP3", unreadable=True)
     tags = audio.tags
     return ScanFields(
         album_title=_text(tags, "TALB"),

--- a/src/harmonist/formats/mp3.py
+++ b/src/harmonist/formats/mp3.py
@@ -41,7 +41,7 @@ from mutagen.id3 import (
 )
 from mutagen.mp3 import MP3
 
-from .types import ScanFields, TagSet
+from .types import ScanFields, TagSet, TrackTags
 
 EXTENSIONS = (".mp3",)
 
@@ -152,6 +152,51 @@ def read_scan_fields(path: Path) -> ScanFields:
         has_cover=bool(tags and tags.getall("APIC")),
         album_artist=_text(tags, "TPE2"),
     )
+
+
+def read_tags(path: Path) -> TrackTags:
+    """Everything the album comparison needs from one file, in a single open."""
+    audio = _open(path)
+    if audio is None:
+        return TrackTags(unreadable=True)
+    tags = audio.tags
+    track_num = _text(tags, "TRCK")
+    return TrackTags(
+        album=_text(tags, "TALB"),
+        album_artist=_text(tags, "TPE2"),
+        date=_text(tags, "TDRC"),
+        label=_text(tags, "TPUB"),  # a real frame, unlike the two below
+        catalog_number=_txxx(tags, TXXX_CATALOG),
+        barcode=_txxx(tags, TXXX_BARCODE),
+        media=_txxx(tags, "MEDIA"),
+        genre=_text(tags, "TCON"),
+        title=_text(tags, "TIT2"),
+        artist=_text(tags, "TPE1"),
+        # TRCK is "5" or "5/12" — the total belongs to the album, not the track.
+        track_num=_first_int(track_num),
+        duration_ms=round(audio.info.length * 1000) if audio.info.length else None,
+        comment=_comment_text(tags),
+    )
+
+
+def _first_int(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(value.split("/")[0])
+    except ValueError:
+        return None
+
+
+def _comment_text(tags: Any) -> str | None:
+    """The COMM frame Harmonist leaves alone on write, so a recovered Bandcamp
+    URL survives a retag. Read back for display only — never compared to MB."""
+    if tags is None:
+        return None
+    for frame in tags.getall("COMM"):
+        if frame.text and frame.text[0]:
+            return str(frame.text[0])
+    return None
 
 
 def read_cover(path: Path) -> tuple[bytes, str] | None:

--- a/src/harmonist/formats/ogg.py
+++ b/src/harmonist/formats/ogg.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from mutagen.oggvorbis import OggVorbis
 
 from . import _vorbis
-from .types import ScanFields
+from .types import ScanFields, TrackTags
 
 EXTENSIONS = (".ogg", ".oga")
 
@@ -42,3 +42,7 @@ read_cover = _impl.read_cover
 
 def read_scan_fields(path: Path) -> ScanFields:
     return _impl.read_scan_fields(path, "Vorbis")
+
+
+def read_tags(path: Path) -> TrackTags:
+    return _impl.read_tags(path)

--- a/src/harmonist/formats/opus.py
+++ b/src/harmonist/formats/opus.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from mutagen.oggopus import OggOpus
 
 from . import _vorbis
-from .types import ScanFields
+from .types import ScanFields, TrackTags
 
 EXTENSIONS = (".opus",)
 
@@ -42,3 +42,7 @@ read_cover = _impl.read_cover
 
 def read_scan_fields(path: Path) -> ScanFields:
     return _impl.read_scan_fields(path, "Opus")
+
+
+def read_tags(path: Path) -> TrackTags:
+    return _impl.read_tags(path)

--- a/src/harmonist/formats/types.py
+++ b/src/harmonist/formats/types.py
@@ -91,5 +91,46 @@ class TagSet:
     media: str | None = None
 
 
+@dataclass(frozen=True)
+class TrackTags:
+    """What one file actually carries, for comparison against MusicBrainz (#106).
+
+    The read-side counterpart to `TagSet`. Separate from it on purpose: `TagSet`
+    is what Harmonist *writes* and every field is required or defaulted, whereas
+    this is what it *finds*, where every field is legitimately absent and the
+    difference between "absent" and "unreadable" is the whole point.
+
+    Deliberately narrower than `TagSet` too. It carries the fields a user would
+    recognise on an album page — not MusicBrainz ids, which are plumbing, and
+    not sort names. Arbitrary/unknown tags are a later addition (see #106); the
+    shape here doesn't preclude them.
+    """
+
+    #: The file could not be opened at all. Every other field is then None, and
+    #: that is NOT the same as an untagged file — see ScanFields.unreadable.
+    unreadable: bool = False
+
+    # Album-level: the same on every track, which is what makes disagreement
+    # between tracks meaningful rather than expected.
+    album: str | None = None
+    album_artist: str | None = None
+    date: str | None = None
+    label: str | None = None
+    catalog_number: str | None = None
+    barcode: str | None = None
+    media: str | None = None
+    genre: str | None = None
+
+    # Per-track: expected to vary.
+    title: str | None = None
+    artist: str | None = None
+    track_num: int | None = None
+    duration_ms: int | None = None
+
+    #: Harmonist-owned. Carries the recovered Bandcamp URL, so MusicBrainz has
+    #: no counterpart and it must never be rendered as a difference.
+    comment: str | None = None
+
+
 class UnsupportedFormatError(Exception):
     """Raised when no audio module handles a given file extension."""

--- a/src/harmonist/formats/types.py
+++ b/src/harmonist/formats/types.py
@@ -25,6 +25,13 @@ class ScanFields(NamedTuple):
     # Album-level artist (Picard: aART / TPE2 / ALBUMARTIST). Authoritative for
     # display; "Various Artists" on a compilation. None when the tag is absent.
     album_artist: str | None = None
+    # True when the file could not be opened at all — a permission error, a
+    # truncated file, a failing disk. WITHOUT this, every field reads None and
+    # the result is byte-identical to a perfectly readable untagged file, so a
+    # COMPLETE album on a dying drive reappears in the inbox as stuck
+    # mid-tagging and invites the user to re-tag it (#112). "I couldn't read
+    # this" and "there's nothing here" are different answers.
+    unreadable: bool = False
 
 
 @dataclass

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -199,7 +199,11 @@ def build_album(album_dir: Path, audio_files: list[Path], io: AlbumIO) -> Album:
     # The sidecar is kept on disk; once the user fixes the on-disk tags
     # via Picard, the next scan re-derives state from the sidecar.
     inconsistent_tracks = _check_consistency(audio_files, fields)
-    state = AlbumState.INCONSISTENT if inconsistent_tracks else _derive_state(sidecar, fields)
+    state = (
+        AlbumState.INCONSISTENT
+        if inconsistent_tracks
+        else _derive_state(sidecar, fields, album_dir)
+    )
 
     return Album(
         id=_album_id(album_dir, sidecar),
@@ -270,7 +274,9 @@ def _album_id(album_dir: Path, sidecar: Sidecar | None) -> str:
     return id_registry.get_or_mint(album_dir)
 
 
-def _derive_state(sidecar: Sidecar | None, fields: list[formats.ScanFields]) -> AlbumState:
+def _derive_state(
+    sidecar: Sidecar | None, fields: list[formats.ScanFields], album_dir: Path
+) -> AlbumState:
     if sidecar is None:
         return AlbumState.NEW
     if sidecar.mb_release_id is None:
@@ -301,6 +307,22 @@ def _derive_state(sidecar: Sidecar | None, fields: list[formats.ScanFields]) -> 
             and not sidecar.purchase_unavailable
         ):
             return AlbumState.NEEDS_SYNC
+        return AlbumState.COMPLETE
+    if any(sf.unreadable for sf in fields):
+        # Files Harmonist could not open don't get to say the album is untagged
+        # (#112). Falling through to TAGGING here meant a COMPLETE album on a
+        # failing disk reappeared in the inbox as stuck mid-tagging — inviting
+        # the user to re-tag, i.e. to WRITE to the drive that just failed to
+        # read. The sidecar is Harmonist's own record of having tagged it, and
+        # trusting that while the evidence is unreadable is both the honest
+        # reading and the non-destructive one.
+        log.warning(
+            "%d of %d file(s) in %s could not be read; keeping the album's "
+            "recorded state rather than treating it as untagged",
+            sum(1 for sf in fields if sf.unreadable),
+            len(fields),
+            album_dir,
+        )
         return AlbumState.COMPLETE
     return AlbumState.TAGGING
 

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -285,6 +285,23 @@ def _derive_state(
         # present — but it's all one state, so the user never round-trips
         # between "review" and "assign".
         return AlbumState.NEEDS_MBID
+    unreadable = sum(1 for sf in fields if sf.unreadable)
+    if unreadable:
+        # A track Harmonist can't open is, for every purpose the user cares
+        # about, a track they don't have — so it lands in the same state as one
+        # that's absent (#112). Checked BEFORE the tagged/untagged branch,
+        # because a correctly tagged album with one corrupt file would otherwise
+        # come out COMPLETE and the corruption would never be shown.
+        #
+        # It also must not read as TAGGING, which is what it did: that invites a
+        # re-tag, i.e. a WRITE to the drive that just failed a read.
+        log.warning(
+            "%d of %d file(s) in %s could not be read — treating the album as incomplete",
+            unreadable,
+            len(fields),
+            album_dir,
+        )
+        return AlbumState.INCOMPLETE
     if _files_tagged_with(fields, sidecar.mb_release_id):
         # INCOMPLETE wins over NEEDS_SYNC when set: the user has explicitly
         # confirmed-as-incomplete (track_count_expected only gets set at
@@ -307,22 +324,6 @@ def _derive_state(
             and not sidecar.purchase_unavailable
         ):
             return AlbumState.NEEDS_SYNC
-        return AlbumState.COMPLETE
-    if any(sf.unreadable for sf in fields):
-        # Files Harmonist could not open don't get to say the album is untagged
-        # (#112). Falling through to TAGGING here meant a COMPLETE album on a
-        # failing disk reappeared in the inbox as stuck mid-tagging — inviting
-        # the user to re-tag, i.e. to WRITE to the drive that just failed to
-        # read. The sidecar is Harmonist's own record of having tagged it, and
-        # trusting that while the evidence is unreadable is both the honest
-        # reading and the non-destructive one.
-        log.warning(
-            "%d of %d file(s) in %s could not be read; keeping the album's "
-            "recorded state rather than treating it as untagged",
-            sum(1 for sf in fields if sf.unreadable),
-            len(fields),
-            album_dir,
-        )
         return AlbumState.COMPLETE
     return AlbumState.TAGGING
 

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -211,6 +211,27 @@ def _has_per_track_art(files: list[Path]) -> bool:
     return False
 
 
+def tagsets_for(release: Release) -> list[TagSet]:
+    """Every track's TagSet for `release`, in track order — what tagging WOULD
+    write, without writing it.
+
+    Exists for the album comparison (#106), and deliberately routes through the
+    same `_build_tagset` the tagger uses rather than re-deriving the fields.
+    A second mapping would drift: read "label" from a different corner of the
+    release than the writer does and the page reports a difference against tags
+    Harmonist itself wrote, which is worse than showing nothing.
+
+    That also gives the comparison its exact meaning — not "do my files match
+    MusicBrainz" in the abstract, but "do my files match what Harmonist would
+    write from this release", which is the question the user can act on.
+    """
+    media_total = len(release.get("medium-list", [])) or 1
+    return [
+        _build_tagset(release, medium, pos, track, media_total)
+        for medium, pos, track in _flatten_tracks(release)
+    ]
+
+
 def _build_tagset(
     release: Release,
     medium: dict[str, Any],

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -8,11 +8,16 @@ featured credit MB keeps out of the title.
 
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
+
+from harmonist import formats
 from harmonist.compare import (
     Agreement,
     AlbumComparison,
     Consensus,
     Kind,
+    album_fields,
     compare_field,
     consensus,
     diff_runs,
@@ -228,6 +233,93 @@ def test_summary_counts_only_real_findings():
     # Artist and Label; NOT the matching album title, NOT the comment.
     assert len(album.differing) == 2
     assert album.summary == "2 of 4 fields differ"
+
+
+# ---------- end to end: real files against a real release ----------
+
+
+def _release() -> dict:
+    """A MusicBrainz release with the fields the album panel shows."""
+    return {
+        "id": "rel-obreel",
+        "title": "Obreel",
+        "date": "2019-03-15",
+        "barcode": "4053804203319",
+        "artist-credit": [{"artist": {"id": "a1", "name": "Galán, Spieth & Guentner"}}],
+        "release-group": {"id": "rg-1", "primary-type": "Album"},
+        "label-info-list": [{"label": {"name": "Dial Records"}, "catalog-number": "DIAL 042"}],
+        "medium-list": [
+            {
+                "position": "1",
+                "format": "Digital Media",
+                "track-list": [
+                    {"id": "t1", "title": "Kaskade", "recording": {"id": "r1", "title": "Kaskade"}}
+                ],
+            }
+        ],
+    }
+
+
+def test_a_tagged_album_compares_clean_against_the_release_it_was_tagged_from(tmp_path):
+    """The end-to-end guarantee, and the one most worth having: tag an album
+    FROM a release, compare it BACK against that release, and nothing should
+    differ. Any mismatch between what the tagger writes and what the reader
+    reads shows up here as a difference the user would be told to fix — against
+    tags Harmonist itself just wrote."""
+    from harmonist.tagger import tag_album, tagsets_for
+
+    d = tmp_path / "Artist" / "Obreel"
+    d.mkdir(parents=True)
+    shutil.copy(Path(__file__).parent / "fixtures" / "sine.m4a", d / "01 Kaskade.m4a")
+
+    release = _release()
+    assert tag_album(d, release) == 1
+
+    tracks = [(f.name, formats.read_tags(f)) for f in sorted(d.glob("*.m4a"))]
+    fields = album_fields(tracks, tagsets_for(release)[0])
+
+    differing = [f.label for f in fields if f.differs]
+    assert differing == [], f"tagging then comparing reported a difference: {differing}"
+
+    by_label = {f.label: f for f in fields}
+    assert by_label["Label"].disk == "Dial Records"  # …and it really did read them
+    assert by_label["Cat. no."].disk == "DIAL 042"
+    assert by_label["Date"].agreement is Agreement.MATCHES
+
+
+def test_an_untagged_album_shows_musicbrainz_values_as_additions(tmp_path):
+    """Nothing on disk to disagree with, so every MB field is ONLY_MB — the
+    'lone purple line' case, not a conflict."""
+    from harmonist.tagger import tagsets_for
+
+    d = tmp_path / "Artist" / "Untagged"
+    d.mkdir(parents=True)
+    shutil.copy(Path(__file__).parent / "fixtures" / "sine.m4a", d / "01 Track.m4a")
+
+    tracks = [(f.name, formats.read_tags(f)) for f in sorted(d.glob("*.m4a"))]
+    by_label = {f.label: f for f in album_fields(tracks, tagsets_for(_release())[0])}
+
+    assert by_label["Label"].agreement is Agreement.ONLY_MB
+    assert by_label["Label"].mb == "Dial Records"
+    assert by_label["Label"].disk is None
+
+
+def test_an_unreadable_track_does_not_report_its_tags_as_missing(tmp_path):
+    """#112 reaching the comparison: a file Harmonist couldn't open must not
+    vote 'absent' and drag every field to ONLY_MB, which would tell the user
+    their tags are gone when the truth is Harmonist couldn't look."""
+    from harmonist.tagger import tagsets_for
+
+    d = tmp_path / "Artist" / "Broken"
+    d.mkdir(parents=True)
+    shutil.copy(Path(__file__).parent / "fixtures" / "sine.m4a", d / "01 Track.m4a")
+    (d / "01 Track.m4a").write_bytes(b"not audio at all")
+
+    tracks = [(f.name, formats.read_tags(f)) for f in sorted(d.glob("*.m4a"))]
+    fields = album_fields(tracks, tagsets_for(_release())[0])
+
+    assert all(f.agreement is Agreement.UNREADABLE for f in fields)
+    assert not any(f.agreement is Agreement.ONLY_MB for f in fields)
 
 
 def test_summary_when_everything_matches():

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -1,0 +1,222 @@
+"""Tests for the disk-vs-MusicBrainz comparison model (#106).
+
+Values throughout are real ones from a Bandcamp library, because the cases that
+matter are the ones a synthetic "foo" vs "bar" never produces: separator
+punctuation in an artist credit, a date MusicBrainz knows more precisely, a
+featured credit MB keeps out of the title.
+"""
+
+from __future__ import annotations
+
+from harmonist.compare import (
+    Agreement,
+    AlbumComparison,
+    Consensus,
+    Kind,
+    compare_field,
+    consensus,
+    diff_runs,
+)
+
+
+def _text(runs) -> str:
+    return "".join(r.text for r in runs)
+
+
+def _changed(runs) -> list[str]:
+    return [r.text for r in runs if r.changed]
+
+
+# ---------- consensus across tracks ----------
+
+
+def test_unanimous_tracks_give_the_album_its_value():
+    c = consensus([(f"{i:02d}.flac", "Obreel") for i in range(1, 9)])
+    assert c.value == "Obreel"
+    assert c.is_unanimous and c.agreeing == 8 and c.total == 8
+    assert c.outliers == ()
+
+
+def test_a_majority_wins_and_names_the_outliers():
+    """A field on six of eight tracks IS what the album says — with two tracks
+    to point at, not an absent value."""
+    tracks: list[tuple[str, str | None]] = [
+        (f"{i:02d}.flac", "Galán | Spieth | Guentner") for i in range(1, 7)
+    ]
+    tracks += [("07 Fernwald.mp3", "Benoît Pioulard"), ("08 Halde.mp3", None)]
+    c = consensus(tracks)
+    assert c.value == "Galán | Spieth | Guentner"
+    assert (c.agreeing, c.total) == (6, 8)
+    assert not c.is_unanimous
+    assert c.outliers == (("07 Fernwald.mp3", "Benoît Pioulard"), ("08 Halde.mp3", None))
+
+
+def test_a_tie_refuses_to_pick():
+    """The case with no honest answer. Choosing one of two equal halves would
+    state something false about the album."""
+    tracks = [(f"{i}.flac", "A") for i in range(4)] + [(f"{i}.flac", "B") for i in range(4, 8)]
+    c = consensus(tracks)
+    assert c.value is None
+    assert c.total == 8
+
+
+def test_no_tracks_and_no_values_are_distinguishable_from_a_tie_by_total():
+    assert consensus([]) == Consensus(value=None, agreeing=0, total=0)
+    empty = consensus([("01.flac", None), ("02.flac", None)])
+    assert empty.value is None and empty.total == 2
+
+
+# ---------- in-value emphasis ----------
+
+
+def test_a_date_marks_only_the_added_precision():
+    a_runs, b_runs = diff_runs("2019", "2019-03-15")
+    assert _text(a_runs) == "2019" and _text(b_runs) == "2019-03-15"
+    assert _changed(a_runs) == []
+    assert _changed(b_runs) == ["-03-15"]
+
+
+def test_separator_punctuation_is_marked_in_place():
+    """The case that motivates in-value emphasis at all: two values that look
+    identical at a glance and differ only in how the artists are joined."""
+    a_runs, b_runs = diff_runs("Galán | Spieth | Guentner", "Galán, Spieth & Guentner")
+    assert _text(a_runs) == "Galán | Spieth | Guentner"
+    assert _text(b_runs) == "Galán, Spieth & Guentner"
+    assert _changed(a_runs) and _changed(b_runs)
+    # Only the joins, never the names.
+    assert all("Spieth" not in r and "Guentner" not in r for r in _changed(a_runs))
+
+
+def test_one_contiguous_change_is_marked_however_big_it_is():
+    """Size alone is the wrong test for confetti — fragmentation is. A whole
+    featured-artist suffix is 80% of the value and perfectly readable marked."""
+    a_runs, b_runs = diff_runs("Halde (feat. Ana Quiroga)", "Halde")
+    assert _changed(a_runs) == [" (feat. Ana Quiroga)"]
+    assert _changed(b_runs) == []
+
+
+def test_wholly_different_values_get_no_emphasis():
+    """Past a third of the characters the runs stop being a signal and start
+    looking like confetti — both values render plain instead."""
+    assert diff_runs("Kaskade", "Rainbow Connection") == ((), ())
+
+
+def test_identical_values_produce_no_runs():
+    assert diff_runs("Fernwald", "Fernwald") == ((), ())
+
+
+def test_runs_reconstruct_the_originals_exactly():
+    """Emphasis must never alter what's displayed — a lost or duplicated
+    character would misreport the user's tags."""
+    for a, b in [
+        ("Obreel pt. II", "Obreel, Pt. II"),
+        ("2019", "2019-03-15"),
+        ("Halde (feat. Ana Quiroga)", "Halde"),
+    ]:
+        a_runs, b_runs = diff_runs(a, b)
+        if a_runs or b_runs:
+            assert _text(a_runs) == a
+            assert _text(b_runs) == b
+
+
+# ---------- field comparison ----------
+
+
+def test_matching_field_is_not_a_finding():
+    f = compare_field("Album", disk=consensus([("1.flac", "Obreel")]), mb="Obreel")
+    assert f.agreement is Agreement.MATCHES
+    assert not f.differs
+    assert f.disk_runs == () and f.mb_runs == ()
+
+
+def test_absent_on_disk_reads_as_only_mb_not_as_a_conflict():
+    """Label and catalogue number aren't disagreements — there's nothing of
+    yours to disagree with. The row carries the MB value alone."""
+    f = compare_field("Label", disk=consensus([("1.flac", None)]), mb="Dial Records")
+    assert f.agreement is Agreement.ONLY_MB
+    assert f.disk is None and f.mb == "Dial Records"
+    assert f.differs
+
+
+def test_a_field_musicbrainz_has_no_opinion_on_is_not_a_difference():
+    """The comment carries the Bandcamp URL. MB has no counterpart, so
+    comparing would invent a finding."""
+    f = compare_field(
+        "Comment",
+        disk=consensus([("1.flac", "https://pioulard.bandcamp.com/album/obreel")]),
+        mb=None,
+    )
+    assert f.agreement is Agreement.ONLY_DISK
+    assert not f.differs
+
+
+def test_differing_field_carries_runs_for_a_small_change():
+    f = compare_field(
+        "Date",
+        kind=Kind.SCALAR,
+        disk=consensus([("1.flac", "2019")]),
+        mb="2019-03-15",
+    )
+    assert f.agreement is Agreement.DIFFERS
+    assert f.differs
+    assert _changed(f.mb_runs) == ["-03-15"]
+
+
+def test_an_unreadable_file_is_neither_matching_nor_absent():
+    """#112: reporting a file Harmonist couldn't open as untagged is how a
+    failing disk gets an album re-tagged."""
+    f = compare_field("Artist", disk=None, mb="Galán, Spieth & Guentner", unreadable=True)
+    assert f.agreement is Agreement.UNREADABLE
+    assert f.differs  # the user has to be told, not quietly shown an absence
+
+
+def test_tracks_that_disagree_with_no_majority_say_so():
+    tracks = [(f"{i}.flac", "A") for i in range(2)] + [(f"{i}.flac", "B") for i in range(2, 4)]
+    f = compare_field("Artist", disk=consensus(tracks), mb="A")
+    assert f.agreement is Agreement.NO_CONSENSUS
+    assert f.disk is None  # nothing arbitrary was picked
+    assert f.consensus is not None and f.consensus.total == 4
+
+
+def test_an_untagged_field_is_absent_not_inconsistent():
+    """The tracks all agree — they agree there's nothing there. Reporting that
+    as "the tracks disagree" would call every field of an untagged album
+    inconsistent."""
+    f = compare_field(
+        "Label",
+        disk=consensus([("1.flac", None), ("2.flac", None), ("3.flac", None)]),
+        mb="Dial Records",
+    )
+    assert f.agreement is Agreement.ONLY_MB
+
+
+def test_a_majority_value_is_still_compared_against_musicbrainz():
+    """Uneven tagging doesn't stop the comparison — it annotates it."""
+    tracks = [(f"{i}.flac", "Obreel") for i in range(6)] + [("7.flac", "obreel")]
+    f = compare_field("Album", disk=consensus(tracks), mb="Obreel")
+    assert f.agreement is Agreement.MATCHES
+    assert f.consensus is not None
+    assert (f.consensus.agreeing, f.consensus.total) == (6, 7)
+    assert not f.consensus.is_unanimous  # the UI has something to flag
+
+
+# ---------- the album headline ----------
+
+
+def test_summary_counts_only_real_findings():
+    fields = (
+        compare_field("Album", disk=consensus([("1.flac", "Obreel")]), mb="Obreel"),
+        compare_field("Artist", disk=consensus([("1.flac", "A | B")]), mb="A, B"),
+        compare_field("Label", disk=consensus([("1.flac", None)]), mb="Dial Records"),
+        compare_field("Comment", disk=consensus([("1.flac", "https://x")]), mb=None),
+    )
+    album = AlbumComparison(fields=fields)
+    # Artist and Label; NOT the matching album title, NOT the comment.
+    assert len(album.differing) == 2
+    assert album.summary == "2 of 4 fields differ"
+
+
+def test_summary_when_everything_matches():
+    fields = (compare_field("Album", disk=consensus([("1.flac", "Obreel")]), mb="Obreel"),)
+    assert AlbumComparison(fields=fields).summary == "all 1 fields match"
+    assert AlbumComparison().summary == "nothing to compare"

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -51,13 +51,22 @@ def test_a_majority_wins_and_names_the_outliers():
     assert c.outliers == (("07 Fernwald.mp3", "Benoît Pioulard"), ("08 Halde.mp3", None))
 
 
-def test_a_tie_refuses_to_pick():
-    """The case with no honest answer. Choosing one of two equal halves would
-    state something false about the album."""
-    tracks = [(f"{i}.flac", "A") for i in range(4)] + [(f"{i}.flac", "B") for i in range(4, 8)]
+def test_a_tie_is_broken_by_track_order():
+    """A 4/4 split has no most-common value, so track 1 decides — a rule that
+    fits in one sentence. The count beside it already tells the user this isn't
+    the album's settled answer."""
+    tracks = [(f"{i}.flac", "B") for i in range(4)] + [(f"{i}.flac", "A") for i in range(4, 8)]
     c = consensus(tracks)
-    assert c.value is None
-    assert c.total == 8
+    assert c.value == "B"  # track 1's value, not the alphabetically first
+    assert (c.agreeing, c.total, c.distinct) == (4, 8, 2)
+    assert not c.is_unanimous
+
+
+def test_a_tie_skips_tracks_with_no_value_at_all():
+    """Track 1 means the first track that actually has a value — an untagged
+    opening track shouldn't decide the album has no artist."""
+    tracks: list[tuple[str, str | None]] = [("01.flac", None), ("02.flac", "B"), ("03.flac", "A")]
+    assert consensus(tracks).value == "B"
 
 
 def test_no_tracks_and_no_values_are_distinguishable_from_a_tie_by_total():
@@ -170,12 +179,17 @@ def test_an_unreadable_file_is_neither_matching_nor_absent():
     assert f.differs  # the user has to be told, not quietly shown an absence
 
 
-def test_tracks_that_disagree_with_no_majority_say_so():
+def test_evenly_split_tracks_still_produce_a_comparison():
+    """Uneven tagging must not suppress the row — the comparison is made against
+    track 1's value, and the consensus counts travel alongside so the UI can say
+    how shaky it is."""
     tracks = [(f"{i}.flac", "A") for i in range(2)] + [(f"{i}.flac", "B") for i in range(2, 4)]
     f = compare_field("Artist", disk=consensus(tracks), mb="A")
-    assert f.agreement is Agreement.NO_CONSENSUS
-    assert f.disk is None  # nothing arbitrary was picked
-    assert f.consensus is not None and f.consensus.total == 4
+    assert f.agreement is Agreement.MATCHES  # track 1 says "A", and so does MB
+    assert f.disk == "A"
+    assert f.consensus is not None
+    assert (f.consensus.agreeing, f.consensus.total) == (2, 4)
+    assert not f.consensus.is_unanimous  # ...but only half the album agrees
 
 
 def test_an_untagged_field_is_absent_not_inconsistent():

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -142,6 +142,72 @@ def test_read_scan_fields_matches_individual_reads(tmp_path, ext, fixture):
     assert sf.codec == formats.describe(f)
 
 
+# ---------- the read side of the comparison (#106) ----------
+
+
+@pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
+def test_read_tags_recovers_what_the_tagger_wrote(tmp_path, ext, fixture):
+    """The real test of the read side: tag a file from a MusicBrainz release,
+    read it back, and check every field survived the round trip.
+
+    Each format stores these somewhere different — MP4 freeform `----` atoms,
+    ID3 `TPUB` and `TXXX` frames, Vorbis comments — so a mapping that's wrong in
+    one direction only shows up here. Comparing against MusicBrainz with a
+    field Harmonist can't read back would report a difference that isn't real.
+    """
+    d = _make_album(tmp_path, fixture)
+    tag_album(d, _release_one_track())
+    f = next(d.glob(f"*{ext}"))
+
+    t = formats.read_tags(f)
+    assert t.unreadable is False
+    assert t.album == "Format Album"
+    assert t.album_artist == "Format Artist"
+    assert t.artist == "Format Artist"
+    assert t.title == "The Track"
+    assert t.date == "2022-03-04"
+    assert t.label == "Test Label"
+    assert t.catalog_number == "CAT-9"
+    assert t.barcode == "5051234567890"
+    assert t.track_num == 1
+    assert t.duration_ms is not None and 900 <= t.duration_ms <= 1200
+
+
+@pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
+def test_read_tags_reports_absent_fields_as_none_not_empty_string(tmp_path, ext, fixture):
+    """An untagged file must come back with None, not "" — the comparison
+    treats None as "absent" and would render an empty string as a value that
+    differs from MusicBrainz."""
+    d = _make_album(tmp_path, fixture)
+    t = formats.read_tags(next(d.glob(f"*{ext}")))
+
+    assert t.unreadable is False  # readable, just untagged
+    for name in ("album", "album_artist", "artist", "title", "label", "catalog_number"):
+        assert getattr(t, name) is None, f"{name} came back {getattr(t, name)!r}"
+
+
+@pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
+def test_read_tags_flags_a_file_it_cannot_open(tmp_path, ext, fixture):
+    """#112's distinction, at the field-read layer this time."""
+    d = _make_album(tmp_path, fixture)
+    f = next(d.glob(f"*{ext}"))
+    f.write_bytes(b"not audio at all")
+
+    t = formats.read_tags(f)
+    assert t.unreadable is True
+    assert t.album is None  # …and still looks empty, which is the trap
+
+
+def test_read_tags_on_an_unsupported_extension_is_empty_not_unreadable(tmp_path):
+    """Nothing went wrong — there's simply nothing to read. Flagging it would
+    put a "couldn't read this" notice on a stray text file."""
+    p = tmp_path / "notes.txt"
+    p.write_text("sleeve notes")
+    t = formats.read_tags(p)
+    assert t.unreadable is False
+    assert t.album is None
+
+
 _TINY_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00" + b"\x00" * 40
 
 

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -822,29 +822,46 @@ def test_a_readable_untagged_file_is_not_flagged_unreadable(tmp_path):
     assert fields.album_id is None
 
 
-def test_a_tagged_album_with_one_unreadable_file_does_not_revert_to_tagging(tmp_path, caplog):
-    """The user-visible bug: a COMPLETE album on a failing disk reappeared in
-    the inbox as stuck mid-tagging, inviting a re-tag — i.e. inviting a WRITE to
-    the drive that just failed to read."""
+def _tag_with_mbid(album_dir: Path, mbid: str) -> None:
     from mutagen.mp4 import MP4
 
-    d = _make_album_dir(tmp_path, "Artist", "Failing", n_tracks=3)
-    for f in sorted(d.glob("*.m4a")):
+    for f in sorted(album_dir.glob("*.m4a")):
         audio = MP4(f)
-        audio[ATOM_MB_ALBUM_ID] = [b"rel-failing"]
+        audio[ATOM_MB_ALBUM_ID] = [mbid.encode()]
         audio.save()
+
+
+def test_an_unreadable_track_makes_the_album_incomplete(tmp_path, caplog):
+    """A track Harmonist can't open is, for every purpose the user cares about,
+    a track they don't have — so it lands in the same state as an absent one.
+
+    It must NOT read as TAGGING (the original bug), which invites a re-tag —
+    a write to the drive that just failed a read."""
+    d = _make_album_dir(tmp_path, "Artist", "Failing", n_tracks=3)
+    _tag_with_mbid(d, "rel-failing")
     sc.write(d, Sidecar(mb_release_id="rel-failing", tagged_at=datetime.now(UTC)))
     assert scan(tmp_path)[0].state == AlbumState.COMPLETE  # before the disk trouble
 
-    for f in sorted(d.glob("*.m4a")):
-        _make_unreadable(f)
+    _make_unreadable(min(d.glob("*.m4a")))
 
     with caplog.at_level("WARNING"):
         album = scan(tmp_path)[0]
 
-    assert album.state is not AlbumState.TAGGING
-    assert album.state == AlbumState.COMPLETE
+    assert album.state == AlbumState.INCOMPLETE
     assert any("could not be read" in r.message for r in caplog.records)
+
+
+def test_one_corrupt_track_is_not_hidden_by_the_others_being_fine(tmp_path):
+    """The ordering that matters: the check runs BEFORE the tagged/untagged
+    branch. Two good files still carry the MBID, so a later check would call the
+    album COMPLETE and the corruption would never be shown."""
+    d = _make_album_dir(tmp_path, "Artist", "OneBad", n_tracks=3)
+    _tag_with_mbid(d, "rel-onebad")
+    sc.write(d, Sidecar(mb_release_id="rel-onebad", tagged_at=datetime.now(UTC)))
+
+    _make_unreadable(min(d.glob("*.m4a")))
+
+    assert scan(tmp_path)[0].state == AlbumState.INCOMPLETE
 
 
 def test_a_genuinely_untagged_album_still_reads_as_tagging(tmp_path):

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -8,8 +8,8 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
+from harmonist import formats, tagger
 from harmonist import sidecar as sc
-from harmonist import tagger
 from harmonist.models import (
     AlbumState,
     BandcampInfo,
@@ -791,3 +791,66 @@ def test_scan_cache_prunes_removed_album(tmp_path):
     shutil.rmtree(d)
     scanner.scan(tmp_path, album_cache=cache)
     assert d not in cache  # stale entry pruned
+
+
+# ---------- an unreadable file is not an untagged one (#112) ----------
+
+
+def _make_unreadable(path: Path) -> None:
+    """Corrupt a file so mutagen can't open it — the observable shape of a
+    permission error, a truncation, or a disk starting to fail."""
+    path.write_bytes(b"not audio at all")
+
+
+def test_a_file_that_cannot_be_read_is_flagged_rather_than_read_as_untagged(tmp_path):
+    """The root of #112: an unopenable file returned all-None fields, which is
+    byte-identical to a readable file carrying no tags."""
+    d = _make_album_dir(tmp_path, "Artist", "Corrupt", n_tracks=1)
+    f = min(d.glob("*.m4a"))
+    _make_unreadable(f)
+
+    fields = formats.read_scan_fields(f)
+    assert fields.unreadable is True
+    assert fields.album_id is None  # …and it still looks empty, which is the trap
+
+
+def test_a_readable_untagged_file_is_not_flagged_unreadable(tmp_path):
+    """The control. Without it the flag could simply be always-on."""
+    d = _make_album_dir(tmp_path, "Artist", "Untagged", n_tracks=1)
+    fields = formats.read_scan_fields(min(d.glob("*.m4a")))
+    assert fields.unreadable is False
+    assert fields.album_id is None
+
+
+def test_a_tagged_album_with_one_unreadable_file_does_not_revert_to_tagging(tmp_path, caplog):
+    """The user-visible bug: a COMPLETE album on a failing disk reappeared in
+    the inbox as stuck mid-tagging, inviting a re-tag — i.e. inviting a WRITE to
+    the drive that just failed to read."""
+    from mutagen.mp4 import MP4
+
+    d = _make_album_dir(tmp_path, "Artist", "Failing", n_tracks=3)
+    for f in sorted(d.glob("*.m4a")):
+        audio = MP4(f)
+        audio[ATOM_MB_ALBUM_ID] = [b"rel-failing"]
+        audio.save()
+    sc.write(d, Sidecar(mb_release_id="rel-failing", tagged_at=datetime.now(UTC)))
+    assert scan(tmp_path)[0].state == AlbumState.COMPLETE  # before the disk trouble
+
+    for f in sorted(d.glob("*.m4a")):
+        _make_unreadable(f)
+
+    with caplog.at_level("WARNING"):
+        album = scan(tmp_path)[0]
+
+    assert album.state is not AlbumState.TAGGING
+    assert album.state == AlbumState.COMPLETE
+    assert any("could not be read" in r.message for r in caplog.records)
+
+
+def test_a_genuinely_untagged_album_still_reads_as_tagging(tmp_path):
+    """Control for the fix: unreadable files must stop the downgrade, but a
+    readable album that really isn't tagged yet still has to reach TAGGING, or
+    the fix would strand albums mid-pipeline."""
+    d = _make_album_dir(tmp_path, "Artist", "NotYet", n_tracks=2)
+    sc.write(d, Sidecar(mb_release_id="rel-notyet", tagged_at=datetime.now(UTC)))
+    assert scan(tmp_path)[0].state == AlbumState.TAGGING


### PR DESCRIPTION
First slice of #106 — the [agreed design](https://github.com/randomphrase/harmonist/issues/106#issuecomment-5208203434). Pure functions over values: no I/O, no mutagen, no MusicBrainz client, no UI. #86 wants the same comparison rendered into the audit log rather than a page, so the model belongs in neither.

## What it encodes

**Agreement is the answer, not a diff.** Most fields match, and those carry no runs and render as one plain line. The register is deliberately not a code diff — most real differences here are formatting (a Bandcamp `A | B` credit against MusicBrainz's join phrases, a featured credit MB keeps out of the title) and calling those errors would be wrong.

**A per-album field is really N per-track fields** that usually agree. `consensus()` reports what most tracks say, how many, and which disagree — and **refuses to pick on a tie** rather than inventing an answer.

**"Couldn't read it" is a third state** (#112), distinct from both "matches" and "differs".

## Two things the tests caught

Both were real bugs in the first cut, and both are pinned by a test:

- **Emphasis was dropped on proportion alone**, which killed exactly the case worth marking: `2019` → `2019-03-15` changes 60% of the characters. Fragmentation is what makes marking unreadable, not size — so a change is now dropped only when it is *both* large and scattered, and one contiguous run is always marked however big.
- **An untagged field looked identical to a tie** — both leave the consensus value `None`. Without `distinct` counting how many values the tracks actually carry, every field of an untagged album reported as "the tracks disagree".

## Testing

21 tests, using real values from a Bandcamp library rather than `foo`/`bar` — the cases that matter are separator punctuation in an artist credit, a date MB knows more precisely, a featured credit. One asserts the runs reconstruct the originals exactly, since emphasis that drops or duplicates a character would misreport the user's tags.

769 green.

Review gate: pure module, no I/O — touches no audit path, no sidecar field, no state derivation, no MB call budget, no transition.

Part of #106