### PR TITLE
Unlink an album when an undo removes its MusicBrainz id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ versions follow [semantic versioning](https://semver.org).
   back the tag values the files carried before it. A field you've changed since
   — in Picard, or by a later re-tag — is left alone and named, and the undo is
   itself recorded, so it can be undone in turn (#157).
-  - The MusicBrainz release id is deliberately kept, so the album stays linked
-    to its release rather than stranding itself mid-tagging; the flash says so.
+  - Undoing the tagging that linked an album to MusicBrainz now unlinks it too,
+    so the files and the album's state can't disagree. It moves to Needs MBID
+    with its release kept as a one-click suggestion, the same place the "wrong
+    match" pencil leaves it (#158).
   - Artwork keeps its own separate Undo, since it has its own store.
 
 ### Changed

--- a/docs/design.md
+++ b/docs/design.md
@@ -366,6 +366,12 @@ without, it leads with the find/assign tools. This avoids a confusing
 round-trip (reject → re-assign) when the user just wants to swap a wrong
 MBID — they can do that inline, and dismissing a suggestion stays put.
 
+**A suggestion need not carry per-track rows.** `track_comparisons` comes from
+an MB fetch, and two paths attach a candidate without one: an unlink after an
+undo (#158) suggests the album's own former release, and nothing here makes a
+network call. The card renders the Confirm and the notes and omits the
+side-by-side, rather than drawing a comparison table with no rows in it.
+
 **Two refinements from the purchase-matcher (§2.5):**
 
 - **Ambiguous link → Complete, not Needs Link.** A bandcamp album with
@@ -419,9 +425,12 @@ stateDiagram-v2
     NEEDS_SYNC --> NEEDS_SYNC: Update URL<br/>(retry on next sync)
 
     COMPLETE --> NEW: Forget<br/>(sidecar deleted)
+    COMPLETE --> NEEDS_MBID: Wrong match<br/>(pencil — tags left on disk)
+    COMPLETE --> NEEDS_MBID: Undo the linking<br/>tagging (#157/#158)
 
     INCOMPLETE --> NEW: Forget
     INCOMPLETE --> NEEDS_MBID: Recheck<br/>(MB tracklist changed → suggestion)
+    INCOMPLETE --> NEEDS_MBID: Wrong match / undo<br/>the linking tagging
     INCOMPLETE --> COMPLETE: Recheck<br/>(missing tracks now on disk)
 
     INCONSISTENT --> NEW: user fixes on-disk<br/>tags via Picard
@@ -639,7 +648,13 @@ The records above exist to be readable, but they were shaped to be *reversible*:
 
 **The undo records itself** as `tag.revert` with its own per-field detail, so it appears in History and is undoable in turn.
 
-**`mb_album_id` is not reverted while the sidecar still holds that release.** Removing it would leave the files carrying no MusicBrainz id while the sidecar claims one, which derives as `TAGGING` (§3) — a spinner in the inbox forever. The outcome says so rather than hiding it. Making the sidecar follow the files is #158; when it lands, the guard lifts and the album drops to `NEEDS_MBID` with the unlinked release kept as its suggestion.
+**`mb_album_id` is all-or-nothing, and the sidecar follows it** (#158). Identity is the one field that isn't per-file: the sidecar records exactly one release, so a revert that moved the id on some files and left it on others would derive as `INCONSISTENT` and leave nothing coherent to write down. So `_identity_revert` decides it once for the album — every file in the plan must agree on the before-value, still carry the after-value, and account for every file in the directory — or the field is left alone and reported stale.
+
+When it does move, the sidecar goes with it: `mb_release_id`, `tagged_at` and `track_count_expected` are cleared and the album derives as `NEEDS_MBID`. Leaving the sidecar naming a release the files no longer carry would derive as `TAGGING` (§3) — the transient spinner, with no action on it and no way out.
+
+**The release is kept as a confirmable suggestion**, not discarded: the Needs MBID card then offers Confirm & Tag, which is the one-click way back, with a note saying why the album is there. Undoing a *re-match* reverts the files to the older release, and that older release — not whichever one the sidecar was holding — is what gets suggested, because it is what the user asked to return to. The candidate carries no `track_comparisons`: building them needs an MB fetch, and an undo makes no network call. Confirming re-tags through the ordinary path, which fetches the release and writes a fresh `track_count_expected`, so nothing here has to guess a track count.
+
+This is the same transition the "wrong match" pencil makes, and deliberately so — it differs only in that the pencil leaves the on-disk tags alone and discards the candidate, since there the release was *wrong* rather than merely undone. See #166 on sharing the mutation between them.
 
 Artwork is not in the plan: it is not an owned tag, and it has its own store, its own availability check and its own button (#131). One button per store, each honest about what it can do.
 

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -328,20 +328,77 @@ class RevertOutcome:
     #: since the message names fields rather than file-field pairs.
     restored: tuple[str, ...] = ()
     stale: tuple[str, ...] = ()
-    #: True when the MusicBrainz release id was deliberately left in place.
-    kept_release_id: bool = False
+    #: Set when the revert moved `mb_album_id`, with what the files carry now —
+    #: None meaning the id was removed altogether. The caller needs both facts
+    #: to keep the sidecar in step: a sidecar still naming a release the files
+    #: no longer carry derives as TAGGING, which is a spinner with no way out
+    #: (#158). `None` for `release_id_now` is a real answer, so the boolean has
+    #: to be separate from it.
+    release_id_reverted: bool = False
+    release_id_now: str | None = None
 
     @property
     def changed(self) -> bool:
         return bool(self.files)
 
 
-def revert_tags(
-    album_dir: Path,
-    plan: Sequence[tag_history.FileRevert],
-    *,
-    keep_release_id: str | None,
-) -> RevertOutcome:
+@dataclass(frozen=True)
+class _IdentityRevert:
+    """The album's `mb_album_id` revert, decided once for the whole album."""
+
+    value: str | None
+
+
+def _identity_revert(
+    album_dir: Path, plan: Sequence[tag_history.FileRevert]
+) -> _IdentityRevert | None:
+    """What `mb_album_id` should become, or None to leave it alone entirely.
+
+    Answered for the album rather than per file, because it is the album's
+    identity: the sidecar records exactly one release, so a revert that moved it
+    on some files and not others would leave nothing coherent to write there —
+    and would derive as INCONSISTENT, a state the user then has to repair by
+    hand in Picard.
+
+    So it is all-or-nothing, and every one of these has to hold:
+
+    * every file in the plan agrees on what the id was before the tagging;
+    * every one of them still carries what the tagging wrote, i.e. nothing has
+      re-tagged or re-matched the album since;
+    * every file is readable, and there is no file in the album that the plan
+      doesn't cover — a tagging that touched half the album can't speak for the
+      identity of the other half.
+    """
+    field = owned.Owned.MB_ALBUM_ID
+    # Keyed by file name, never by position: the plan's order and the
+    # directory's are both file order today, but pairing two lists that merely
+    # happen to agree is how the wrong track's id gets written.
+    changes = {item.file: item.fields[field] for item in plan if field in item.fields}
+    if not changes or len(changes) != len(plan):
+        return None
+    befores = {before for before, _after in changes.values()}
+    if len(befores) != 1:
+        return None
+
+    on_disk = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
+    if {p.name for p in on_disk} != set(changes):
+        # Files have appeared or gone since. Any the plan doesn't name would
+        # keep whatever id they carry, so moving the rest would split the
+        # album's identity between two releases.
+        return None
+    for path in on_disk:
+        try:
+            current = formats.read_owned(path)
+        except Exception as e:
+            raise RevertUnavailableError(f"could not read the tags on {path.name}: {e}") from e
+        if owned.values_differ(current.get(field), changes[path.name][1]):
+            return None
+
+    before = next(iter(befores))
+    return _IdentityRevert(value=before if isinstance(before, str) and before else None)
+
+
+def revert_tags(album_dir: Path, plan: Sequence[tag_history.FileRevert]) -> RevertOutcome:
     """Put back the tags one tagging changed, and report what actually moved.
 
     `plan` comes from `tag_history.revert_plan` — the same records the History
@@ -353,12 +410,13 @@ def revert_tags(
     reached past the change it names into someone else's would be the confident
     lie the artwork restore was careful to avoid.
 
-    **`keep_release_id` names a release the sidecar still points at**, and while
-    it is set `mb_album_id` is never reverted. Removing it would leave the files
-    carrying no MusicBrainz id while the sidecar still claims one, which derives
-    as TAGGING (`scanner._derive_state`) — a spinner in the Inbox forever.
-    Making the sidecar follow the files instead is #158; until then this is a
-    stated limit rather than a silent one. Pass None once that lands.
+    **`mb_album_id` is all-or-nothing**, unlike every other field. It is the
+    album's identity, and the sidecar has to follow it (#158) — so it must come
+    out of here single-valued. Reverting it on the files whose value still
+    matches while leaving the rest would leave the album's tracks disagreeing
+    about which release they belong to, which derives as INCONSISTENT and hands
+    the caller no id to write down. So it moves on every file or on none, and
+    the outcome reports what the album now carries.
 
     **Everything resolves before anything is written**, like `restore_artwork`:
     every file is opened and read first, and a missing or unreadable one raises
@@ -370,7 +428,7 @@ def revert_tags(
     targets: dict[Path, tuple[dict[str, Any], dict[str, Any]]] = {}
     restored: set[str] = set()
     stale: set[str] = set()
-    kept_release_id = False
+    identity = _identity_revert(album_dir, plan)
 
     for item in plan:
         # `item.file` reaches here from a stored record and is joined to a path.
@@ -389,8 +447,13 @@ def revert_tags(
 
         target = dict(current)
         for field, (before, after) in item.fields.items():
-            if field == owned.Owned.MB_ALBUM_ID and keep_release_id is not None:
-                kept_release_id = True
+            if field == owned.Owned.MB_ALBUM_ID:
+                # Decided once for the album, above — not per file.
+                if identity is not None:
+                    target[field] = identity.value
+                    restored.add(field)
+                else:
+                    stale.add(field)
                 continue
             if field not in current:
                 # A field this build no longer owns. The records are permanent
@@ -419,7 +482,7 @@ def revert_tags(
             files=len(targets),
             fields=len(restored),
             stale=len(stale),
-            release_id="kept" if kept_release_id else "-",
+            release_id=(identity.value or "removed") if identity is not None else "-",
         )
     for path, (target, _current) in targets.items():
         before = formats.write_owned(path, target)
@@ -442,7 +505,11 @@ def revert_tags(
         files=files,
         restored=tuple(sorted(restored)),
         stale=tuple(sorted(stale)),
-        kept_release_id=kept_release_id,
+        # Reported only when files were actually written: an identity decided
+        # but not carried out (every field already back) must not send the
+        # caller off to rewrite a sidecar that is already correct.
+        release_id_reverted=identity is not None and bool(files),
+        release_id_now=identity.value if identity is not None else None,
     )
 
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1414,7 +1414,73 @@ def _revert_plan(album: Album, event_id: int) -> tuple[tag_history.FileRevert, .
     return tag_history.revert_plan(records) if records else ()
 
 
-def _revert_detail(outcome: tagger_mod.RevertOutcome) -> str:
+def _unlink_after_revert(album: Album, outcome: tagger_mod.RevertOutcome) -> bool:
+    """Make the sidecar follow the files after an undo moved `mb_album_id` (#158).
+
+    A sidecar naming a release the files no longer carry derives as **TAGGING**
+    (`scanner._derive_state`) — the transient spinner state, with no action on
+    it and no way out. So when the undo changes the album's identity, the
+    sidecar's release id goes with it and the album derives as NEEDS_MBID.
+
+    **The release is kept as a suggestion**, not thrown away: the card then
+    offers Confirm & Tag, which is the one-click way back, and a note says why
+    the album is there. Without it the user would have to know an MBID by heart
+    to undo their own undo.
+
+    **Which release to suggest** is whatever the files now say, falling back to
+    the one being unlinked when they say nothing. Undoing a re-match reverts the
+    files to the *older* release, and that older release — not the one the
+    sidecar happened to be holding — is what the user just asked to go back to.
+
+    Confirming re-tags through the ordinary path, which fetches the release and
+    writes a fresh `track_count_expected`, so nothing here has to guess a track
+    count it has no lookup for.
+
+    Returns whether the sidecar was rewritten.
+    """
+    sc = album.sidecar
+    if not outcome.release_id_reverted or sc is None:
+        return False
+    if not owned.values_differ(sc.mb_release_id, outcome.release_id_now):
+        return False  # already agrees — nothing to do
+
+    suggest = outcome.release_id_now or sc.mb_release_id
+    files = len([p for p in album.path.iterdir() if formats.is_supported(p)])
+    candidate = (
+        MatchCandidate(
+            mb_release_id=suggest,
+            # It WAS the confirmed release — this is not a fresh guess, and
+            # calling it approximate would invite the user to re-check a match
+            # they made themselves.
+            confidence="exact",
+            file_count=files,
+            # The count recorded when it was tagged, so the card offers the same
+            # Confirm it would have before. `track_comparisons` stays empty: it
+            # would need an MB fetch, and an undo makes no network call.
+            track_count=sc.track_count_expected or files,
+            proposed_at=datetime.now(UTC),
+            notes=["Unlinked when you undid the tagging that linked this album"],
+        )
+        if suggest
+        else None
+    )
+    # `mb_release_id=None` makes `sidecar.write` mint the path-derived temp_uid
+    # and record the MBID -> temp_uid alias, which is what keeps the album's
+    # pre-unlink history reachable from its new id (#33).
+    sidecar_mod.write(
+        album.path,
+        replace(
+            sc,
+            mb_release_id=None,
+            tagged_at=None,
+            track_count_expected=None,
+            mb_match_candidate=candidate,
+        ),
+    )
+    return True
+
+
+def _revert_detail(outcome: tagger_mod.RevertOutcome, *, unlinked: bool = False) -> str:
     """What the undo did, as one line under the flash heading.
 
     Counts what went back, but NAMES what didn't. The fields that were put back
@@ -1432,8 +1498,11 @@ def _revert_detail(outcome: tagger_mod.RevertOutcome) -> str:
         )
     if outcome.stale:
         parts.append(f"{_named_fields(outcome.stale)} left alone (changed since)")
-    if outcome.kept_release_id:
-        parts.append("MusicBrainz id kept, so the album stays linked")
+    if unlinked:
+        # The one consequence that isn't a tag: the album has left the Library.
+        # Saying where it went, and that the release is still on offer, is the
+        # difference between an undo and an album that vanished.
+        parts.append("now Needs MBID — its release is kept as a suggestion")
     return "; ".join(parts)
 
 
@@ -1453,8 +1522,6 @@ def _named_fields(fields: tuple[str, ...]) -> str:
 def _revertable_anchors(
     history: list[activity_store.StoredEvent],
     detail: dict[int, activity_store.TagChanges],
-    *,
-    keep_release_id: str | None,
 ) -> set[int]:
     """Which history rows are worth offering an Undo on.
 
@@ -1468,20 +1535,11 @@ def _revertable_anchors(
     So the button appears when the tagging changed something revertable at all,
     and a revert that finds every field already changed says so when clicked —
     "nothing left to put back" rather than a silent success.
-
-    `keep_release_id` mirrors `tagger.revert_tags`: while it is set, a tagging
-    whose only tag change was the MusicBrainz id has nothing this build can
-    undo, so it gets no button rather than one that would do nothing (#158).
     """
     out: set[int] = set()
     for anchor, records in tag_history.group_records(history, detail).items():
-        for item in tag_history.revert_plan(records):
-            fields = set(item.fields)
-            if keep_release_id is not None:
-                fields.discard(owned.Owned.MB_ALBUM_ID)
-            if fields:
-                out.add(anchor)
-                break
+        if any(item.fields for item in tag_history.revert_plan(records)):
+            out.add(anchor)
     return out
 
 
@@ -2723,11 +2781,7 @@ def _register_routes(app: FastAPI) -> None:
             # Only offer Undo where the images are actually still there (#131).
             restorable = _restorable_anchors(history, detail)
             # And where the tagging changed a tag this build can put back (#157).
-            revertable = _revertable_anchors(
-                history,
-                detail,
-                keep_release_id=album.sidecar.mb_release_id if album.sidecar else None,
-            )
+            revertable = _revertable_anchors(history, detail)
         except activity_store.StoreUnavailableError:
             history_unavailable = True  # already logged with a traceback in the store
         ctx = _ctx(
@@ -2967,14 +3021,7 @@ def _register_routes(app: FastAPI) -> None:
                 status.HTTP_404_NOT_FOUND, "no tag change to undo on that history entry"
             )
         try:
-            outcome = tagger_mod.revert_tags(
-                album.path,
-                plan,
-                # Until #158 lets the sidecar follow the files, removing the MB
-                # id would leave the album deriving as TAGGING — a spinner in
-                # the Inbox forever. Stated in the outcome, not hidden.
-                keep_release_id=album.sidecar.mb_release_id if album.sidecar else None,
-            )
+            outcome = tagger_mod.revert_tags(album.path, plan)
         except tagger_mod.RevertUnavailableError as e:
             # Expected, not exceptional: files get renamed and deleted, and
             # saying so plainly beats a stack trace.
@@ -3001,9 +3048,12 @@ def _register_routes(app: FastAPI) -> None:
                 # reciting every field in the album.
                 record_activity=False,
             )
+        unlinked = _unlink_after_revert(album, outcome)
+        if unlinked:
+            request.app.state.scan_runner.request_scan()
         return _flash_response(
             "Tags put back",
-            _revert_detail(outcome),
+            _revert_detail(outcome, unlinked=unlinked),
             extra_triggers={"album-retagged": True},
             album=album,
         )

--- a/templates/partials/task_card_needs_mbid.html
+++ b/templates/partials/task_card_needs_mbid.html
@@ -129,7 +129,13 @@
         </div>
         {% endif %}
 
+        {# Only when there is something to compare. A candidate can legitimately
+           carry no per-track rows — an unlink after an undo (#158) suggests the
+           album's own release without an MB fetch to build them from — and the
+           table would otherwise render as a header with nothing under it. #}
+        {% if candidate.track_comparisons %}
         <div class="mb-3">{% include 'partials/_track_comparison.html' %}</div>
+        {% endif %}
 
         <div class="flex gap-2 flex-wrap">
             {% if exact_count %}

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -718,12 +718,20 @@ def _minimal_jpeg() -> bytes:
 # ---------- undoing a tagging (#157) ----------
 
 
-def _plan():
+def _plan(last: int | None = None):
     """The revert plan for the tagging that just ran, built the way the route
-    builds it — from the stored records, through the shared grouping."""
+    builds it — from the stored records, through the shared grouping.
+
+    `last` takes only the final N records, which is how a test with more than one
+    tagging names the most recent one. `_detail()` returns every stored record,
+    and `activity_store.clear()` does not remove them (#165), so slicing is the
+    honest way to say "the tagging that just ran" here. The route doesn't need
+    this — it groups by action id.
+    """
     from harmonist import tag_history
 
-    return tag_history.revert_plan(_detail())
+    records = _detail()
+    return tag_history.revert_plan(records[-last:] if last else records)
 
 
 def test_reverting_a_first_tagging_strips_the_tags_back_off(album_with_tracks, tmp_path):
@@ -738,7 +746,7 @@ def test_reverting_a_first_tagging_strips_the_tags_back_off(album_with_tracks, t
     tagged = formats.read_owned(next(album_dir.glob("*.m4a")))
     assert tagged["album"] == "Test Album"
 
-    outcome = tagger.revert_tags(album_dir, _plan(), keep_release_id=None)
+    outcome = tagger.revert_tags(album_dir, _plan())
 
     assert outcome.files == 2
     assert "album" in outcome.restored
@@ -766,7 +774,7 @@ def test_reverting_leaves_a_field_that_changed_since_alone(album_with_tracks, tm
         formats.write_owned(f, {**formats.read_owned(f), "album": "Edited By Hand"})
     f = next(album_dir.glob("*.m4a"))
 
-    outcome = tagger.revert_tags(album_dir, plan, keep_release_id=None)
+    outcome = tagger.revert_tags(album_dir, plan)
 
     assert "album" in outcome.stale
     assert "album" not in outcome.restored
@@ -775,22 +783,70 @@ def test_reverting_leaves_a_field_that_changed_since_alone(album_with_tracks, tm
     assert after["title"] is None, "everything else still went back"
 
 
-def test_reverting_keeps_the_release_id_while_the_sidecar_claims_it(album_with_tracks, tmp_path):
-    """#158's stated limit, made visible. Removing mb_album_id while the sidecar
-    still holds the release derives as TAGGING — a spinner in the Inbox forever
-    — so the field is left in place and the outcome says so."""
+def test_reverting_reports_the_release_id_it_removed(album_with_tracks, tmp_path):
+    """The caller has to keep the sidecar in step (#158), so the outcome says
+    both that identity moved and what the files carry now. None is a real
+    answer — the id was removed — so the flag can't be folded into the value."""
     from harmonist import activity_store, formats
 
     activity_store.init(tmp_path / "audit.db")
     album_dir = album_with_tracks(2)
     tagger.tag_album(album_dir, _release_2_tracks())
 
-    outcome = tagger.revert_tags(album_dir, _plan(), keep_release_id="rel-aaa")
+    outcome = tagger.revert_tags(album_dir, _plan())
 
-    assert outcome.kept_release_id is True
-    after = formats.read_owned(next(album_dir.glob("*.m4a")))
-    assert after["mb_album_id"] == "rel-aaa", "still linked"
-    assert after["album"] is None, "everything else went back"
+    assert outcome.release_id_reverted is True
+    assert outcome.release_id_now is None, "a first tagging had no id before it"
+    assert formats.read_owned(next(album_dir.glob("*.m4a")))["mb_album_id"] is None
+
+
+def test_reverting_a_rematch_puts_back_the_older_release_id(album_with_tracks, tmp_path):
+    """Undoing a re-match reverts identity to the release the album had BEFORE
+    it — not to nothing. That older release is what the sidecar must follow, and
+    what the user asked to go back to."""
+    from harmonist import activity_store, formats
+
+    activity_store.init(tmp_path / "audit.db")
+    album_dir = album_with_tracks(2)
+    tagger.tag_album(album_dir, _release_2_tracks())
+
+    other = _release_2_tracks()
+    other["id"] = "rel-bbb"
+    tagger.tag_album(album_dir, other)
+    assert formats.read_owned(next(album_dir.glob("*.m4a")))["mb_album_id"] == "rel-bbb"
+
+    # The last two records are the re-match's — one per file. Undoing the FIRST
+    # tagging is a different question, and this test asks about the re-match.
+    outcome = tagger.revert_tags(album_dir, _plan(last=2))
+
+    assert outcome.release_id_reverted is True
+    assert outcome.release_id_now == "rel-aaa"
+    assert formats.read_owned(next(album_dir.glob("*.m4a")))["mb_album_id"] == "rel-aaa"
+
+
+def test_reverting_leaves_identity_alone_when_the_files_disagree(album_with_tracks, tmp_path):
+    """Identity is all-or-nothing. If one file has been re-tagged since, moving
+    the others would split the album between two releases — INCONSISTENT, which
+    the user then has to repair by hand — and would leave the caller no single
+    id to write to the sidecar."""
+    from harmonist import activity_store, formats
+
+    activity_store.init(tmp_path / "audit.db")
+    album_dir = album_with_tracks(2)
+    tagger.tag_album(album_dir, _release_2_tracks())
+    plan = _plan()
+
+    odd = min(album_dir.glob("*.m4a"))
+    formats.write_owned(odd, {**formats.read_owned(odd), "mb_album_id": "rel-elsewhere"})
+
+    outcome = tagger.revert_tags(album_dir, plan)
+
+    assert outcome.release_id_reverted is False
+    assert "mb_album_id" in outcome.stale
+    assert formats.read_owned(odd)["mb_album_id"] == "rel-elsewhere"
+    other = sorted(album_dir.glob("*.m4a"))[1]
+    assert formats.read_owned(other)["mb_album_id"] == "rel-aaa", "not split in two"
+    assert formats.read_owned(other)["album"] is None, "the rest still went back"
 
 
 def test_reverting_twice_is_a_no_op(album_with_tracks, tmp_path):
@@ -803,9 +859,9 @@ def test_reverting_twice_is_a_no_op(album_with_tracks, tmp_path):
     tagger.tag_album(album_dir, _release_2_tracks())
     plan = _plan()
 
-    first = tagger.revert_tags(album_dir, plan, keep_release_id=None)
+    first = tagger.revert_tags(album_dir, plan)
     snapshot = formats.read_owned(next(album_dir.glob("*.m4a")))
-    second = tagger.revert_tags(album_dir, plan, keep_release_id=None)
+    second = tagger.revert_tags(album_dir, plan)
 
     assert first.files == 2
     assert second.files == 0, "nothing left to put back"
@@ -828,7 +884,7 @@ def test_reverting_refuses_before_writing_when_a_file_is_gone(album_with_tracks,
     before = formats.read_owned(survivor)
 
     with pytest.raises(tagger.RevertUnavailableError):
-        tagger.revert_tags(album_dir, plan, keep_release_id=None)
+        tagger.revert_tags(album_dir, plan)
 
     assert formats.read_owned(survivor) == before, "the surviving file was not touched"
 
@@ -845,7 +901,7 @@ def test_reverting_records_what_it_undid(album_with_tracks, tmp_path):
     tagger.tag_album(album_dir, _release_2_tracks())
     before_rows = len(_detail())
 
-    tagger.revert_tags(album_dir, _plan(), keep_release_id=None)
+    tagger.revert_tags(album_dir, _plan())
 
     lines = [e.message for e in activity_store.recent(50, source=Source.AUDIT)]
     per_file = [m for m in lines if m.startswith("tag.revert.track")]
@@ -877,6 +933,6 @@ def test_reverting_does_not_touch_the_artwork(album_with_tracks, tmp_path):
     embedded = formats.read_cover(f)
     assert embedded is not None
 
-    tagger.revert_tags(album_dir, _plan(), keep_release_id=None)
+    tagger.revert_tags(album_dir, _plan())
 
     assert formats.read_cover(f) == embedded

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3026,6 +3026,60 @@ def test_undo_unlink_derives_the_album_back_to_needs_mbid(client, cfg):
     assert album.state is AlbumState.NEEDS_MBID
 
 
+def test_undo_unlink_after_a_directory_rename_mints_the_new_paths_id(client, cfg):
+    """A tagged album's id is its release, so a rename doesn't move it — but an
+    unlink has to mint one from the path, and the path has changed.
+
+    The id it mints must be the one the SCANNER will derive for the directory as
+    it now stands. Minting from a remembered path would hand the album an id
+    nothing on disk agrees with, and its history would split at the rename.
+    """
+    from harmonist import activity_store, id_registry
+
+    album_id, d, anchor = _tagging_with_tag_changes(cfg, "TagRenamed")
+    moved = d.parent / "Renamed After Tagging"
+    d.rename(moved)
+
+    r = client.post(f"/tags/restore/{album_id}", data={"event_id": anchor})
+    assert "now Needs MBID" in r.text
+
+    after = sc.read(moved)
+    assert after is not None
+    assert after.mb_release_id is None
+    assert after.temp_uid == id_registry.get_or_mint(moved), "the id the scanner will derive"
+
+    # And the history came with it, across both identity changes.
+    messages = [e.message for e in activity_store.album_history(after.temp_uid)]
+    assert any("Re-tagged" in m for m in messages)
+
+
+def test_undo_refuses_when_a_file_has_been_renamed(client, cfg):
+    """Records name their file, so renaming one puts it out of the undo's reach.
+
+    It refuses rather than doing part of the job: the album is left exactly as
+    it was, tags and link both. The record carries three other ways to name the
+    track (`track_ref`, `rec_ref`, `position`) that would find it anyway — that
+    lookup isn't built yet (#167), and until it is, a clear refusal is the right
+    failure.
+    """
+    from harmonist import formats
+
+    album_id, d, anchor = _tagging_with_tag_changes(cfg, "TagFileRenamed")
+    path = min(p for p in d.iterdir() if formats.is_supported(p))
+    before = formats.read_owned(path)
+    path.rename(path.with_name("99 Renamed.m4a"))
+
+    r = client.post(f"/tags/restore/{album_id}", data={"event_id": anchor})
+
+    # The apostrophe is escaped in the rendered flash (#142).
+    assert "Couldn&#x27;t undo" in r.text
+    assert "no longer in this album" in r.text
+    # Nothing was written, and the album is still linked.
+    assert formats.read_owned(d / "99 Renamed.m4a") == before
+    after = sc.read(d)
+    assert after is not None and after.mb_release_id == "rel-TagFileRenamed"
+
+
 def test_undo_unlink_keeps_the_albums_history_reachable(client, cfg):
     """Unlinking changes the album's id back to its path-derived temp_uid, so
     the alias row is what stops its whole tagged-era history disappearing from

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2983,18 +2983,62 @@ def test_undo_puts_back_the_tags_a_tagging_changed(client, cfg):
     assert after["album"] is None
 
 
-def test_undo_keeps_the_release_id_and_says_so(client, cfg):
-    """#158's limit surfaced in the flash, not hidden: the album stays linked,
-    so it can't strand itself in TAGGING with a spinner in the Inbox."""
+def test_undo_unlinks_the_album_and_keeps_its_release_as_a_suggestion(client, cfg):
+    """#158: the sidecar follows the files. Leaving `mb_release_id` set while
+    the files carry no id derives as TAGGING — a spinner with no way out — so
+    the link goes too, and the release stays on the card so Confirm puts it
+    back in one click."""
     from harmonist import formats
 
-    album_id, d, anchor = _tagging_with_tag_changes(cfg, "TagKeep")
+    album_id, d, anchor = _tagging_with_tag_changes(cfg, "TagUnlink")
     path = min(p for p in d.iterdir() if formats.is_supported(p))
 
     r = client.post(f"/tags/restore/{album_id}", data={"event_id": anchor})
 
-    assert "MusicBrainz id kept" in r.text
-    assert formats.read_owned(path)["mb_album_id"] == "rel-TagKeep"
+    assert "now Needs MBID" in r.text
+    assert formats.read_owned(path)["mb_album_id"] is None
+
+    after = sc.read(d)
+    assert after is not None
+    assert after.mb_release_id is None, "unlinked"
+    assert after.tagged_at is None
+    assert after.track_count_expected is None
+    assert after.mb_match_candidate is not None
+    assert after.mb_match_candidate.mb_release_id == "rel-TagUnlink", "kept as a suggestion"
+    assert after.mb_match_candidate.notes, "and says why the album is back here"
+    # Confirmable, unlike a surrender — the whole point is a one-click way back.
+    assert after.mb_match_candidate.unmatched_purchase is False
+
+
+def test_undo_unlink_derives_the_album_back_to_needs_mbid(client, cfg):
+    """The transition the sidecar change exists to produce, asserted on the
+    state itself rather than on the fields behind it."""
+    from harmonist import scanner
+    from harmonist.models import AlbumState
+
+    album_id, d, anchor = _tagging_with_tag_changes(cfg, "TagState")
+    client.post(f"/tags/restore/{album_id}", data={"event_id": anchor})
+
+    # NEEDS_MBID, specifically not TAGGING — which is what a sidecar still
+    # naming a release the files no longer carry would derive as, and which has
+    # no action on it and no way out.
+    album = next(a for a in scanner.scan(cfg.paths.music_dir) if a.path == d)
+    assert album.state is AlbumState.NEEDS_MBID
+
+
+def test_undo_unlink_keeps_the_albums_history_reachable(client, cfg):
+    """Unlinking changes the album's id back to its path-derived temp_uid, so
+    the alias row is what stops its whole tagged-era history disappearing from
+    the page (#33)."""
+    from harmonist import activity_store
+
+    album_id, d, anchor = _tagging_with_tag_changes(cfg, "TagAlias")
+    client.post(f"/tags/restore/{album_id}", data={"event_id": anchor})
+
+    new_id = _id_for(cfg, d)
+    assert new_id != album_id, "identity moved"
+    messages = [e.message for e in activity_store.album_history(new_id)]
+    assert any("Re-tagged" in m for m in messages), "the pre-unlink history came with it"
 
 
 def test_undo_names_the_fields_it_left_alone(client, cfg):
@@ -3019,10 +3063,10 @@ def test_undo_tags_button_appears_on_a_tagging_that_changed_tags(client, cfg):
     assert "tag-changes__undo--tags" in client.get(f"/album/{album_id}").text
 
 
-def test_undo_tags_button_is_absent_when_only_the_release_id_changed(client, cfg):
-    """While #158 is pending, the MB id is never reverted — so a tagging whose
-    only tag change was that id has nothing this build can undo, and gets no
-    button rather than one that would do nothing."""
+def test_undo_tags_button_appears_when_only_the_release_id_changed(client, cfg):
+    """A tagging whose only change was the MusicBrainz id is now undoable like
+    any other — that used to be the one case with nothing to offer, because the
+    id was the one field the revert refused (#158)."""
     from harmonist import activity, activity_store, audit
 
     d = _make_album(cfg, "OnlyId")
@@ -3036,7 +3080,7 @@ def test_undo_tags_button_is_absent_when_only_the_release_id_changed(client, cfg
             event_id, file="01 a.m4a", changes={"mb_album_id": [None, "rel-onlyid"]}
         )
 
-    assert "tag-changes__undo--tags" not in client.get(f"/album/{album_id}").text
+    assert "tag-changes__undo--tags" in client.get(f"/album/{album_id}").text
 
 
 def test_undo_tags_rebuilds_its_plan_from_the_albums_own_history(client, cfg):


### PR DESCRIPTION
#157 shipped with one field it refused to revert. Removing `mb_album_id` while the sidecar still named a release left the files and the sidecar disagreeing, which derives as `TAGGING` — the transient spinner, with no action on it and no way out — so the undo skipped it and said so in the flash.

**Let the sidecar follow the files.** When a revert moves the id, `mb_release_id`, `tagged_at` and `track_count_expected` go with it and the album derives as `NEEDS_MBID`, with the release kept as a confirmable suggestion and a note saying why it is there. Confirming re-tags through the ordinary path, so the way back is one click and the track count is rewritten from a real lookup rather than guessed here.

**Identity is now the one all-or-nothing field.** It belongs to the album, not to a file: the sidecar records exactly one release, so reverting the id on the files that still match while leaving the rest would split the album between two releases — `INCONSISTENT`, which the user then repairs by hand — and would leave nothing coherent to write down. `_identity_revert` decides it once, and declines unless every file in the plan agrees on the before value, still carries the after value, and accounts for every file in the directory.

Undoing a **re-match** therefore reverts to the *older* release and suggests that one, not whichever the sidecar happened to hold — that is what the user asked to go back to.

## No schema change

The album-id question that made this look big turned out to be settled already. `temp_uid` is deterministic (`sha256` of the path relative to the library root), so an unlink reproduces the id the album had before it was ever tagged — verified in demo, where it came back as `8a9b9cb8…`, the exact id from before. `_record_identity_alias` already claimed to cover the `MBID -> temp_uid` direction, and the backward walk that history uses is BFS with a seen-set, so the cycle an unlink-then-retag creates is safe.

## Verification

End-to-end in demo mode, not just in tests: **linked → undo → Needs MBID → Confirm & Tag → linked**, with `track_count_expected` rewritten from a real lookup on the way back and the candidate cleared.

Renames are covered both ways. A **directory** rename is handled — the unlink mints its `temp_uid` from the path as it stands, which is the id the scanner will derive, and the history follows. A **file** rename is not: the undo refuses, writing nothing and leaving the album linked. That is the right failure and there is a test for it; using the record's other three track identifiers is #167.

## Also here

- The Needs MBID card no longer renders a per-track comparison table when the candidate has no rows for it — this is the first path to produce one, since building rows needs an MB fetch and an undo makes no network call.
- The design diagram gains the `COMPLETE/INCOMPLETE → NEEDS_MBID` edges. That transition already existed via the "wrong match" pencil and was never recorded.

Follow-ups raised, not folded in: #166 (the pencil and this now duplicate the unlink, and disagree about `track_count_expected`), #167 (rename-aware file lookup), #168 (the demo fixture that made this harder to verify than it should have been).

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)