### PR TITLE
Escape message text before putting it into HTML responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ versions follow [semantic versioning](https://semver.org).
 - A track numbered by vinyl side (`A1`, `B2`) no longer breaks the album page
   on FLAC, Ogg and Opus files (#137).
 
+- MusicBrainz error messages are now escaped before being shown, so angle
+  brackets in an upstream error render as text rather than as markup (#142).
+
 ## [1.5.0] - 2026-08-09
 
 ### Added

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import html
 import json
 import logging
 import os
@@ -2506,8 +2507,11 @@ def _register_routes(app: FastAPI) -> None:
         try:
             release = mb_lookup.fetch_release(sc.mb_release_id)
         except mb_lookup.MBError as e:
+            # Escaped: an MBError wraps upstream musicbrainzngs text, so the
+            # message originates off-box and must not reach the DOM as markup.
             return HTMLResponse(
-                f'<p class="text-2xs text-red-700 mt-2">Couldn\'t fetch from MusicBrainz: {e}</p>'
+                '<p class="text-2xs text-red-700 mt-2">Couldn\'t fetch from '
+                f"MusicBrainz: {html.escape(str(e))}</p>"
             )
         # No `assess_match` here any more (#135). It re-opened every file in the
         # album for a duration and a title that `_album_comparison` had just
@@ -3124,13 +3128,24 @@ def _process_rss_bytes() -> int | None:
 
 
 def _flash(message: str, *, level: str) -> str:
-    """Render a small flash message fragment for HTMX swap-or-replace."""
+    """Render a small flash message fragment for HTMX swap-or-replace.
+
+    `message` is escaped: it routinely carries `str(e)` from a failed MB call,
+    and album/track text read off disk. Plain text only — no caller passes
+    markup, and any that wanted to would have to render it elsewhere. The
+    client half of this path already escapes (the `esc()` helper behind the
+    `harmonist-status` trigger in index.html); this keeps the server-rendered
+    fragment consistent with it.
+    """
     classes = {
         "info": "bg-bc-teal/10 text-bc-teal border-bc-teal/30",
         "warning": "bg-amber-500/10 text-amber-300 border-amber-500/30",
         "error": "bg-red-500/10 text-red-300 border-red-500/30",
     }.get(level, "bg-slate-700/30 text-slate-200 border-slate-600")
-    return f'<div class="px-4 py-2 border rounded {classes} text-sm font-bold">{message}</div>'
+    return (
+        f'<div class="px-4 py-2 border rounded {classes} text-sm font-bold">'
+        f"{html.escape(message)}</div>"
+    )
 
 
 def _live_album_ref(album: Album) -> tuple[str | None, str]:

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -17,6 +17,7 @@ import pytest
 from fastapi.testclient import TestClient
 from mutagen.mp4 import MP4
 
+from harmonist import mb_lookup
 from harmonist import sidecar as sc
 from harmonist.activity_store import Level
 from harmonist.config import BandcampConfig, Config, PathsConfig, ServerConfig, TestConfig
@@ -1670,6 +1671,28 @@ def test_manual_candidates_lists_store_url_releases(client, cfg, monkeypatch):
     assert "(24-bit)" in r.text  # disambiguation rendered distinctly
     assert f"2{cross}CD" in r.text  # media summary
     assert r.text.count('name="mbid"') == 2  # a Use button per release
+
+
+def test_recheck_escapes_mb_error_text_in_the_flash(client, cfg, monkeypatch):
+    """#142: an MBError message reaches the flash fragment as text, not markup.
+
+    The message wraps upstream musicbrainzngs output, so it originates off-box.
+    The diagnostic still has to be readable — this pins escaped, not dropped.
+    """
+    d = _needs_mbid_with_store_url(cfg, "Hostile", "https://x.bandcamp.com/album/y")
+    aid = _id_for(cfg, d)
+
+    def boom(url):
+        raise mb_lookup.MBError('MB request failed: <script>alert(1)</script> & "quoted"')
+
+    monkeypatch.setattr("harmonist.mb_lookup.lookup_by_bandcamp_url", boom)
+
+    r = client.post(f"/recheck/{aid}")
+    assert r.status_code == 200
+    assert "<script>" not in r.text
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in r.text
+    assert "&amp;" in r.text and "&quot;quoted&quot;" in r.text
+    assert "MB lookup failed" in r.text  # the diagnostic survives, escaped
 
 
 def test_recheck_multiple_matches_shows_picker_not_autopick(client, cfg, monkeypatch):
@@ -3957,6 +3980,22 @@ def test_library_compare_renders_the_tracklist(client, cfg, monkeypatch):
     assert r.status_code == 200
     assert "track-diff" in r.text
     assert "Track 1" in r.text  # MusicBrainz's title for the one track
+
+
+def test_library_compare_escapes_mb_error_text(client, cfg, monkeypatch):
+    """#142: the compare panel's fetch-failure fragment escapes the MB message."""
+    d = _make_tagged_album(cfg, "Hostile", mbid="rel-hostile", tagged_at=datetime.now(UTC))
+
+    def boom(mbid):
+        raise mb_lookup.MBError("MB ResponseError: <img src=x onerror=alert(1)>")
+
+    monkeypatch.setattr("harmonist.web.main.mb_lookup.fetch_release", boom)
+
+    r = client.get(f"/library/{_id_for(cfg, d)}/compare")
+    assert r.status_code == 200
+    assert "<img" not in r.text
+    assert "&lt;img src=x onerror=alert(1)&gt;" in r.text
+    assert "Couldn't fetch from MusicBrainz" in r.text
 
 
 # ---------- the per-field tag comparison on the album page (#106) ----------


### PR DESCRIPTION
Two places built a response body with an f-string and no escaping, so any `<`, `>`, `&` or quote in the interpolated text reached the operator's DOM as markup rather than as characters: the MB-compare handler's fetch-failure fragment (`web/main.py:2510`), and `_flash()` (`web/main.py:3133`), which ~14 call sites funnel `str(e)` through.

The text is not all locally sourced. An `MBError` wraps upstream musicbrainzngs output (`MB ResponseError: {e}`), so the message originates off-box. The client half of this path already knew that — the status-bar JS in `templates/index.html` runs every trigger field through an `esc()` helper — which left the same text safe on one route and not the other.

`html.escape()` both sites. No caller passes markup through either, so this is behavior-preserving for every message Harmonist actually emits, and the diagnostic stays intact and readable.

## Tests

Two, both verified failing before the fix and passing after:

- `test_recheck_escapes_mb_error_text_in_the_flash` — the `_flash()` path.
- `test_library_compare_escapes_mb_error_text` — the compare-panel path.

Each asserts the payload is escaped *and* that the diagnostic survives, so a future "just drop the error text" change trips them.

`make check` green locally (833 passed, 16 skipped). No template edits, so no CSS rebuild.

## Relationship to CodeQL alert #13

Not a response to it. Alert #13 (`py/stack-trace-exposure`) sits on one of these lines and stays dismissed as accepted risk per #63 — the MB error text is the diagnostic a self-hosted single operator needs. CodeQL tracks exception text reaching a response regardless of escaping, so this neither clears that alert nor is meant to. #13 was a re-flag of the already-dismissed #11/#12 after the line moved.

Fixes #142