### PR TITLE
Clear the tag detail along with the events it hangs off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Resetting demo mode now clears the per-field tagging detail along with
+  everything else, instead of leaving it in the history store attached to
+  entries that no longer exist (#165).
+
 ### Added
 
 - Any tagging in an album's History can now be undone: "Undo tag changes" puts

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -833,15 +833,28 @@ def _alias_ancestors(album_id: str, *, max_hops: int = 20) -> list[str]:
 
 
 def clear() -> None:
-    """Drop all stored state — events AND aliases (tests / demo reset).
+    """Drop all stored state — events, their tag detail, AND aliases (tests /
+    demo reset).
 
     Aliases go too: they describe albums in the library this store was recording,
     so after a demo re-seed (or between tests) they'd point at identities that no
     longer exist, and could mis-resolve a deep link to the wrong album.
+
+    `tag_changes` goes too, and used not to. Its rows hang off an event id, so
+    clearing the events without them left detail attached to nothing: invisible,
+    because every reader reaches it by joining from an event that no longer
+    exists, but never collected either — and these are the widest rows in the
+    store, a whole owned-field snapshot per file per tagging. A demo reset a few
+    times over is a slow leak of the one table that grows fastest (#165).
+
+    Child first, so the declared `REFERENCES events (id)` would hold even if the
+    store ever turns on `PRAGMA foreign_keys` — which it does not today, and is
+    why the orphans were possible at all.
     """
     try:
         conn = _ensure()
         with _LOCK:
+            conn.execute("DELETE FROM tag_changes")
             conn.execute("DELETE FROM events")
             conn.execute("DELETE FROM album_aliases")
             conn.commit()

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -397,6 +397,34 @@ def test_clear_drops_aliases_too(tmp_path):
     assert activity_store.resolve_alias("old") is None
 
 
+def test_clear_drops_tag_change_detail_too(tmp_path):
+    """Detail hangs off an event id, so clearing the events without it leaves
+    rows attached to nothing — invisible, since every reader joins from an event
+    that no longer exists, and never collected either (#165).
+
+    These are the widest rows in the store: a whole owned-field snapshot per
+    file per tagging. A demo reset a few times over leaks the fastest-growing
+    table in it.
+    """
+    from harmonist import audit
+
+    activity_store.init(tmp_path / "a.db")
+    event_id = audit.record("tag.track", album_id="alb-1", file="01 a.m4a")
+    assert event_id is not None
+    activity_store.record_tag_changes(
+        event_id, file="01 a.m4a", changes={"album": [None, "Something"]}
+    )
+    assert activity_store.tag_changes_for([event_id])
+
+    activity_store.clear()
+
+    # Asked of the table directly, not through the join: the join would report
+    # these gone whether they were deleted or merely orphaned, which is the
+    # distinction under test.
+    conn = activity_store._ensure()
+    assert conn.execute("SELECT COUNT(*) FROM tag_changes").fetchone()[0] == 0
+
+
 def test_sidecar_write_records_the_identity_change(tmp_path):
     """Capture happens at the sidecar write — the only moment the pair is
     knowable, since normalisation erases temp_uid once an MBID lands."""


### PR DESCRIPTION
`activity_store.clear()` deleted `events` and `album_aliases` but not `tag_changes`, whose rows are keyed to an event id. Wiping the store therefore left detail attached to nothing — invisible, because every reader reaches it by joining from an event that no longer exists, but never collected either.

They are the widest rows in the store (a whole owned-field snapshot per file per tagging), and `clear()` is the demo-reset path as well as the test-teardown one, so a few demo resets leak the fastest-growing table in it.

**Deleted child-first**, so the declared `REFERENCES events (id)` would hold if the store ever turns on `PRAGMA foreign_keys`. Deliberately not turning it on here: databases already in the field carry these orphans, and enabling enforcement would make the `DELETE FROM events` that clears them start failing instead. No table or column changes, so no migration.

The test asks the table directly rather than through `tag_changes_for()` — the join reports these rows gone whether they were deleted or merely orphaned, which is the distinction under test. Mutation-checked: removing the new `DELETE` turns it red.

Found by a #158 test that ran two taggings and got the first one's records back in the second one's plan.

Fixes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)