### PR TITLE
Let demo's album-awaiting-confirmation start untagged, like a real one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Demo mode's album awaiting confirmation now starts untagged, like a real one:
+  confirming it genuinely assigns its MusicBrainz id rather than re-writing tags
+  it already had, so the tagging and undo flows can be tried end to end (#168).
 - Resetting demo mode now clears the per-field tagging detail along with
   everything else, instead of leaving it in the history store attached to
   entries that no longer exist (#165).

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -122,14 +122,24 @@ LIBRARY: list[dict[str, Any]] = [
         "sidecar": {},
     },
     {
-        # State: NEEDS_MBID (with suggestion) — files tagged, candidate stashed but
-        # confidence is "approximate" (lengths off). Side-by-side renders.
+        # State: NEEDS_MBID (with suggestion) — candidate stashed but confidence
+        # is "approximate" (lengths off). Side-by-side renders.
         # Confirm → tags from MB; Reject → back to NEEDS_MBID.
+        #
+        # NO `file_mbid`, deliberately: an album awaiting confirmation has not
+        # been tagged yet — tagging happens ON confirm (§3.1) — so its files
+        # carry no MusicBrainz id. This used to seed one, which made Confirm
+        # re-tag fields that were already there without ever ESTABLISHING the
+        # album's identity, and left the demo with no way to exercise the
+        # commonest first tagging of all (#168).
+        #
+        # The tagged-files-but-unlinked shape is real — it is what the "wrong
+        # match" pencil leaves behind — but it needs no fixture: click the
+        # pencil on any Library album to reach it.
         "artist": "The Thamesmen",
         "album": "Gimme Some Money",
         "tracks": ["Gimme Some Money", "(Listen to the) Flower People", "Cups and Cakes"],
         "cover": "cover-3.jpg",
-        "file_mbid": "demo-rel-thamesmen",
         "sidecar": {
             "store_url": "https://thamesmen.bandcamp.com/album/gimme-some-money",
             "bandcamp_item_id": 1002,


### PR DESCRIPTION
The demo seeded "Gimme Some Money" (The Thamesmen) with an MBID already in its files while its sidecar had none — its own comment said *"files tagged, candidate stashed"*.

That state is real: it is what the "wrong match" pencil leaves behind, and it derives correctly as Needs MBID, since state comes from the sidecar and `_derive_state` never looks at the files for that row. But it is the *unusual* shape, and this was the only album seeded with a suggestion attached — so it was the one anyone reached for to exercise Confirm.

**What it cost.** Confirming it re-tagged fields that were already there and never established the album's identity, leaving the commonest first tagging of all with no demo path to it. Verifying #157's undo and #158's unlink against it showed no unlink at all — correctly, since that tagging never touched `mb_album_id` — and reaching the case meant stripping the id out of the files by hand.

**The fix** is to drop `file_mbid`: an album awaiting confirmation has not been tagged yet, because tagging happens *on* confirm (§3.1). Confirm now assigns the id.

Checked from a clean re-seed rather than from tests alone: confirm → 17 fields written including the release id → undo → *"now Needs MBID — its release is kept as a suggestion"*, with no hand-editing anywhere.

No fixture added for the pencil's tagged-but-unlinked shape — it needs none, since clicking the pencil on any Library album reaches it.

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)