### PR TITLE
Split the README into a pitch plus docs/ for the rest

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -44,10 +44,11 @@ retroactively.
 
 ## 2. Sweep the docs for staleness
 
-A release is when someone new reads `README.md` and `docs/design.md`. Grep them
-for whatever this cycle removed or renamed — states, routes, UI surfaces,
-flags. 1.5.0 was about to ship with `docs/design.md` still telling users to
-click Re-tag from MB "in the detail modal", a surface deleted an hour earlier.
+A release is when someone new reads `README.md`, `docs/usage.md` and
+`docs/design.md`. Grep them for whatever this cycle removed or renamed — states,
+routes, UI surfaces, flags. 1.5.0 was about to ship with `docs/design.md` still
+telling users to click Re-tag from MB "in the detail modal", a surface deleted an
+hour earlier. `docs/usage.md` is the likeliest to rot: it names buttons.
 
 ## 3. Roll the changelog and bump the version
 
@@ -127,7 +128,7 @@ Confirm from the workflow run, not the registry: reading published tags via
 ## Done when
 
 - [ ] every commit since the last tag is in the changelog or genuinely internal
-- [ ] `README.md` and `docs/design.md` describe what actually shipped
+- [ ] `README.md`, `docs/usage.md` and `docs/design.md` describe what shipped
 - [ ] `pyproject.toml` bumped, `make check` green
 - [ ] `Release X.Y.Z` commit, GPG-signed tag verified locally
 - [ ] commit pushed, then tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,16 @@ then follow the conventions below.
 
 ## Read these first (don't duplicate them here)
 
-- **`README.md`** — what Harmonist is and where it fits, running it (Docker /
-  from source / demo mode), configuration, deployment & security, the tech stack.
+- **`README.md`** — the pitch: what Harmonist is, where it fits against Picard /
+  Lidarr / beets, the two guarantees it makes, the tech stack. It links out
+  rather than explaining; keep it that way.
+- **`docs/usage.md`** — the user guide: onboarding an existing library, the
+  inbox, syncing, the Library and its filters, an album's page, undo, activity.
+  User-visible behavior gets documented **here**, not in the README.
+- **`docs/installation.md`** — Docker (incl. Synology/ACL permissions), from
+  source, demo mode, the `harmonist.toml` reference, uninstall.
+- **`docs/deployment.md`** — the security posture: reverse proxy, allowed hosts,
+  built-in Basic auth.
 - **`docs/design.md`** — the design spec and source of truth for *how it's meant
   to work*: use cases, the album **state machine** (states + transition diagram),
   the **sidecar schema**, the tagging contract, cover art, the **module map**,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ CI can validate them. When in doubt, just open the PR; a maintainer will help.
 
 ## Where to read more
 
-- **`README.md`** — what Harmonist is, how to run it, configuration, deployment.
+- **`README.md`** — what Harmonist is and where it fits.
+- **`docs/usage.md`** — the user guide; **`docs/installation.md`** for running and
+  configuring it, **`docs/deployment.md`** for exposing it safely.
 - **`docs/design.md`** — the design spec: states, the sidecar schema, the tagging
   contract, and the matching/linking mechanics.

