### PR TITLE
Give unlinking one definition, and let the track count go with the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Marking a MusicBrainz match as wrong now clears the track count that came
+  with it, instead of leaving a count describing a release the album is no
+  longer linked to (#166).
 - Demo mode's album awaiting confirmation now starts untagged, like a real one:
   confirming it genuinely assigns its MusicBrainz id rather than re-writing tags
   it already had, so the tagging and undo flows can be tried end to end (#168).

--- a/docs/design.md
+++ b/docs/design.md
@@ -448,6 +448,15 @@ Notes:
   via Picard (§13.2). No sidecar action needed.
 - Forget adds the path to an in-memory exemption set so auto-reconcile
   doesn't immediately reverse it.
+- **Unlinking is one operation, `sidecar.unlink`**, reached two ways: the
+  "wrong match" pencil, and undoing the tagging that linked the album (§4.x,
+  #158). It clears everything that describes the release — `mb_release_id`,
+  `tagged_at`, `track_count_expected` — and keeps the store link, which is not
+  a claim about which MusicBrainz release this is. The two differ only in the
+  `mb_match_candidate` they pass, and that difference is the point: the pencil
+  passes none, because re-offering a release the user just called wrong would
+  undo their own judgement, while the undo passes the release it unlinked so
+  Confirm is the one-click way back.
 
 ### Match confidence (when MB has the URL but the files might not match)
 
@@ -654,7 +663,7 @@ When it does move, the sidecar goes with it: `mb_release_id`, `tagged_at` and `t
 
 **The release is kept as a confirmable suggestion**, not discarded: the Needs MBID card then offers Confirm & Tag, which is the one-click way back, with a note saying why the album is there. Undoing a *re-match* reverts the files to the older release, and that older release — not whichever one the sidecar was holding — is what gets suggested, because it is what the user asked to return to. The candidate carries no `track_comparisons`: building them needs an MB fetch, and an undo makes no network call. Confirming re-tags through the ordinary path, which fetches the release and writes a fresh `track_count_expected`, so nothing here has to guess a track count.
 
-This is the same transition the "wrong match" pencil makes, and deliberately so — it differs only in that the pencil leaves the on-disk tags alone and discards the candidate, since there the release was *wrong* rather than merely undone. See #166 on sharing the mutation between them.
+This is the same transition the "wrong match" pencil makes, and deliberately so: both go through `sidecar.unlink` (§3). It differs only in that the pencil leaves the on-disk tags alone and passes no candidate, since there the release was *wrong* rather than merely undone.
 
 Artwork is not in the plan: it is not an owned tag, and it has its own store, its own availability check and its own button (#131). One button per store, each honest about what it can do.
 

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -159,6 +159,48 @@ def write(album_dir: Path, sidecar: Sidecar) -> None:
     library_index.upsert(album_dir, sidecar)
 
 
+def unlink(album_dir: Path, sidecar: Sidecar, *, candidate: MatchCandidate | None = None) -> None:
+    """Drop the album's MusicBrainz release, sending it back to NEEDS_MBID.
+
+    The one definition of what "unlinked" means, because two paths reach it and
+    they disagreed about it before this existed (#166):
+
+    * the **"wrong match" pencil** — this release is wrong, help me pick another;
+      the on-disk tags are deliberately left alone until the user re-tags;
+    * **undoing the tagging that linked the album** (#158) — the tags have just
+      been put back, so the sidecar follows them.
+
+    Everything that describes the release goes: `mb_release_id`, `tagged_at`,
+    and `track_count_expected`. That last one used to survive a pencil, leaving
+    a track count describing a release the sidecar no longer named — harmless
+    while it went unread (`_derive_state` only consults it inside the
+    `mb_release_id` branch) but untrue, and untrue stored facts are what this
+    codebase spends its time not having.
+
+    The store link (`store_url`, `bandcamp`) stays: which shop it came from is
+    not a claim about which MusicBrainz release it is.
+
+    `candidate` is the caller's, because it is the one thing the two paths must
+    NOT share. The pencil passes None — re-offering a release the user just
+    rejected would undo their own judgement. The undo passes the release it
+    unlinked, so Confirm is the one-click way back.
+
+    Writes through `write()`, so identity is normalised to the path-derived
+    `temp_uid` and the MBID -> temp_uid alias is recorded — which is what keeps
+    the album's history reachable from its new id (#33).
+    """
+    write(
+        album_dir,
+        replace(
+            sidecar,
+            mb_release_id=None,
+            tagged_at=None,
+            track_count_expected=None,
+            mb_match_candidate=candidate,
+        ),
+    )
+
+
 def album_id_for(album_dir: Path) -> str | None:
     """The album's canonical id as recorded ON DISK right now, or None if it has
     no sidecar yet.

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1436,6 +1436,10 @@ def _unlink_after_revert(album: Album, outcome: tagger_mod.RevertOutcome) -> boo
     writes a fresh `track_count_expected`, so nothing here has to guess a track
     count it has no lookup for.
 
+    The mutation itself is `sidecar.unlink`, shared with the "wrong match"
+    pencil (#166) — the two differ only in the candidate they pass, which is
+    exactly the part that should differ.
+
     Returns whether the sidecar was rewritten.
     """
     sc = album.sidecar
@@ -1464,19 +1468,7 @@ def _unlink_after_revert(album: Album, outcome: tagger_mod.RevertOutcome) -> boo
         if suggest
         else None
     )
-    # `mb_release_id=None` makes `sidecar.write` mint the path-derived temp_uid
-    # and record the MBID -> temp_uid alias, which is what keeps the album's
-    # pre-unlink history reachable from its new id (#33).
-    sidecar_mod.write(
-        album.path,
-        replace(
-            sc,
-            mb_release_id=None,
-            tagged_at=None,
-            track_count_expected=None,
-            mb_match_candidate=candidate,
-        ),
-    )
+    sidecar_mod.unlink(album.path, sc, candidate=candidate)
     return True
 
 
@@ -2878,12 +2870,18 @@ def _register_routes(app: FastAPI) -> None:
 
     @app.post("/library/{album_id}/rematch", response_class=HTMLResponse)
     def library_rematch(request: Request, album_id: str) -> Response:
-        """Mark the MusicBrainz match as wrong. Clears `mb_release_id` (and
-        `tagged_at`), which derives the album back to Needs MBID — where the
-        manual search / store-URL-candidate tools let the user pick the correct
-        release and re-tag. `sidecar.write` mints a `temp_uid` and audits the
-        identity change; the Bandcamp link (`store_url` / `item_id`) is kept, and
-        the on-disk tags are left untouched until the user re-tags. Non-destructive."""
+        """Mark the MusicBrainz match as wrong, deriving the album back to Needs
+        MBID — where the manual search / store-URL-candidate tools let the user
+        pick the correct release and re-tag.
+
+        Unlinks through `sidecar.unlink`, shared with the undo that removes a
+        release id (#158/#166): it mints the path-derived `temp_uid`, audits the
+        identity change, and keeps the Bandcamp link (`store_url` / `item_id`).
+        No candidate — re-offering the release the user just called wrong would
+        undo their own judgement, which is the one way this differs from the undo.
+
+        The on-disk tags are left untouched until the user re-tags.
+        Non-destructive."""
         album = _find_album(request, album_id)
         sc = album.sidecar
         if sc is None or not sc.mb_release_id:
@@ -2894,8 +2892,7 @@ def _register_routes(app: FastAPI) -> None:
                 album=album,
             )
         old_mbid = sc.mb_release_id
-        new_sc = replace(sc, mb_release_id=None, tagged_at=None, mb_match_candidate=None)
-        sidecar_mod.write(album.path, new_sc)
+        sidecar_mod.unlink(album.path, sc)
         activity.record(
             f"Cleared MB match for {album.artist} — {album.title} "
             f"(was {old_mbid}): Library → Needs MBID"

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 import shutil
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest import mock
@@ -2350,6 +2351,50 @@ def test_rematch_clears_mbid_and_demotes_to_needs_mbid(client, cfg):
     # Non-destructive: the on-disk tag is untouched until the user re-tags.
     assert MP4(d / "01 Track.m4a")[ATOM_MB_ALBUM_ID][0].decode() == "rel-wrong"
     assert next(a for a in scan(cfg.paths.music_dir) if a.path == d).state == AlbumState.NEEDS_MBID
+
+
+def test_rematch_clears_the_track_count_of_the_release_it_dropped(client, cfg):
+    """`track_count_expected` describes the MB release, so it goes with it (#166).
+
+    It used to survive a re-match, leaving a count describing a release the
+    sidecar no longer named. Nothing read it while the album was unlinked —
+    `_derive_state` only consults it inside the `mb_release_id` branch — so it
+    was harmless, and it was still a stored fact that had stopped being true.
+    """
+    d = _make_tagged_album(
+        cfg, "Counted", mbid="rel-counted", tagged_at=datetime.now(UTC), item_id=7
+    )
+    before = sc.read(d)
+    assert before is not None
+    sc.write(d, replace(before, track_count_expected=9))
+
+    client.post(f"/library/{_id_for(cfg, d)}/rematch")
+
+    loaded = sc.read(d)
+    assert loaded is not None
+    assert loaded.mb_release_id is None
+    assert loaded.track_count_expected is None, "the count went with the release"
+    assert loaded.tagged_at is None
+    assert loaded.store_url is not None, "the store link is not a claim about the release"
+
+
+def test_rematch_offers_no_suggestion_but_an_undo_does(client, cfg):
+    """The one thing the two unlink paths must NOT share (#166).
+
+    A re-match means the release was wrong, so putting it straight back as a
+    suggestion would undo the user's own judgement. An undo means "put it back",
+    so keeping it is the one-click way home.
+    """
+    d = _make_tagged_album(cfg, "NoSuggestion", mbid="rel-nosug", tagged_at=datetime.now(UTC))
+
+    client.post(f"/library/{_id_for(cfg, d)}/rematch")
+
+    loaded = sc.read(d)
+    assert loaded is not None
+    assert loaded.mb_match_candidate is None
+
+    # The undo's side of the contract is covered by
+    # test_undo_unlinks_the_album_and_keeps_its_release_as_a_suggestion.
 
 
 def test_rematch_warns_when_no_mb_release(client, cfg):


### PR DESCRIPTION
Two paths drop an album back to Needs MBID — the "wrong match" pencil, and undoing the tagging that linked it (#158). They performed the same sidecar mutation in two places, and had already drifted:

| | rematch (before) | undo | now |
|---|---|---|---|
| `mb_release_id` | cleared | cleared | cleared |
| `tagged_at` | cleared | cleared | cleared |
| `track_count_expected` | **left** | cleared | cleared |
| `mb_match_candidate` | none | the unlinked release | **caller's** |

**The stale track count.** Nothing read it while the album was unlinked — `_derive_state` only consults it inside the `mb_release_id` branch — so this was harmless in practice. It was still a stored fact that had stopped being true, and the next thing to read it would have got an answer about the previous release. Review-gate item 3 asks that every persisted field be load-bearing; this one stops being load-bearing the moment the release goes.

**`sidecar.unlink` is now the one definition.** It lives in `sidecar.py` because identity is that module's business — the same reason `album_id_for` is there — which also makes it testable without going through the web layer. The store link (`store_url`, `bandcamp`) is kept: which shop an album came from is not a claim about which MusicBrainz release it is.

**The candidate stays the caller's**, because it is the one thing the two must *not* share. The pencil passes none — re-offering a release the user just called wrong would undo their own judgement — and the undo passes the release it unlinked, so Confirm is the one-click way back. There's a test for each side.

Mutation-checked: dropping the `track_count_expected=None` turns the new test red.

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)