### PR TITLE
Clear the tags Harmonist owns before writing new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Re-tagging an MP3 or M4A now **removes** Harmonist's tags that the new release
+  doesn't carry, instead of leaving them behind. Correcting a mis-tag previously
+  left the wrong release's label, catalogue number, barcode and release country
+  on the files indefinitely; FLAC and Opus were already correct (#149).
+- The Media field (CD, Vinyl, …) now reads back correctly from MP3 files.
+  Harmonist wrote it to one frame and read it from another, so every MP3 album it
+  had tagged showed Media as missing on the album page, permanently flagged as
+  differing from MusicBrainz (#149).
+
 ## [1.6.0] - 2026-08-10
 
 ### Added

--- a/docs/design.md
+++ b/docs/design.md
@@ -574,6 +574,23 @@ The existing `©cmt` (Bandcamp comment) is **preserved** if present — it's the
 
 The current code's `MUSICBRAINZ_RELEASEID` atom is **non-Picard** and gets removed by the tagger when it writes the correct atoms.
 
+### The tags Harmonist owns
+
+`formats/owned.py` names them, and the list is the concrete form of the promise not to touch tags Harmonist doesn't understand: **these fields, and only these, are the ones it writes, overwrites, and removes.** Each backend maps `Owned` to its native keys and clears that mapping before writing, so a field absent from the new `TagSet` — a release with no catalogue number, say — is *removed* rather than left stale from a previous tagging. Before #149 only the Vorbis backend did this, so a mis-tag correction left the wrong release's label on MP3 and M4A files indefinitely.
+
+Everything not in the set is left exactly as found: the comment carrying a recovered Bandcamp URL, a genre tagged elsewhere (Harmonist writes none — see #12), and any arbitrary tag another tool put there (ReplayGain, encoder settings, user ratings).
+
+`Owned` is split by **scope** — whether a field's value depends on which track it is:
+
+- **Album** — `mb_album_id`, `album`, `album_artist`, `album_artist_sort`, `mb_album_artist_ids`, `mb_release_group_id`, `mb_album_type`, `mb_album_status`, `mb_album_country`, `date`, `original_date`, `script`, `label`, `catalog_number`, `barcode`, `asin`, `disc_total`.
+- **Track** — `title`, `artist`, `artist_sort`, `artists`, `track_num`, `track_total`, `disc_num`, `media`, `mb_track_id`, `mb_release_track_id`, `mb_artist_ids`, `isrcs`.
+
+`media`, `disc_num` and `track_total` are derived from the *medium*, so they are track-scoped even though they look album-level: on a 2-disc release, or a CD+DVD set, they genuinely differ between tracks. The scope drives the tagging audit records (#86), which record an album-level change once per album rather than once per track.
+
+The `Owned` member values are exactly the `TagSet` attribute names, and a test asserts the two sets match. That guards drift in both directions: a new `TagSet` field nobody classified would be written but never cleared, and an `Owned` member with no field behind it would clear a tag Harmonist never writes.
+
+**Artwork is deliberately not in the set.** Embedded cover art is not a tag here — `tagger.tag_album` passes `cover=None` when the tracks carry differing per-track images precisely so `write_tags` leaves them alone, and clearing artwork with the owned set would make that protection a no-op. Per-track artwork is a third category that fits neither scope, which neither MusicBrainz nor Picard really models; it is handled in the tagger. See #131.
+
 ### Cover art (mandatory)
 
 Plex with the MusicBrainz agent can fetch its own artwork from external sources, but **Navidrome does not** — it reads from embedded tags and `cover.jpg` only. Navidrome is the strict consumer; we design for it.

--- a/src/harmonist/formats/_vorbis.py
+++ b/src/harmonist/formats/_vorbis.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from mutagen.flac import Picture
 
+from .owned import Owned
 from .types import ScanFields, TagSet, TrackTags
 
 # Vorbis comment keys (uppercase by convention; lookups are case-insensitive).
@@ -59,40 +60,42 @@ KEY_COMMENT = "COMMENT"
 KEY_GENRE = "GENRE"
 KEY_DESCRIPTION = "DESCRIPTION"
 
-# Keys this tagger manages on write (cleared then rewritten). COMMENT /
-# DESCRIPTION are deliberately excluded so a recovered Bandcamp URL survives.
-_MANAGED_KEYS = (
-    KEY_ALBUM_ID,
-    KEY_ALBUM_ARTIST_ID,
-    KEY_RELEASE_GROUP_ID,
-    KEY_TRACK_ID,
-    KEY_RELEASE_TRACK_ID,
-    KEY_ARTIST_ID,
-    KEY_ISRC,
-    KEY_RELEASE_TYPE,
-    KEY_RELEASE_STATUS,
-    KEY_RELEASE_COUNTRY,
-    KEY_TITLE,
-    KEY_ALBUM,
-    KEY_ARTIST,
-    KEY_ALBUM_ARTIST,
-    KEY_ARTIST_SORT,
-    KEY_ALBUM_ARTIST_SORT,
-    KEY_ARTISTS,
-    KEY_DATE,
-    KEY_ORIGINAL_DATE,
-    KEY_ORIGINAL_YEAR,
-    KEY_SCRIPT,
-    KEY_TRACK_NUMBER,
-    KEY_TRACK_TOTAL,
-    KEY_DISC_NUMBER,
-    KEY_DISC_TOTAL,
-    KEY_LABEL,
-    KEY_CATALOG,
-    KEY_BARCODE,
-    KEY_ASIN,
-    KEY_MEDIA,
-)
+# The Vorbis keys behind each owned field (#149). COMMENT / DESCRIPTION are
+# absent so a recovered Bandcamp URL survives a retag, GENRE because Harmonist
+# doesn't write one (#12), and the picture block because per-track artwork is
+# preserved deliberately — see `owned.py`.
+OWNED_KEYS: dict[Owned, tuple[str, ...]] = {
+    Owned.MB_ALBUM_ID: (KEY_ALBUM_ID,),
+    Owned.ALBUM: (KEY_ALBUM,),
+    Owned.ALBUM_ARTIST: (KEY_ALBUM_ARTIST,),
+    Owned.ALBUM_ARTIST_SORT: (KEY_ALBUM_ARTIST_SORT,),
+    Owned.MB_ALBUM_ARTIST_IDS: (KEY_ALBUM_ARTIST_ID,),
+    Owned.MB_RELEASE_GROUP_ID: (KEY_RELEASE_GROUP_ID,),
+    Owned.MB_ALBUM_TYPE: (KEY_RELEASE_TYPE,),
+    Owned.MB_ALBUM_STATUS: (KEY_RELEASE_STATUS,),
+    Owned.MB_ALBUM_COUNTRY: (KEY_RELEASE_COUNTRY,),
+    Owned.DATE: (KEY_DATE,),
+    # One field, two keys: Picard writes the year alongside the full date.
+    Owned.ORIGINAL_DATE: (KEY_ORIGINAL_DATE, KEY_ORIGINAL_YEAR),
+    Owned.SCRIPT: (KEY_SCRIPT,),
+    Owned.LABEL: (KEY_LABEL,),
+    Owned.CATALOG_NUMBER: (KEY_CATALOG,),
+    Owned.BARCODE: (KEY_BARCODE,),
+    Owned.ASIN: (KEY_ASIN,),
+    Owned.DISC_TOTAL: (KEY_DISC_TOTAL,),
+    Owned.TITLE: (KEY_TITLE,),
+    Owned.ARTIST: (KEY_ARTIST,),
+    Owned.ARTIST_SORT: (KEY_ARTIST_SORT,),
+    Owned.ARTISTS: (KEY_ARTISTS,),
+    Owned.TRACK_NUM: (KEY_TRACK_NUMBER,),
+    Owned.TRACK_TOTAL: (KEY_TRACK_TOTAL,),
+    Owned.DISC_NUM: (KEY_DISC_NUMBER,),
+    Owned.MEDIA: (KEY_MEDIA,),
+    Owned.MB_TRACK_ID: (KEY_TRACK_ID,),
+    Owned.MB_RELEASE_TRACK_ID: (KEY_RELEASE_TRACK_ID,),
+    Owned.MB_ARTIST_IDS: (KEY_ARTIST_ID,),
+    Owned.ISRCS: (KEY_ISRC,),
+}
 
 
 def _first_int(value: str | None) -> int | None:
@@ -270,11 +273,14 @@ class VorbisTagger:
             audio.add_tags()
         tags = audio.tags
 
-        # Clear the keys we manage; leave COMMENT/DESCRIPTION (and anything
-        # else) alone.
-        for key in _MANAGED_KEYS:
-            if key in tags:
-                del tags[key]
+        # Clear every owned key before writing, so a field absent from this
+        # TagSet is REMOVED rather than left stale from a previous tagging
+        # (#149). Anything not owned — COMMENT/DESCRIPTION, GENRE, arbitrary
+        # user tags, the picture block — is untouched.
+        for keys in OWNED_KEYS.values():
+            for key in keys:
+                if key in tags:
+                    del tags[key]
 
         tags[KEY_ALBUM_ID] = [tagset.mb_album_id]
         if tagset.mb_album_artist_ids:

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from mutagen.mp4 import MP4, MP4Cover
 
+from .owned import Owned
 from .types import ScanFields, TagSet, TrackTags
 
 EXTENSIONS = (".m4a", ".mp4")
@@ -65,6 +66,48 @@ ATOM_ALBUM_ARTIST_SORT = "soaa"
 ATOM_TRACK_NUM = "trkn"
 ATOM_DISC_NUM = "disk"
 ATOM_COVER = "covr"
+
+
+# The MP4 atoms behind each owned field (#149). ATOM_COMMENT is absent so a
+# recovered Bandcamp URL survives a retag, ATOM_GENRE because Harmonist doesn't
+# write one (#12), and ATOM_COVER because per-track artwork is preserved
+# deliberately — see `owned.py`.
+OWNED_ATOMS: dict[Owned, tuple[str, ...]] = {
+    # The legacy atom rides along with the id it was an older spelling of, so
+    # the cleanup happens by construction rather than as a separate step.
+    Owned.MB_ALBUM_ID: (ATOM_MB_ALBUM_ID, LEGACY_RELEASE_ID),
+    Owned.ALBUM: (ATOM_ALBUM,),
+    Owned.ALBUM_ARTIST: (ATOM_ALBUM_ARTIST,),
+    Owned.ALBUM_ARTIST_SORT: (ATOM_ALBUM_ARTIST_SORT,),
+    Owned.MB_ALBUM_ARTIST_IDS: (ATOM_MB_ALBUM_ARTIST_ID,),
+    Owned.MB_RELEASE_GROUP_ID: (ATOM_MB_RELEASE_GROUP_ID,),
+    Owned.MB_ALBUM_TYPE: (ATOM_MB_ALBUM_TYPE,),
+    Owned.MB_ALBUM_STATUS: (ATOM_MB_ALBUM_STATUS,),
+    Owned.MB_ALBUM_COUNTRY: (ATOM_MB_ALBUM_COUNTRY,),
+    Owned.DATE: (ATOM_DATE,),
+    Owned.ORIGINAL_DATE: (ATOM_ORIGINAL_DATE, ATOM_ORIGINAL_YEAR),
+    Owned.SCRIPT: (ATOM_SCRIPT,),
+    Owned.LABEL: (ATOM_LABEL,),
+    Owned.CATALOG_NUMBER: (ATOM_CATALOG,),
+    Owned.BARCODE: (ATOM_BARCODE,),
+    Owned.ASIN: (ATOM_ASIN,),
+    # `trkn` and `disk` each carry the (number, total) pair in one atom, so two
+    # owned fields map to the same atom. Clearing is idempotent, and both are
+    # always written together below.
+    Owned.DISC_TOTAL: (ATOM_DISC_NUM,),
+    Owned.TITLE: (ATOM_TITLE,),
+    Owned.ARTIST: (ATOM_ARTIST,),
+    Owned.ARTIST_SORT: (ATOM_ARTIST_SORT,),
+    Owned.ARTISTS: (ATOM_ARTISTS,),
+    Owned.TRACK_NUM: (ATOM_TRACK_NUM,),
+    Owned.TRACK_TOTAL: (ATOM_TRACK_NUM,),
+    Owned.DISC_NUM: (ATOM_DISC_NUM,),
+    Owned.MEDIA: (ATOM_MEDIA,),
+    Owned.MB_TRACK_ID: (ATOM_MB_TRACK_ID,),
+    Owned.MB_RELEASE_TRACK_ID: (ATOM_MB_RELEASE_TRACK_ID,),
+    Owned.MB_ARTIST_IDS: (ATOM_MB_ARTIST_ID,),
+    Owned.ISRCS: (ATOM_ISRC,),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +259,14 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> None:
     """
     audio = MP4(path)
 
+    # Clear every owned atom before writing, so a field absent from this TagSet
+    # is REMOVED rather than left stale from a previous tagging (#149). Anything
+    # not owned — the comment, genre, arbitrary atoms, the cover — is untouched.
+    for atoms in OWNED_ATOMS.values():
+        for atom in atoms:
+            if atom in audio:
+                del audio[atom]
+
     # ---- Album-level MBID atoms ----
     audio[ATOM_MB_ALBUM_ID] = [tagset.mb_album_id.encode("utf-8")]
     if tagset.mb_album_artist_ids:
@@ -279,10 +330,7 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> None:
         fmt = MP4Cover.FORMAT_PNG if cover[:4] == b"\x89PNG" else MP4Cover.FORMAT_JPEG
         audio[ATOM_COVER] = [MP4Cover(cover, imageformat=fmt)]
 
-    # ---- Cleanup legacy atom ----
-    if LEGACY_RELEASE_ID in audio:
-        del audio[LEGACY_RELEASE_ID]
-
+    # The legacy atom is cleared with the owned set above, not here.
     # ATOM_COMMENT is intentionally NOT touched.
 
     audio.save()

--- a/src/harmonist/formats/mp3.py
+++ b/src/harmonist/formats/mp3.py
@@ -41,6 +41,7 @@ from mutagen.id3 import (
 )
 from mutagen.mp3 import MP3
 
+from .owned import Owned
 from .types import ScanFields, TagSet, TrackTags
 
 EXTENSIONS = (".mp3",)
@@ -61,6 +62,51 @@ TXXX_BARCODE = "BARCODE"
 TXXX_ASIN = "ASIN"
 TXXX_ARTISTS = "ARTISTS"
 TXXX_SCRIPT = "SCRIPT"
+
+
+# The ID3 frames behind each owned field (#149), by mutagen HashKey — which for
+# a user-text frame is "TXXX:<description>" and for the recording MBID is
+# "UFID:<owner>". COMM is absent so a recovered Bandcamp URL survives a retag,
+# TCON because Harmonist doesn't write a genre (#12), and APIC because per-track
+# artwork is preserved deliberately — see `owned.py`.
+#
+# This table is the single definition the read and write paths share. They
+# disagreed before it existed: `media` was written to TMED and read back from
+# TXXX:MEDIA, so it never round-tripped.
+OWNED_FRAMES: dict[Owned, tuple[str, ...]] = {
+    Owned.MB_ALBUM_ID: (f"TXXX:{TXXX_ALBUM_ID}",),
+    Owned.ALBUM: ("TALB",),
+    Owned.ALBUM_ARTIST: ("TPE2",),
+    Owned.ALBUM_ARTIST_SORT: ("TSO2",),
+    Owned.MB_ALBUM_ARTIST_IDS: (f"TXXX:{TXXX_ALBUM_ARTIST_ID}",),
+    Owned.MB_RELEASE_GROUP_ID: (f"TXXX:{TXXX_RELEASE_GROUP_ID}",),
+    Owned.MB_ALBUM_TYPE: (f"TXXX:{TXXX_ALBUM_TYPE}",),
+    Owned.MB_ALBUM_STATUS: (f"TXXX:{TXXX_ALBUM_STATUS}",),
+    Owned.MB_ALBUM_COUNTRY: (f"TXXX:{TXXX_ALBUM_COUNTRY}",),
+    Owned.DATE: ("TDRC",),
+    Owned.ORIGINAL_DATE: ("TDOR",),
+    Owned.SCRIPT: (f"TXXX:{TXXX_SCRIPT}",),
+    Owned.LABEL: ("TPUB",),
+    Owned.CATALOG_NUMBER: (f"TXXX:{TXXX_CATALOG}",),
+    Owned.BARCODE: (f"TXXX:{TXXX_BARCODE}",),
+    Owned.ASIN: (f"TXXX:{TXXX_ASIN}",),
+    # TRCK and TPOS each carry "n/total" in one frame, so two owned fields map
+    # to the same frame. Clearing is idempotent, and both are always written
+    # together below.
+    Owned.DISC_TOTAL: ("TPOS",),
+    Owned.TITLE: ("TIT2",),
+    Owned.ARTIST: ("TPE1",),
+    Owned.ARTIST_SORT: ("TSOP",),
+    Owned.ARTISTS: (f"TXXX:{TXXX_ARTISTS}",),
+    Owned.TRACK_NUM: ("TRCK",),
+    Owned.TRACK_TOTAL: ("TRCK",),
+    Owned.DISC_NUM: ("TPOS",),
+    Owned.MEDIA: ("TMED",),
+    Owned.MB_TRACK_ID: (f"UFID:{UFID_OWNER}",),
+    Owned.MB_RELEASE_TRACK_ID: (f"TXXX:{TXXX_RELEASE_TRACK_ID}",),
+    Owned.MB_ARTIST_IDS: (f"TXXX:{TXXX_ARTIST_ID}",),
+    Owned.ISRCS: ("TSRC",),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +214,10 @@ def read_tags(path: Path) -> TrackTags:
         label=_text(tags, "TPUB"),  # a real frame, unlike the two below
         catalog_number=_txxx(tags, TXXX_CATALOG),
         barcode=_txxx(tags, TXXX_BARCODE),
-        media=_txxx(tags, "MEDIA"),
+        # TMED — the frame `write_tags` actually writes. Read as TXXX:MEDIA
+        # until #149, so `media` never round-tripped and every MP3 Harmonist
+        # had tagged reported it missing on the album page.
+        media=_text(tags, "TMED"),
         genre=_text(tags, "TCON"),
         title=_text(tags, "TIT2"),
         artist=_text(tags, "TPE1"),
@@ -227,6 +276,13 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> None:
     if audio.tags is None:
         audio.add_tags()
     tags = audio.tags
+
+    # Clear every owned frame before writing, so a field absent from this
+    # TagSet is REMOVED rather than left stale from a previous tagging (#149).
+    # Anything not owned — COMM, TCON, arbitrary frames, APIC — is untouched.
+    for frames in OWNED_FRAMES.values():
+        for frame_id in frames:
+            tags.delall(frame_id)
 
     # ---- Album-level MB IDs ----
     _set_txxx(tags, TXXX_ALBUM_ID, [tagset.mb_album_id])

--- a/src/harmonist/formats/owned.py
+++ b/src/harmonist/formats/owned.py
@@ -1,0 +1,133 @@
+"""The tags Harmonist owns — the single definition every format shares (#149).
+
+Harmonist promises not to touch tags it doesn't understand. This module is the
+concrete form of that promise: **these fields, and only these, are the ones
+Harmonist writes, overwrites, and removes.** Everything else on a file — the
+comment carrying a recovered Bandcamp URL, a genre tagged elsewhere (#12), any
+arbitrary tag the user or another tool put there — is left exactly as found.
+
+Each format module maps `Owned` to its own native keys and clears that mapping
+before writing. Owning the definition here rather than per-backend is what makes
+the three agree; when it lived only in `_vorbis.py` they didn't, and two
+bugs followed:
+
+- a field absent from the new `TagSet` was removed on FLAC and silently left
+  stale on MP3 and M4A, so the label of a *wrong* release survived the mis-tag
+  correction that was supposed to clear it;
+- MP3 wrote `media` to `TMED` and read it back from `TXXX:MEDIA`, so it never
+  round-tripped and the album page reported it missing on every MP3 it had
+  itself tagged.
+
+**Artwork is deliberately absent from this set.** Embedded cover art is not a
+tag here: `tagger.tag_album` passes `cover=None` when the tracks carry differing
+per-track images, precisely so `write_tags` leaves them alone (a compilation's
+per-track art is user data a re-tag must not destroy). Adding artwork to the
+owned set would clear it before every write and make that protection a no-op.
+Per-track artwork is a third category that fits neither scope below — MusicBrainz
+and Picard don't really model it either — and it is handled in the tagger, not
+here. See #131.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Scope(StrEnum):
+    """Whether a field's value depends on which track of the album it is.
+
+    The split is load-bearing for the tagging audit records (#86), which record
+    an album-level change once per album rather than once per track — the
+    difference between one line and twenty identical ones in an album's history.
+
+    The test is deliberately "can this vary between tracks", not "does it
+    usually". `media`, `disc_num` and `track_total` are derived from the medium,
+    so on a multi-disc release — or a CD+DVD set — they genuinely differ per
+    track, and calling them album-level would make the audit record wrong on
+    exactly the releases where it matters most. A field that *happens* to be
+    constant across an album is still recognised as constant at render time;
+    a field wrongly declared constant here cannot be recovered from.
+    """
+
+    ALBUM = "album"
+    TRACK = "track"
+
+
+class Owned(StrEnum):
+    """One tag Harmonist owns.
+
+    The values are exactly the `TagSet` attribute names — not a coincidence and
+    not decoration. It lets the format mappings be checked mechanically against
+    `TagSet` (see `test_formats.py`), and it gives #86 a stable vocabulary for
+    the persisted before/after records without inventing a second set of names
+    that would have to be kept in step with this one.
+    """
+
+    # --- Album-level ---
+    MB_ALBUM_ID = "mb_album_id"
+    ALBUM = "album"
+    ALBUM_ARTIST = "album_artist"
+    ALBUM_ARTIST_SORT = "album_artist_sort"
+    MB_ALBUM_ARTIST_IDS = "mb_album_artist_ids"
+    MB_RELEASE_GROUP_ID = "mb_release_group_id"
+    MB_ALBUM_TYPE = "mb_album_type"
+    MB_ALBUM_STATUS = "mb_album_status"
+    MB_ALBUM_COUNTRY = "mb_album_country"
+    DATE = "date"
+    ORIGINAL_DATE = "original_date"
+    SCRIPT = "script"
+    LABEL = "label"
+    CATALOG_NUMBER = "catalog_number"
+    BARCODE = "barcode"
+    ASIN = "asin"
+    DISC_TOTAL = "disc_total"
+
+    # --- Per-track ---
+    TITLE = "title"
+    ARTIST = "artist"
+    ARTIST_SORT = "artist_sort"
+    ARTISTS = "artists"
+    TRACK_NUM = "track_num"
+    TRACK_TOTAL = "track_total"
+    DISC_NUM = "disc_num"
+    MEDIA = "media"
+    MB_TRACK_ID = "mb_track_id"
+    MB_RELEASE_TRACK_ID = "mb_release_track_id"
+    MB_ARTIST_IDS = "mb_artist_ids"
+    ISRCS = "isrcs"
+
+
+SCOPE: dict[Owned, Scope] = {
+    Owned.MB_ALBUM_ID: Scope.ALBUM,
+    Owned.ALBUM: Scope.ALBUM,
+    Owned.ALBUM_ARTIST: Scope.ALBUM,
+    Owned.ALBUM_ARTIST_SORT: Scope.ALBUM,
+    Owned.MB_ALBUM_ARTIST_IDS: Scope.ALBUM,
+    Owned.MB_RELEASE_GROUP_ID: Scope.ALBUM,
+    Owned.MB_ALBUM_TYPE: Scope.ALBUM,
+    Owned.MB_ALBUM_STATUS: Scope.ALBUM,
+    Owned.MB_ALBUM_COUNTRY: Scope.ALBUM,
+    Owned.DATE: Scope.ALBUM,
+    Owned.ORIGINAL_DATE: Scope.ALBUM,
+    Owned.SCRIPT: Scope.ALBUM,
+    Owned.LABEL: Scope.ALBUM,
+    Owned.CATALOG_NUMBER: Scope.ALBUM,
+    Owned.BARCODE: Scope.ALBUM,
+    Owned.ASIN: Scope.ALBUM,
+    Owned.DISC_TOTAL: Scope.ALBUM,
+    Owned.TITLE: Scope.TRACK,
+    Owned.ARTIST: Scope.TRACK,
+    Owned.ARTIST_SORT: Scope.TRACK,
+    Owned.ARTISTS: Scope.TRACK,
+    Owned.TRACK_NUM: Scope.TRACK,
+    Owned.TRACK_TOTAL: Scope.TRACK,
+    Owned.DISC_NUM: Scope.TRACK,
+    Owned.MEDIA: Scope.TRACK,
+    Owned.MB_TRACK_ID: Scope.TRACK,
+    Owned.MB_RELEASE_TRACK_ID: Scope.TRACK,
+    Owned.MB_ARTIST_IDS: Scope.TRACK,
+    Owned.ISRCS: Scope.TRACK,
+}
+
+ALBUM_FIELDS: tuple[Owned, ...] = tuple(f for f in Owned if SCOPE[f] is Scope.ALBUM)
+TRACK_FIELDS: tuple[Owned, ...] = tuple(f for f in Owned if SCOPE[f] is Scope.TRACK)

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -520,3 +520,231 @@ def test_scanner_audio_format_mixed(tmp_path):
     d = _make_album(tmp_path, "sine.flac", name="a")
     shutil.copy(FIXTURES_DIR / "sine.mp3", d / "02 b.mp3")
     assert scan(tmp_path)[0].audio_format == "Mixed"
+
+
+# ---------- the owned-tag set (#149) ----------
+
+
+def _copy_fixture(tmp_path: Path, fixture: str) -> Path:
+    dst = tmp_path / fixture
+    shutil.copy(FIXTURES_DIR / fixture, dst)
+    return dst
+
+
+def _tagset(**overrides: Any) -> Any:
+    """A minimal valid TagSet, plus whatever the test wants to vary."""
+    from harmonist.formats.types import TagSet
+
+    base: dict[str, Any] = {
+        "mb_album_id": "album-mbid",
+        "album": "Album",
+        "album_artist": "Album Artist",
+        "title": "Title",
+        "artist": "Artist",
+        "track_num": 1,
+        "track_total": 1,
+    }
+    return TagSet(**{**base, **overrides})
+
+
+def test_owned_fields_match_tagset_exactly():
+    """`Owned` and `TagSet` name the same set of fields.
+
+    The guard against silent drift in both directions: a new TagSet field that
+    nobody classified would be written and never cleared (the #149 bug, back
+    again for one field), and an Owned member with no TagSet field behind it
+    would clear a tag Harmonist never writes — destroying user data.
+    """
+    from dataclasses import fields as dc_fields
+
+    from harmonist.formats.owned import Owned
+    from harmonist.formats.types import TagSet
+
+    assert {f.name for f in dc_fields(TagSet)} == {f.value for f in Owned}
+
+
+def test_every_owned_field_has_a_scope():
+    from harmonist.formats.owned import ALBUM_FIELDS, SCOPE, TRACK_FIELDS, Owned
+
+    assert set(SCOPE) == set(Owned)
+    assert set(ALBUM_FIELDS) | set(TRACK_FIELDS) == set(Owned)
+    assert not set(ALBUM_FIELDS) & set(TRACK_FIELDS)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "table"),
+    [
+        ("m4a", "OWNED_ATOMS"),
+        ("mp3", "OWNED_FRAMES"),
+        ("_vorbis", "OWNED_KEYS"),
+    ],
+)
+def test_every_backend_maps_every_owned_field(module_name: str, table: str):
+    """A backend that forgets a field stops clearing it — which is exactly the
+    bug this set exists to prevent, reintroduced one format at a time."""
+    import importlib
+
+    from harmonist.formats.owned import Owned
+
+    mod = importlib.import_module(f"harmonist.formats.{module_name}")
+    assert set(getattr(mod, table)) == set(Owned)
+
+
+@pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
+def test_retag_removes_owned_tags_the_new_release_lacks(tmp_path, ext, fixture):
+    """The #149 bug: a re-tag onto a release with no label/catalogue number
+    must REMOVE the old ones, not leave them attributed to a release that never
+    carried them. FLAC did this; MP3 and M4A silently didn't."""
+    path = _copy_fixture(tmp_path, fixture)
+
+    formats.write_tags(path, _tagset(label="Warp", catalog_number="WARP1", media="CD"), None)
+    assert formats.read_tags(path).label == "Warp"
+
+    formats.write_tags(path, _tagset(), None)  # same album, release has no label
+    after = formats.read_tags(path)
+    assert after.label is None
+    assert after.catalog_number is None
+    assert after.media is None
+    assert after.album == "Album"  # the fields that ARE written still land
+
+
+@pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
+def test_write_preserves_tags_harmonist_does_not_own(tmp_path, ext, fixture):
+    """The promise not to touch what it doesn't understand. The comment carries
+    a recovered Bandcamp URL, the genre is #12's territory, and ReplayGain
+    stands in for arbitrary third-party tags."""
+    path = _copy_fixture(tmp_path, fixture)
+    _set_unowned_tags(path, comment="https://artist.bandcamp.com/album/x", genre="Ambient")
+
+    formats.write_tags(path, _tagset(), None)
+
+    assert formats.read_comment(path) == "https://artist.bandcamp.com/album/x"
+    kept = _read_unowned_tags(path)
+    assert kept["genre"] == "Ambient"
+    assert kept["replaygain"] == "-3.20 dB"
+
+
+@pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
+def test_write_with_no_cover_preserves_embedded_art(tmp_path, ext, fixture):
+    """DATA SAFETY: `cover=None` means "leave the art alone" — the path
+    `tag_album` uses to protect a compilation's per-track images. Clearing the
+    owned set must not touch artwork, which is why it isn't in that set."""
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+    path = _copy_fixture(tmp_path, fixture)
+
+    formats.write_tags(path, _tagset(), png)
+    embedded = formats.read_cover(path)
+    assert embedded is not None
+
+    formats.write_tags(path, _tagset(title="Retagged"), None)
+    assert formats.read_cover(path) == embedded
+
+
+@pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
+def test_media_round_trips(tmp_path, ext, fixture):
+    """Regression for #149: MP3 wrote `media` to TMED and read it back from
+    TXXX:MEDIA, so every MP3 Harmonist tagged reported Media missing on the
+    album page — a permanent false difference against MusicBrainz."""
+    path = _copy_fixture(tmp_path, fixture)
+    formats.write_tags(path, _tagset(media='12" Vinyl'), None)
+    assert formats.read_tags(path).media == '12" Vinyl'
+
+
+def _set_unowned_tags(path: Path, *, comment: str, genre: str) -> None:
+    """Put a comment, a genre and a ReplayGain tag on `path`, natively."""
+    if path.suffix == ".mp3":
+        from mutagen.id3 import COMM, TCON, TXXX, Encoding
+        from mutagen.mp3 import MP3
+
+        audio = MP3(path)
+        if audio.tags is None:
+            audio.add_tags()
+        audio.tags.add(COMM(encoding=Encoding.UTF8, lang="eng", desc="", text=[comment]))
+        audio.tags.add(TCON(encoding=Encoding.UTF8, text=[genre]))
+        audio.tags.add(
+            TXXX(encoding=Encoding.UTF8, desc="REPLAYGAIN_TRACK_GAIN", text=["-3.20 dB"])
+        )
+        audio.save()
+    elif path.suffix in (".m4a", ".mp4"):
+        from mutagen.mp4 import MP4
+
+        audio = MP4(path)
+        audio["\xa9cmt"] = [comment]
+        audio["\xa9gen"] = [genre]
+        audio["----:com.apple.iTunes:replaygain_track_gain"] = [b"-3.20 dB"]
+        audio.save()
+    else:
+        audio = _vorbis_open(path)
+        audio["COMMENT"] = [comment]
+        audio["GENRE"] = [genre]
+        audio["REPLAYGAIN_TRACK_GAIN"] = ["-3.20 dB"]
+        audio.save()
+
+
+def _read_unowned_tags(path: Path) -> dict[str, str | None]:
+    if path.suffix == ".mp3":
+        from mutagen.mp3 import MP3
+
+        tags = MP3(path).tags
+        gain = tags.get("TXXX:REPLAYGAIN_TRACK_GAIN")
+        genre = tags.get("TCON")
+        return {
+            "genre": genre.text[0] if genre else None,
+            "replaygain": gain.text[0] if gain else None,
+        }
+    if path.suffix in (".m4a", ".mp4"):
+        from mutagen.mp4 import MP4
+
+        audio = MP4(path)
+        gain = audio.get("----:com.apple.iTunes:replaygain_track_gain")
+        genre = audio.get("\xa9gen")
+        return {
+            "genre": genre[0] if genre else None,
+            "replaygain": bytes(gain[0]).decode() if gain else None,
+        }
+    audio = _vorbis_open(path)
+    return {
+        "genre": (audio.get("GENRE") or [None])[0],
+        "replaygain": (audio.get("REPLAYGAIN_TRACK_GAIN") or [None])[0],
+    }
+
+
+@pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
+def test_tagging_result_does_not_depend_on_what_was_tagged_before(tmp_path, ext, fixture):
+    """Tagging is idempotent, and — the stronger property clearing buys — its
+    result is independent of the file's tagging history.
+
+    Re-tagging onto a different release used to leave the previous one's
+    residue on MP3 and M4A, so a file tagged A-then-B differed from one tagged
+    B outright. That made the operation non-idempotent in the way that matters:
+    the outcome depended on what had happened to the file before.
+    """
+    release_a = _tagset(album="First", label="Warp", catalog_number="WARP1", media="CD")
+    release_b = _tagset(album="Second", barcode="5099999999999")
+
+    history = _copy_fixture(tmp_path, fixture)
+    formats.write_tags(history, release_a, None)
+    formats.write_tags(history, release_b, None)
+
+    fresh_dir = tmp_path / "fresh"
+    fresh_dir.mkdir()
+    fresh = fresh_dir / fixture
+    shutil.copy(FIXTURES_DIR / fixture, fresh)
+    formats.write_tags(fresh, release_b, None)
+
+    assert formats.read_tags(history) == formats.read_tags(fresh)
+
+    # And tagging the same release twice changes nothing the second time.
+    before = formats.read_tags(history)
+    formats.write_tags(history, release_b, None)
+    assert formats.read_tags(history) == before
+
+
+def _vorbis_open(path: Path) -> Any:
+    if path.suffix == ".flac":
+        from mutagen.flac import FLAC
+
+        return FLAC(path)
+    from mutagen.oggopus import OggOpus
+
+    return OggOpus(path)


### PR DESCRIPTION
Only the Vorbis backend cleared its managed keys before writing, so a field absent from the new `TagSet` was removed on FLAC and Opus and silently left stale on MP3 and M4A. Correcting a mis-tag therefore left the wrong release's label, catalogue number, barcode and release country on the files for good — and nothing surfaced it, because the album page reads what is on disk and reported the stale value as the album's own.

## What changed

`formats/owned.py` is the new single definition of the tags Harmonist owns: an `Owned` enum split per-album / per-track by `Scope`, with each backend (`m4a.OWNED_ATOMS`, `mp3.OWNED_FRAMES`, `_vorbis.OWNED_KEYS`) mapping it to native keys and clearing that mapping before it writes. The `Owned` member values are exactly the `TagSet` attribute names, and a test asserts the two sets match, so neither can grow a field the other doesn't know about.

This also fixes a second bug the single definition makes structurally impossible: MP3 wrote `media` to `TMED` and read it back from `TXXX:MEDIA`, so it never round-tripped and every MP3 album Harmonist had tagged showed Media as missing on the album page — a permanent false difference against MusicBrainz.

**Artwork is deliberately not in the owned set.** `tag_album` passes `cover=None` when the tracks carry differing per-track images precisely so `write_tags` leaves them alone; clearing artwork alongside the tags would make that protection a no-op. Per-track artwork is a third category that fits neither scope, which neither MusicBrainz nor Picard really models (#131).

## Behaviour change on existing libraries

The first re-tag after this ships **removes** owned tags that MP3 and M4A files have been carrying — some since a mis-tag that was corrected long ago. That is the fix, and the changelog says so plainly, but it is a change to what Harmonist does to user data on an existing library rather than a pure bug fix.

Unowned tags are untouched, as before: the comment carrying a recovered Bandcamp URL, a genre tagged elsewhere (#12), and arbitrary third-party tags all survive, and there are tests for each.

## Tests

Nine new tests, each verified load-bearing by running it against the pre-change code: all fail on M4A and MP3 and pass on FLAC and Opus, matching the asymmetry above.

- stale owned tags are removed on re-tag;
- comment, genre and arbitrary third-party tags (ReplayGain) survive a write;
- embedded art survives a `cover=None` write;
- `media` round-trips;
- the result of tagging no longer depends on what the file was tagged as before — the stronger form of idempotency this change buys;
- two structural guards: `Owned` matches `TagSet` exactly, and every backend maps every field.

## Known gap

The audit records say a track was re-tagged but not which tags were removed. What is removed is only ever a Harmonist-owned value Harmonist itself wrote earlier, and #86 — which adds the per-field before/after detail — is blocked on this change and closes the gap.

Fixes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