--- a/README.md
+++ b/README.md
@@ -19,17 +19,59 @@ gets mislabeled.
   releases straight to [Harmony](https://harmony.pulsewidth.org.uk).
 - **Picard-compatible tagging** across `.m4a`, `.mp3`, `.flac`, `.ogg`, and
   `.opus`, embedding the MusicBrainz Release ID and cover art.
-- **Library view** of everything done, with an on-demand "verify tagging vs
-  MusicBrainz" check.
-- **A full record of every change** — Harmonist never edits your files silently.
-  Each entry in the Activity feed expands to show exactly what it did underneath
-  (see [Nothing happens silently](#nothing-happens-silently)).
-- **See what a tagging changed — and undo it.** Every tag write is recorded field
-  by field, so an album's History shows what moved and can put it back, cover art
-  included (see [Nothing is a one-way door](#nothing-is-a-one-way-door)).
+- **A library view** that finds the albums that are finished but not *right* —
+  incomplete, partially tagged, or missing artwork — and compares any album's
+  tags and tracklist against MusicBrainz, field by field.
+- **A full record of every change**, and a way back from it: Harmonist never edits
+  your files silently, and every tagging can be undone (see
+  [Nothing happens silently](#nothing-happens-silently) and
+  [Nothing is a one-way door](#nothing-is-a-one-way-door)).
 
 The UI is a single page with **Inbox / Library / Activity** tabs, built with
 HTMX — no SPA, no build step at runtime.
+
+## Demo
+
+A short walk-through of the flow — inbox triage, matching, and a link-only sync:
+
+https://github.com/user-attachments/assets/dc08c85f-43f8-402a-85a5-09388200c239
+
+Or try it yourself against a sandboxed sample library, with no Bandcamp account
+and no real network traffic:
+
+```bash
+HARMONIST_DEMO_MODE=1 uvicorn harmonist.web.main:app --reload
+```
+
+## Quickstart
+
+```yaml
+# docker-compose.yml — edit the two paths and the uid:gid, then `docker compose up -d`
+services:
+  harmonist:
+    image: ghcr.io/randomphrase/harmonist:latest
+    restart: unless-stopped
+    ports: ["8000:8000"]
+    volumes:
+      - /path/to/music:/music     # your music library
+      - /path/to/config:/config   # settings, cookies, history
+    user: "1000:1000"             # the OWNER of those two dirs
+```
+
+Then visit `http://<host>:8000`. Full instructions — permissions, Synology/ACL
+shares, running from source, configuration — are in
+**[docs/installation.md](docs/installation.md)**.
+
+## Documentation
+
+- **[Usage guide](docs/usage.md)** — onboarding an existing library, working the
+  inbox, syncing, the Library and its filters, an album's page, undo, activity.
+- **[Installation](docs/installation.md)** — Docker, from source, demo mode,
+  configuration, uninstall.
+- **[Deployment & security](docs/deployment.md)** — reverse proxy, hostname
+  allow-listing, built-in auth. **Read this before exposing Harmonist.**
+- **[Design](docs/design.md)** — the internal spec: state machine, sidecar schema,
+  tagging contract, module map. Written for people changing the code.
 
 ## Where Harmonist fits
 
@@ -104,26 +146,12 @@ show precisely what:
                  cover.write  file=cover.jpg source=caa overwrote=False
 ```
 
-The properties that make it trustworthy rather than decorative:
-
-- **Durable.** Kept in SQLite in your config dir, so it survives restarts and
-  isn't evicted. Nothing is pruned.
-- **Complete.** Tag writes, sidecar rewrites, file moves and overwrites, cover
-  art, checkpoint clears, surrenders — and erasing sidecars names every album
-  that lost one, because that's the most destructive thing Harmonist can do.
-- **Attributable.** Every record is tied to the action that caused it, so the
-  detail under an entry is *that* action's work, not everything that happened
-  around the same moment.
-- **Still readable later.** Entries keep the album's name as it was, and follow
-  an album across re-identification — so history doesn't rot when a release is
-  re-matched or renamed.
-- **Honest when it can't answer.** If Harmonist can't read its own history it
-  says so, rather than showing you an empty feed. "Nothing happened" and "I
-  couldn't tell you" are different claims, and only one of them is ever a guess.
-
-Album names in the feed link straight to that album's page, where the same
-history is gathered in one place — including the records written before the
-album was last re-identified.
+It's durable (SQLite in your config dir, nothing pruned), complete (down to
+sidecar rewrites, file moves and every album that loses a sidecar), attributable
+to the action that caused it, still readable after an album is re-matched or
+renamed — and honest when it *can't* answer, because "nothing happened" and "I
+couldn't tell you" are different claims and only one of them is ever a guess.
+[More in the usage guide](docs/usage.md#activity).
 
 ## Nothing is a one-way door
 
@@ -145,226 +173,7 @@ files and Harmonist's own record can't quietly disagree: the album returns to
 Needs MBID with that release kept as a one-click suggestion. The undo is itself
 recorded, so it can be undone in turn. Cover art has its own Undo, from a bounded
 store of the images that re-tags have overwritten.
-
-## Demo
-
-A short walk-through of the flow — inbox triage, matching, and a link-only sync:
-
-https://github.com/user-attachments/assets/dc08c85f-43f8-402a-85a5-09388200c239
-
-<!-- Stills can be added later, e.g.
-![Inbox](docs/screenshots/inbox.png)
-![Library](docs/screenshots/library.png)
-![Activity](docs/screenshots/activity.png)
--->
-
-
-## Running
-
-### Docker (recommended)
-
-Copy this into a `docker-compose.yml`, edit the two host paths and the `user:`,
-then `docker compose up -d` and visit `http://<host>:8000`:
-
-```yaml
-services:
-  harmonist:
-    image: ghcr.io/randomphrase/harmonist:latest   # published to GHCR, linux/amd64
-    container_name: harmonist
-    restart: unless-stopped
-    ports:
-      - "8000:8000"
-    volumes:
-      - /path/to/music:/music     # your music library
-      - /path/to/config:/config   # persistent: harmonist.toml, cookies.txt, ignores.txt, id registry, activity.db
-    # Run as the OWNER of the two host dirs above, so sidecars, tags and cover.*
-    # files aren't written as root. `id -u` / `id -g` to find yours; omit to run
-    # as root. (Synology: usually a 1026+ uid and gid 100 — the `users` group.)
-    user: "1000:1000"
-    # Only if you expose Harmonist beyond localhost: restrict the hostname
-    # allow-list (DNS-rebinding protection). Loopback is always allowed.
-    # environment:
-    #   - HARMONIST_ALLOWED_HOSTS=harmonist.example.com,nas.local
-```
-
-**Permissions.** Make the host `music`/`config` dirs writable by that `user:`
-*before* starting — Docker won't `chown` them for you (`sudo chown -R 1000:1000
-/path/to/music /path/to/config`). On startup Harmonist probe-writes both and
-fails fast with a clear message if either isn't writable, so a permission problem
-announces itself instead of looking like a stuck scan.
-
-**Synology / ACL shares:** `user:` sets the uid and *primary* gid only — not
-your supplementary groups. So `1026:100` has `groups=[100]` even though your
-login is also in `administrators` (101); if the share grants write via that
-group or a DSM ACL, the container is denied despite the "right" uid. Cleanest
-fix: grant **Authenticated Users** (or the `users` group) Read/Write
-**recursively** on the music + config shared folders.
-
-### From source (dev)
-
-```bash
-pip install -e ".[dev]"
-uvicorn harmonist.web.main:app --reload      # http://127.0.0.1:8000
-```
-
-### Demo mode
-
-Explore with a mocked, sandboxed sample library — no real Bandcamp/MusicBrainz
-traffic, and your real `music_dir` is never touched:
-
-```bash
-HARMONIST_DEMO_MODE=1 uvicorn harmonist.web.main:app --reload
-```
-
-## Configuration
-
-Config is read at startup from `harmonist.toml` in the config dir
-(`~/.config/harmonist/` by default, `/config` in Docker), overridable by
-`HARMONIST_*` environment variables. Most settings (download format, MB
-user-agent, cover-art size, download cap, log level) are editable live from the
-**Settings** page; library/config paths require a restart.
-
-```toml
-# ~/.config/harmonist/harmonist.toml
-[paths]
-music_dir = "/path/to/music"      # absolute (TOML doesn't expand ~)
-
-[bandcamp]
-download_format = "flac"
-max_downloads_per_sync = 25       # safety cap
-
-[musicbrainz]
-user_agent = "Harmonist/1.0 ( you@example.com )"
-```
-
-Bandcamp sync needs a `cookies.txt` (exported from a logged-in browser) — paste
-or upload it via the in-app **Set up Bandcamp sync** prompt.
-
-## Onboarding an existing library
-
-Point Harmonist at a music library you already have and it does its best to
-**adopt** it — recognizing what's already tagged, linking your previous Bandcamp
-downloads to your purchases, and flagging the rest for review — all **without
-re-downloading anything you own**.
-
-It works best on a library that's already in reasonable shape. Harmonist assumes:
-
-- **One album per folder** — each directory of audio files is treated as a single
-  album. A folder mixing several albums is flagged **Inconsistent**; split it with
-  [Picard](https://picard.musicbrainz.org) first.
-- **Already tagged** — ideally Picard-tagged. Harmonist reads the MusicBrainz
-  Album ID from your files to recognize what's matched; anything untagged lands in
-  the inbox for you to match by hand.
-
-**What to expect on the first scan.** Every album is sorted into the inbox by what
-it needs:
-
-- **Library** — already tagged and matched; nothing to do.
-- **Needs MBID** — not matched to a MusicBrainz release yet. Resolve it from the
-  inbox: search by name, paste an MBID, or seed a missing release via
-  [Harmony](https://harmony.pulsewidth.org.uk).
-- **Needs Link** — a Bandcamp-sourced album that's tagged but not yet tied to its
-  purchase (a sync fills that in).
-
-**Recommended order:**
-
-1. **Get everything matched first.** Work through **Needs MBID** — this is the one
-   step that genuinely needs you; untagged/unmatched albums are the main thing
-   Harmonist can't do on its own. Aim to clear it *before* your first sync.
-2. **Then run your first Sync.** While unlinked albums remain, that sync runs in
-   **link-only** mode: it links your on-disk albums to your Bandcamp purchases and
-   **downloads nothing new**. Anything it can't confidently match surfaces as a
-   *potential download* to Match / Download / skip.
-3. Once everything's linked, later syncs fetch genuinely new purchases as normal.
-
-## Deployment & security
-
-Harmonist stores a Bandcamp session cookie (a real credential — it's how the
-sync logs in to your account) and exposes destructive actions: bulk tagging,
-"Forget", and "erase all sidecars". It is **not** built to face the public
-internet directly. The expected deployment is single-user, on a private network
-or behind a reverse proxy that handles authentication.
-
-**What ships in the box.** Three layers of defense apply automatically:
-
-1. **Loopback by default.** `server.host = 127.0.0.1` unless you change it.
-   (The Docker image overrides this to `0.0.0.0` because container networking
-   requires it — see below.)
-2. **CSRF protection.** All state-changing requests require an `HX-Request:
-   true` header (sent by HTMX, not by a malicious cross-origin form) plus a
-   matching `Origin`/`Referer`. This blocks drive-by CSRF even if you're
-   already logged in.
-3. **Hostname allow-listing** via `server.allowed_hosts` (DNS-rebinding
-   protection). Default is `["*"]` (permissive — see below).
-
-**Recommended deployment:** put Harmonist behind a reverse proxy on its own
-hostname, with TLS (e.g. Let's Encrypt) and authentication handled by the
-proxy. Caddy, nginx, Traefik, Authelia, Authentik, and Tailscale Serve all
-work; pick what you already run. Then lock down the hostname allow-list to
-match:
-
-```toml
-[server]
-host = "0.0.0.0"                              # for Docker / LAN bind
-allowed_hosts = ["harmonist.example.com",     # your real hostname
-                 "localhost", "127.0.0.1"]    # keep healthchecks working
-```
-
-**If you can't put a proxy in front**, enable the built-in HTTP Basic auth as
-a fallback:
-
-```bash
-python -m harmonist.web.security
-# Password: ********
-# Confirm:  ********
-#
-# password_hash = "pbkdf2_sha256$600000$...$..."
-```
-
-```toml
-[auth]
-enabled = true
-username = "alice"
-password_hash = "pbkdf2_sha256$600000$...$..."   # paste from the CLI above
-```
-
-Restart, and every request except `/healthz` is gated by Basic auth.
-Basic auth without TLS sends the password in plaintext on every request —
-**always pair it with HTTPS** (i.e. with a reverse proxy or a Tailscale tunnel).
-
-**Do not expose Harmonist's raw port to the internet.** The combination of a
-credential-holding tagger and destructive endpoints is not something you want
-behind nothing but luck.
-
-## Uninstall
-
-All of Harmonist's state lives in `.harmonist.json` **sidecar** files next to your
-albums — your audio, its MusicBrainz tags, and `cover.*` art are just your library
-and carry nothing Harmonist-specific. To remove it cleanly:
-
-1. **Settings → Erase sidecars.** This deletes every `.harmonist.json`; your
-   tagged audio and cover files are not touched.
-2. **Stop the app straight away — don't return to the Inbox.** Opening the inbox
-   triggers a re-scan and reconcile, which would re-derive the sidecars from your
-   files' tags. Shut down first (e.g. `docker compose down`) and the library is
-   left sidecar-free.
-
-Your music stays fully tagged and Picard-compatible, with no trace of Harmonist.
-To also drop the stored Bandcamp cookie and settings, delete the config dir.
-
-## Development
-
-```bash
-make check     # ruff lint + format check + mypy --strict + pytest
-make css       # rebuild static/harmonist.css (Tailwind v4, no Node)
-```
-
-CI (GitHub Actions) runs the same gate on Python 3.12 / 3.13 plus a CSS-drift
-check. The Tailwind CLI is pinned for reproducible output.
-
-**Tech:** Python 3.12+, FastAPI, HTMX + Jinja2, Tailwind CSS (via
-`pytailwindcss`), `mutagen`, `musicbrainzngs`, `bandcampsync`, `httpx` +
-BeautifulSoup, Pydantic, `tomlkit`.
+[More in the usage guide](docs/usage.md#undoing-a-tagging).
 
 ## How it's built
 
@@ -384,6 +193,20 @@ helped *build* it; it has no part in *running* it — which is exactly the idea
 behind "asks before it guesses": exact, auditable matches, never a model's guess.
 
 If something falls short of that bar, please open an issue.
+
+**Tech:** Python 3.12+, FastAPI, HTMX + Jinja2, Tailwind CSS (via
+`pytailwindcss`), `mutagen`, `musicbrainzngs`, `bandcampsync`, `httpx` +
+BeautifulSoup, Pydantic, `tomlkit`.
+
+## Contributing
+
+```bash
+make check     # ruff lint + format check + mypy --strict + pytest
+make css       # rebuild static/harmonist.css (Tailwind v4, no Node)
+```
+
+CI runs the same gate on Python 3.12 / 3.13 plus a CSS-drift check. See
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,67 @@
+# Deployment & security
+
+Read this before Harmonist is reachable by anything other than your own machine.
+For getting it running in the first place, see
+**[installation.md](installation.md)**.
+
+Harmonist stores a Bandcamp session cookie (a real credential — it's how the
+sync logs in to your account) and exposes destructive actions: bulk tagging,
+"Forget", and "erase all sidecars". It is **not** built to face the public
+internet directly. The expected deployment is single-user, on a private network
+or behind a reverse proxy that handles authentication.
+
+## What ships in the box
+
+Three layers of defense apply automatically:
+
+1. **Loopback by default.** `server.host = 127.0.0.1` unless you change it.
+   (The Docker image overrides this to `0.0.0.0` because container networking
+   requires it — see below.)
+2. **CSRF protection.** All state-changing requests require an `HX-Request:
+   true` header (sent by HTMX, not by a malicious cross-origin form) plus a
+   matching `Origin`/`Referer`. This blocks drive-by CSRF even if you're
+   already logged in.
+3. **Hostname allow-listing** via `server.allowed_hosts` (DNS-rebinding
+   protection). Default is `["*"]` (permissive — see below).
+
+## Recommended: a reverse proxy
+
+Put Harmonist behind a reverse proxy on its own hostname, with TLS (e.g. Let's
+Encrypt) and authentication handled by the proxy. Caddy, nginx, Traefik,
+Authelia, Authentik, and Tailscale Serve all work; pick what you already run.
+Then lock down the hostname allow-list to match:
+
+```toml
+[server]
+host = "0.0.0.0"                              # for Docker / LAN bind
+allowed_hosts = ["harmonist.example.com",     # your real hostname
+                 "localhost", "127.0.0.1"]    # keep healthchecks working
+```
+
+## Fallback: built-in Basic auth
+
+**If you can't put a proxy in front**, enable the built-in HTTP Basic auth as
+a fallback:
+
+```bash
+python -m harmonist.web.security
+# Password: ********
+# Confirm:  ********
+#
+# password_hash = "pbkdf2_sha256$600000$...$..."
+```
+
+```toml
+[auth]
+enabled = true
+username = "alice"
+password_hash = "pbkdf2_sha256$600000$...$..."   # paste from the CLI above
+```
+
+Restart, and every request except `/healthz` is gated by Basic auth.
+Basic auth without TLS sends the password in plaintext on every request —
+**always pair it with HTTPS** (i.e. with a reverse proxy or a Tailscale tunnel).
+
+**Do not expose Harmonist's raw port to the internet.** The combination of a
+credential-holding tagger and destructive endpoints is not something you want
+behind nothing but luck.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,105 @@
+# Installing Harmonist
+
+How to get Harmonist running and configured. Once it's up, see
+**[usage.md](usage.md)** for what to do with it, and **[deployment.md](deployment.md)**
+before you expose it beyond your own machine.
+
+## Docker (recommended)
+
+Copy this into a `docker-compose.yml`, edit the two host paths and the `user:`,
+then `docker compose up -d` and visit `http://<host>:8000`:
+
+```yaml
+services:
+  harmonist:
+    image: ghcr.io/randomphrase/harmonist:latest   # published to GHCR, linux/amd64
+    container_name: harmonist
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    volumes:
+      - /path/to/music:/music     # your music library
+      - /path/to/config:/config   # persistent: harmonist.toml, cookies.txt, ignores.txt, id registry, activity.db
+    # Run as the OWNER of the two host dirs above, so sidecars, tags and cover.*
+    # files aren't written as root. `id -u` / `id -g` to find yours; omit to run
+    # as root. (Synology: usually a 1026+ uid and gid 100 — the `users` group.)
+    user: "1000:1000"
+    # Only if you expose Harmonist beyond localhost: restrict the hostname
+    # allow-list (DNS-rebinding protection). Loopback is always allowed.
+    # environment:
+    #   - HARMONIST_ALLOWED_HOSTS=harmonist.example.com,nas.local
+```
+
+**Permissions.** Make the host `music`/`config` dirs writable by that `user:`
+*before* starting — Docker won't `chown` them for you (`sudo chown -R 1000:1000
+/path/to/music /path/to/config`). On startup Harmonist probe-writes both and
+fails fast with a clear message if either isn't writable, so a permission problem
+announces itself instead of looking like a stuck scan.
+
+**Synology / ACL shares:** `user:` sets the uid and *primary* gid only — not
+your supplementary groups. So `1026:100` has `groups=[100]` even though your
+login is also in `administrators` (101); if the share grants write via that
+group or a DSM ACL, the container is denied despite the "right" uid. Cleanest
+fix: grant **Authenticated Users** (or the `users` group) Read/Write
+**recursively** on the music + config shared folders.
+
+## From source (dev)
+
+```bash
+pip install -e ".[dev]"
+uvicorn harmonist.web.main:app --reload      # http://127.0.0.1:8000
+```
+
+## Demo mode
+
+Explore with a mocked, sandboxed sample library — no real Bandcamp/MusicBrainz
+traffic, and your real `music_dir` is never touched:
+
+```bash
+HARMONIST_DEMO_MODE=1 uvicorn harmonist.web.main:app --reload
+```
+
+The sample library covers every album state, including a mis-tag and an album
+with no cover art, so the flows in [usage.md](usage.md) can be tried end to end
+before you point Harmonist at anything you care about. A **Reset Demo** button
+puts the sandbox back to its original state.
+
+## Configuration
+
+Config is read at startup from `harmonist.toml` in the config dir
+(`~/.config/harmonist/` by default, `/config` in Docker), overridable by
+`HARMONIST_*` environment variables. Most settings (download format, MB
+user-agent, cover-art size, download cap, log level) are editable live from the
+**Settings** page; library/config paths require a restart.
+
+```toml
+# ~/.config/harmonist/harmonist.toml
+[paths]
+music_dir = "/path/to/music"      # absolute (TOML doesn't expand ~)
+
+[bandcamp]
+download_format = "flac"
+max_downloads_per_sync = 25       # safety cap
+
+[musicbrainz]
+user_agent = "Harmonist/1.0 ( you@example.com )"
+```
+
+Bandcamp sync needs a `cookies.txt` (exported from a logged-in browser) — paste
+or upload it via the in-app **Set up Bandcamp sync** prompt.
+
+## Uninstall
+
+All of Harmonist's state lives in `.harmonist.json` **sidecar** files next to your
+albums — your audio, its MusicBrainz tags, and `cover.*` art are just your library
+and carry nothing Harmonist-specific. To remove it cleanly:
+
+1. **Settings → Erase sidecars.** This deletes every `.harmonist.json`; your
+   tagged audio and cover files are not touched.
+2. **Stop the app straight away — don't return to the Inbox.** Opening the inbox
+   triggers a re-scan and reconcile, which would re-derive the sidecars from your
+   files' tags. Shut down first (e.g. `docker compose down`) and the library is
+   left sidecar-free.
+
+Your music stays fully tagged and Picard-compatible, with no trace of Harmonist.
+To also drop the stored Bandcamp cookie and settings, delete the config dir.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,250 @@
+# Using Harmonist
+
+What to do with Harmonist once it's running. For getting it running, see
+**[installation.md](installation.md)**; for exposing it safely, see
+**[deployment.md](deployment.md)**. If you want the mechanism rather than the
+workflow — the state machine's exact derivation rules, the sidecar schema, the
+tagging contract — that's **[design.md](design.md)**, which is written for people
+changing the code.
+
+Everything here can be tried without touching your own music: start Harmonist in
+[demo mode](installation.md#demo-mode) and the sample library covers every state
+described below.
+
+## The shape of the app
+
+One page, three tabs, plus Settings:
+
+- **Inbox** — albums that need something from you, grouped by what they need.
+- **Library** — albums that are done, with filters for the ones that are done but
+  not *right*.
+- **Activity** — everything Harmonist has changed, newest first.
+
+**Sync** lives in the header and is available from any tab.
+
+## Onboarding an existing library
+
+Point Harmonist at a music library you already have and it does its best to
+**adopt** it — recognizing what's already tagged, linking your previous Bandcamp
+downloads to your purchases, and flagging the rest for review — all **without
+re-downloading anything you own**.
+
+It works best on a library that's already in reasonable shape. Harmonist assumes:
+
+- **One album per folder** — each directory of audio files is treated as a single
+  album. A folder mixing several albums is flagged **Inconsistent**; split it with
+  [Picard](https://picard.musicbrainz.org) first.
+- **Already tagged** — ideally Picard-tagged. Harmonist reads the MusicBrainz
+  Album ID from your files to recognize what's matched; anything untagged lands in
+  the inbox for you to match by hand.
+
+**Recommended order:**
+
+1. **Get everything matched first.** Work through **Needs MBID** — this is the one
+   step that genuinely needs you; untagged/unmatched albums are the main thing
+   Harmonist can't do on its own. Aim to clear it *before* your first sync.
+2. **Then run your first Sync.** While unlinked albums remain, that sync runs in
+   **link-only** mode: it links your on-disk albums to your Bandcamp purchases and
+   **downloads nothing new**. Anything it can't confidently match surfaces as a
+   *potential download* to Match / Download / skip.
+3. Once everything's linked, later syncs fetch genuinely new purchases as normal.
+
+## The Inbox
+
+Every album is in exactly one state, **derived** from what's on disk each time
+Harmonist looks — there's no status field to get out of step with your files.
+The inbox groups by state, and each group says what will clear it.
+
+<!-- screenshot: docs/screenshots/inbox.png -->
+
+**New** — no sidecar yet: an album Harmonist has seen but knows nothing about.
+Search MusicBrainz by name or paste an MBID. If the files already carry a
+MusicBrainz Album ID, a reconcile derives the rest from the tags.
+
+**Needs MBID** — no confirmed MusicBrainz release. Three ways out, and the card
+leads with whichever fits:
+
+- *With a suggestion.* Harmonist found a candidate but isn't certain (usually the
+  track lengths are outside tolerance). The card shows your files against the MB
+  release side by side, per track. **Confirm** tags the album from it;
+  **Confirm as Incomplete** accepts it when you knowingly have fewer tracks;
+  **Dismiss suggestion** leaves the album where it is.
+- *Without one.* Search by artist + title, or paste an MBID directly.
+- *Not in MusicBrainz yet.* Common for Bandcamp-only releases. **Open in Harmony**
+  seeds it to [Harmony](https://harmony.pulsewidth.org.uk) in a couple of clicks,
+  then **Recheck** picks it up — so every gap you hit makes MusicBrainz better for
+  the next person.
+
+**Needs Link** — tagged from MusicBrainz, but not yet tied to the Bandcamp
+purchase it came from. **Sync** links these; that's the common case. If a sync
+can't find the purchase, use **Try a different URL** or **Mark purchased
+elsewhere**.
+
+**Inconsistent** — the files in one folder disagree about album title or MBID,
+which normally means several albums share a directory. Harmonist won't guess:
+split them in Picard and refresh.
+
+**Tagging** — transient, shown while a tagging runs.
+
+Albums that are **Complete** or **Incomplete** aren't in the inbox at all; they're
+in the Library.
+
+## Syncing
+
+**Sync** in the header pages your Bandcamp collection and reconciles it against
+what's on disk. The popover next to it carries the options — including the
+per-run download cap — and the status bar reports progress.
+
+A sync runs in one of two modes, and says which:
+
+- **Link-only**, automatically, while any album is still unlinked. It matches
+  purchases to albums you already own and **downloads nothing**. This is what
+  makes adoption safe: your first sync can't re-download a library you already
+  have.
+- **Full**, once everything's linked. New purchases download as normal.
+
+**Potential downloads.** A purchase a sync can't confidently tie to an album on
+disk isn't downloaded on a hunch — it surfaces as a card for you to resolve:
+**Download** it, mark **Already in your library?** to search your own albums for
+it by artist and title, or **Don't download** to set it aside.
+
+That last one isn't a one-way door: Settings lists everything under **Won't
+download** with a **Restore** button beside each.
+
+**When a purchase can't be found at all.** A *full* sync that pages your whole
+collection and still can't match an album has learned something real, so it says
+so: the album is demoted to Needs MBID with a read-only "no purchase found" note,
+keeping its current release as context. **Move to Library** accepts it as yours
+and done.
+
+**When the match looks wrong.** After a sync, Harmonist checks whether you
+actually own a *different edition* of what an album is tagged as — a live version
+where the files claim the standard release, say. If so the album is flagged
+**Possibly mis-tagged**, with the edition you own offered as the fix.
+
+## The Library
+
+Everything that's finished. Tiles are paged — **Previous**/**Next**, with a
+**Show N per page** control that's remembered between visits — and the page rides
+in the URL, so Back, a bookmark, and returning from an album all land you where
+you left off.
+
+<!-- screenshot: docs/screenshots/library-filters.png -->
+
+Finished isn't the same as right, so the filter chips find the albums that are
+done but still wrong, each with its count:
+
+- **Incomplete** — fewer tracks on disk than the MusicBrainz release has. The tile
+  badges "N of M".
+- **Partially tagged** — some files carry the MusicBrainz Album Id and some don't.
+  A half-finished tagging run, or Picard applied to part of a folder, leaves this.
+- **No artwork** — correctly tagged, fully linked, and still a grey square in
+  Plex or Navidrome.
+
+The active filter rides in the URL too, so a filtered view is a link you can share
+or bookmark.
+
+## An album's page
+
+Clicking a tile opens a summary that answers "is this the right release?"; from
+there, the album's own page at `/album/<id>` has the whole story. It has an
+address, so it can be shared, bookmarked, and gone back from.
+
+<!-- screenshot: docs/screenshots/album-tags.png -->
+
+**Tags** compares your files against MusicBrainz field by field and shows **only
+what differs**, with small changes marked inside the value — so a pipe-joined
+artist credit against MusicBrainz's join phrase, or a bare year against a full
+date, is visible at a glance rather than needing a character-by-character read.
+When your own tracks disagree with each other, it says what's wrong ("missing on
+1 track"), and clicking that lists the tracks.
+
+**Tracks** compares the tracklist — title, artist, number and length — flagging
+tracks that are missing, unreadable, or absent from MusicBrainz.
+
+**History** gathers everything Harmonist has recorded about the album, including
+records written before it was last re-identified, so history doesn't rot when a
+release is re-matched or renamed.
+
+The actions live on the page too: **Re-tag from MB** (also the remedy for a
+partially-tagged album — it writes the id to the files missing it), the
+wrong-match pencil beside the release badge (which sends the album back to Needs
+MBID to re-pick, leaving your files' current tags alone until you re-tag), and
+**Forget**, which deletes the sidecar and returns the album to New without
+touching a single audio file.
+
+## Undoing a tagging
+
+Every tagging is recorded field by field — the value before and the value after,
+for each file — so an album's History shows what each one actually changed, with
+how far each change reached and a per-track breakdown behind a disclosure. A
+re-tag that changed nothing says nothing.
+
+<!-- screenshot: docs/screenshots/history-tagging.png -->
+
+**Undo tag changes** on that entry puts those values back. What it refuses is the
+point:
+
+- **The tagging is the unit, not the field.** Reverting one field while its
+  neighbours keep the new value would build a state your files never had.
+- **A field you've changed since is left alone** — in Picard, or by a later re-tag
+  — and named in the outcome. An old row is safe to offer rather than a trap.
+- **Every file is read before any is written**, so a failure leaves the album as
+  it was.
+- **Undoing the tagging that linked an album to MusicBrainz unlinks it too**, so
+  your files and Harmonist's own record can't quietly disagree. The album returns
+  to Needs MBID with that release kept as a one-click suggestion.
+
+The undo is itself recorded, so it can be undone in turn.
+
+**Cover art has its own Undo.** Artwork that a re-tag overwrites is kept in a
+bounded store (500 MB) and can be put back from the Artwork row in History.
+Settings shows what's held under **Kept artwork**.
+
+## Activity
+
+Every change, newest first, in plain language — "Tagged", "Unlinked",
+"Auto-tagged after sync" — with each album named and linked. Entries that changed
+something on disk expand to show exactly what:
+
+```
+14:22:07  ●  Boards of Canada — Geogaddi · Tagged     ▸ what changed · 4
+                 tag.album  release=… tracks=12 art=embedded mode=full
+                 tag.track  file="01 Ready Lets Go.m4a" track=1 …
+                 sidecar.update  mbid=None->2f0e…
+                 cover.write  file=cover.jpg source=caa overwrote=False
+```
+
+<!-- screenshot: docs/screenshots/activity.png -->
+
+**Show details** reveals the raw audit records, each sitting under the entry that
+caused it, so one big action doesn't fill the page. The feed pages back through
+older history.
+
+What makes the record worth reading rather than just kept:
+
+- **Durable.** SQLite in your config dir, so it survives restarts. Nothing is
+  pruned or evicted.
+- **Complete.** Tag writes, sidecar rewrites, file moves and overwrites, cover
+  art, checkpoint clears, surrenders — and erasing sidecars names every album that
+  lost one, because that's the most destructive thing Harmonist can do.
+- **Attributable.** Every record is tied to the action that caused it, so the
+  detail under an entry is *that* action's work, not everything that happened at
+  the same moment.
+- **Still readable later.** Entries keep the album's name as it was, and follow an
+  album across re-identification.
+- **Honest when it can't answer.** If Harmonist can't read its own history it says
+  so, rather than showing an empty feed. "Nothing happened" and "I couldn't tell
+  you" are different claims, and only one of them is ever a guess.
+
+## Settings
+
+- **Bandcamp sync** — paste or upload the `cookies.txt` that lets the sync log in.
+- **Preferences** — download format, max downloads per sync, cover art size,
+  MusicBrainz user agent, log level. Saved to `harmonist.toml` and applied right
+  away; see [installation.md](installation.md#configuration) for the file itself.
+- **Won't download** — the purchases you've set aside, each with **Restore**.
+- **Kept artwork** — the images re-tags have overwritten, still recoverable.
+- **Maintenance** — erase all `.harmonist.json` sidecars. Audio files aren't
+  touched, but every match and sync link is removed; this is the uninstall step,
+  not a routine one.

--- a/src/harmonist/config.py
+++ b/src/harmonist/config.py
@@ -39,7 +39,7 @@ class ServerConfig(BaseModel):
     # ["*"] is permissive — set this to your real hostname(s) when exposing
     # Harmonist beyond loopback. Loopback aliases are always implicitly
     # allowed regardless, so a tightened list still works for local curl /
-    # healthcheck. See docs §security in the README.
+    # healthcheck. See docs/deployment.md.
     allowed_hosts: list[str] = Field(default_factory=lambda: ["*"])
 
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -630,7 +630,7 @@ def _install_security_middleware(app: FastAPI, cfg: config_mod.Config) -> None:
         log.warning(
             "server.host=%s but server.allowed_hosts=['*']. For non-loopback "
             "binds, set allowed_hosts to your actual hostname(s) to enable "
-            "DNS-rebinding protection. See README §Security.",
+            "DNS-rebinding protection. See docs/deployment.md.",
             cfg.server.host,
         )
 


### PR DESCRIPTION
The README answered two questions at once — "why should I use this?" and "how do I run and use it?" — and at 397 lines the second was burying the first. It also left feature screenshots with nowhere to live except the pitch, so every landed feature either bloated the README or left it stale.

**README.md** (397 → 220 lines) now carries the pitch only: what it is, Where Harmonist fits, the two "Nothing…" guarantees (trimmed, anchors intact), a minimal Docker quickstart, and a documentation index.

**New docs:**

- `docs/usage.md` — onboarding an existing library, the inbox state by state, syncing (link-only vs full, potential downloads, surrender, mis-tag detection), the Library and its filters, an album's page, undo, activity, settings. Mostly new prose: everything from 1.4 onwards was undocumented outside the changelog. Button and state names are taken from the templates and `design.md` rather than written from memory.
- `docs/installation.md` — Docker, Synology/ACL permissions, from source, demo mode, the `harmonist.toml` reference, uninstall.
- `docs/deployment.md` — the security posture, split out because it has a different audience from "get it running".

Feature screenshots now belong in `docs/usage.md`, added with the feature that introduces them, so the README's imagery ages slowly. Placement markers are in place for the stills.

Also updates `CLAUDE.md`'s "Read these first" list, `CONTRIBUTING.md`'s pointers, and the `release` skill's staleness sweep (usage.md names buttons, so it's the likeliest to rot); and repoints the two code references to "README §Security" at `docs/deployment.md` — one a comment, one an operator-facing log line.

No `CHANGELOG.md` entry: nothing about Harmonist's behavior changed.

Fixes #178