### PR TITLE
Say on the album page when only some files carry the MusicBrainz id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- An album whose files don't all carry the MusicBrainz id now says so on its own
+  page — "MusicBrainz id on 1 of 3 tracks", beside the Re-tag from MB button that
+  fixes it. Only the Library tile mentioned it, and the album page's Tracks
+  section reported "All 3 tracks match MusicBrainz" (#175).
 - "All N fields match MusicBrainz" no longer counts Genre and Comment, which
   MusicBrainz has no counterpart for and which were never compared — an album
   with 7 comparable fields said 9 (#164).

--- a/templates/partials/library_detail.html
+++ b/templates/partials/library_detail.html
@@ -101,6 +101,37 @@
                 {% endif %}
             </div>
             {% endif %}
+
+            {# Only SOME files carry the MusicBrainz Album Id (#175). The Library
+               tile has said "1/3 tagged" since #139, but the album page — where
+               you'd act on it — said nothing at all, and the Tracks section below
+               reports "All 3 tracks match MusicBrainz": true of the fields it
+               compares (title, artist, number, length), and a blanket all-clear
+               to read. The id isn't among them, because it is the album's
+               IDENTITY rather than metadata, so a file missing it produces no
+               finding anywhere on this page.
+
+               It sits with the badges and directly above the actions on purpose:
+               Re-tag from MB is the remedy — it writes the id to the files
+               missing it — and the finding is useless three sections away from
+               the button that fixes it.
+
+               Derived, never stored: `partial_tag_count` is worked out by the
+               scanner from the files themselves on every scan (§15.1). It is a
+               quality indicator, not a state — the album is legitimately
+               COMPLETE, which is exactly why it needs saying out loud. #}
+            {% if album.partial_tag_count %}
+            <p class="mt-2 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-2xs font-bold
+                      bg-amber-50 text-amber-800 border border-amber-300"
+               title="Re-tag from MB writes the MusicBrainz Album Id to the {{ album.partial_tag_count[1] - album.partial_tag_count[0] }} file(s) missing it.">
+                <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor"
+                     stroke-width="2" aria-hidden="true" class="flex-shrink-0">
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                          d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                </svg>
+                MusicBrainz id on {{ album.partial_tag_count[0] }} of {{ album.partial_tag_count[1] }} tracks
+            </p>
+            {% endif %}
             </div>{# /left of the row: badges #}
 
             {# A two-column grid so labels and values each right-align into their

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2262,6 +2262,29 @@ def test_library_detail_shows_store_url_and_item_id(client, cfg):
     assert "42" in r.text  # item_id
 
 
+def test_album_page_says_when_only_some_files_carry_the_mb_id(client, cfg):
+    """#175: the Library tile has said "1/3 tagged" since #139, but the album page
+    said nothing — and its Tracks section reports "All N tracks match MusicBrainz",
+    because the MB Album Id is identity rather than a compared field, so a file
+    missing it produces no finding there. The album is legitimately COMPLETE; that
+    is exactly why it has to be said out loud."""
+    from datetime import datetime
+
+    d = _make_tagged_album(cfg, "Half", mbid="abc-123", tagged_at=datetime.now(UTC))
+    shutil.copy(SINE_M4A, d / "02 Track.m4a")  # second file, no MB Album Id atom
+    body = client.get(f"/album/{_id_for(cfg, d)}").text
+    assert "MusicBrainz id on 1 of 2 tracks" in body
+
+
+def test_album_page_stays_quiet_when_every_file_is_tagged(client, cfg):
+    """The normal case must not grow a warning — `partial_tag_count` is None both
+    when every file carries the id and when none does."""
+    from datetime import datetime
+
+    d = _make_tagged_album(cfg, "Whole", mbid="abc-123", tagged_at=datetime.now(UTC))
+    assert "MusicBrainz id on" not in client.get(f"/album/{_id_for(cfg, d)}").text
+
+
 def test_library_detail_omits_bandcamp_removal_controls(client, cfg):
     """#42 interim: the Bandcamp link-removal controls (× forget-URL and Unlink) are
     temporarily pulled — with no way to re-link a Library album, removing a link is a


### PR DESCRIPTION
The Library tile has said "1/3 tagged" since #139. Click through to the album page — the place you go to do something about it — and there was nothing, while the Tracks section said "All 3 tracks match MusicBrainz".

That sentence is true of what it compared. `TracklistComparison` looks at title, artist, number and length; the MusicBrainz Album Id is not among them, because it is the album's *identity* rather than metadata, so a file missing it produces no finding anywhere on the page. Read next to a tile that just said 1/3, it is a blanket all-clear.

INCOMPLETE needs no such help — MusicBrainz's tracklist is compared against the files, so a short album already reads "2 of 4 tracks differ from MusicBrainz · 2 not on disk". Partial tagging has no natural home, and `partial_tag_count` was rendered in exactly one place in the codebase.

**The change:** a chip in the album panel, beside the badges and directly above the actions — because **Re-tag from MB** is the remedy and writes the id to precisely the files missing it. A finding three sections away from the button that fixes it is a finding nobody acts on.

```
(MusicBrainz) ✎  (Bandcamp)
⚠ MusicBrainz id on 1 of 3 tracks
PATH    Various Artists/The Rural Juror (OST)
FORMAT  ALAC
──────────────────────────────────────────
[ RE-TAG FROM MB ]  [ FORGET ]
```

Nothing new is persisted — `partial_tag_count` is worked out by the scanner from the files on every scan (§15.1). It is a quality indicator, not a state: the album is legitimately COMPLETE, which is exactly why it needs saying out loud.

**Verified** in demo mode by stripping the id atom from two of three files of a seeded album: the chip appears, and clicking Re-tag from MB clears it. `make check` green.

**Deliberately out of scope:** any change to `TracklistComparison.summary`'s wording (folding a fourth thing into that sentence reopens the counting question #164 just settled), and marking *which* tracks lack the id.

Fixes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bAzfpUm4BMtVe69UcvG2b
