### PR TITLE
Keep the join phrase in the artist sort tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ versions follow [semantic versioning](https://semver.org).
   narrows the filters alongside it, so "the albums with no artwork by Aphex Twin"
   is a link you can share (#180).
 
+### Fixed
+
+- Artist sort and Album artist sort no longer run a collaboration's artists
+  together — "zakè & rhubiqs" was tagged as "zakèrhubiqs". Re-tag an affected
+  album to correct it (#183).
+
 ## [1.8.0] - 2026-08-18
 
 ### Added

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -739,7 +739,13 @@ def _artist_ids(artist_credit: list[Any] | None) -> list[str]:
 
 
 def _artist_phrase(artist_credit: list[Any] | None) -> str:
-    """Build a display string from an MB artist-credit list."""
+    """Build a display string from an MB artist-credit list.
+
+    musicbrainzngs emits each join phrase as a **bare string element** between the
+    artist dicts (`[{...}, ' & ', {...}]`), not as a `joinphrase` key on the dict —
+    the key is the JSON web service's shape, which Picard consumes but we never see.
+    Every walker over an artist-credit must handle the string elements or it will
+    silently concatenate the artists with no separator (#183)."""
     if not artist_credit:
         return ""
     parts: list[str] = []
@@ -762,7 +768,9 @@ def _artist_sort_phrase(artist_credit: list[Any] | None) -> str:
     parts: list[str] = []
     any_sort = False
     for ac in artist_credit:
-        if isinstance(ac, dict):
+        if isinstance(ac, str):
+            parts.append(ac)
+        elif isinstance(ac, dict):
             sort = (ac.get("artist") or {}).get("sort-name")
             if sort:
                 any_sort = True

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1207,7 +1207,10 @@ def _release_name_parts(release: Release) -> tuple[str, str]:
     if not artist:
         parts = []
         for ac in release.get("artist-credit") or []:
-            if isinstance(ac, dict):
+            # Bare strings are the join phrases — see `_artist_phrase` in tagger.py.
+            if isinstance(ac, str):
+                parts.append(ac)
+            elif isinstance(ac, dict):
                 parts.append(ac.get("name") or ac.get("artist", {}).get("name", ""))
         artist = "".join(parts).strip()
     title = (release.get("title") or "").strip()

--- a/test/test_mb_search.py
+++ b/test/test_mb_search.py
@@ -104,7 +104,9 @@ def test_falls_back_to_artist_credit_when_phrase_absent(monkeypatch):
                 "id": "rel-aaa",
                 "title": "X",
                 "artist-credit": [
-                    {"name": "A", "joinphrase": " feat. "},
+                    {"name": "A"},
+                    # musicbrainzngs emits join phrases as bare strings.
+                    " feat. ",
                     {"name": "B"},
                 ],
             }
@@ -112,7 +114,7 @@ def test_falls_back_to_artist_credit_when_phrase_absent(monkeypatch):
     }
     monkeypatch.setattr(musicbrainzngs, "search_releases", lambda **kw: response)
     results = search_releases("A", "X")
-    assert results[0]["artist"] == "AB"
+    assert results[0]["artist"] == "A feat. B"
 
 
 def test_handles_missing_optional_fields(monkeypatch):

--- a/test/test_picard_spec.py
+++ b/test/test_picard_spec.py
@@ -112,8 +112,9 @@ def _fully_populated_release() -> dict:
                                     "sort-name": "Guest",
                                 },
                                 "name": "Guest",
-                                "joinphrase": " feat. ",
                             },
+                            # musicbrainzngs emits join phrases as bare strings.
+                            " feat. ",
                             {
                                 "artist": {
                                     "id": "host11111-1111-1111-1111-111111111111",

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -99,8 +99,9 @@ def _release_2_tracks() -> dict:
                                     "sort-name": "Featured Artist",
                                 },
                                 "name": "Featured Artist",
-                                "joinphrase": " feat. ",
                             },
+                            # musicbrainzngs emits join phrases as bare strings.
+                            " feat. ",
                             {
                                 "artist": {
                                     "id": "art-ccc",
@@ -462,6 +463,41 @@ def test_tag_album_writes_sort_artists_original_date_script(album_with_tracks):
     track2 = MP4(album_dir / "02 Track 2.m4a")
     assert track2[ATOM_ARTIST_SORT] == ["Featured Artist feat. Other, The"]
     assert _atom_strs(track2, ATOM_ARTISTS) == ["Featured Artist", "Other"]
+
+
+@pytest.mark.parametrize(
+    "credit",
+    [
+        # The shape musicbrainzngs actually returns: join phrases are bare strings.
+        pytest.param(
+            [
+                {"artist": {"name": "zakè", "sort-name": "zakè"}, "name": "zakè"},
+                " & ",
+                {"artist": {"name": "rhubiqs", "sort-name": "rhubiqs"}, "name": "rhubiqs"},
+            ],
+            id="sibling-string",
+        ),
+        # The JSON web service's shape, tolerated in case the client is swapped (#26).
+        pytest.param(
+            [
+                {
+                    "artist": {"name": "zakè", "sort-name": "zakè"},
+                    "name": "zakè",
+                    "joinphrase": " & ",
+                },
+                {"artist": {"name": "rhubiqs", "sort-name": "rhubiqs"}, "name": "rhubiqs"},
+            ],
+            id="joinphrase-key",
+        ),
+    ],
+)
+def test_artist_phrases_keep_the_join_phrase(credit):
+    """#183: the sort phrase dropped the join phrase entirely, because it only read
+    `joinphrase` off the dict — the shape musicbrainzngs never produces. Both walkers
+    must agree, whichever shape the credit arrives in."""
+    assert tagger._artist_phrase(credit) == "zakè & rhubiqs"
+    assert tagger._artist_sort_phrase(credit) == "zakè & rhubiqs"
+    assert tagger._artist_names(credit) == ["zakè", "rhubiqs"]
 
 
 def test_tag_album_track_artist_credit_overrides_release(album_with_tracks):


### PR DESCRIPTION
A collaboration was tagged `zakèrhubiqs` where Picard writes `zakè & rhubiqs`. `_artist_sort_phrase` walked the artist-credit looking for a `joinphrase` key on each artist dict — the MB **JSON** web service's shape, which Picard consumes. We fetch through **musicbrainzngs**, whose XML parser emits each join phrase as a bare string element *between* the dicts, so every separator was silently dropped. `_artist_phrase` already handled that shape, which is why only the sort variants were mangled; single-artist releases were never affected.

`_release_name_parts` (`web/main.py`) had the same blind spot in its fallback branch — display-only, and only when `artist-credit-phrase` is absent.

## The fixtures are the reason this shipped

Every artist-credit in the suite was hand-written in the JSON shape, so the tests exercised data MusicBrainz will never hand us. `test_picard_spec.py` already asserted `t2["soar"] == ["Guest feat. Host"]` — and passed, against the wrong shape. Converting the three fixtures to the musicbrainzngs shape is what turns those existing assertions into an actual regression test.

Verified: with the source fix stashed, 3 tests fail; with it, the full suite passes.

```
FAILED test/test_tagger.py::test_tag_album_writes_sort_artists_original_date_script
FAILED test/test_tagger.py::test_artist_phrases_keep_the_join_phrase[sibling-string]
FAILED test/test_picard_spec.py::test_sort_artists_original_date_script_atoms
```

`test_mb_search.py`'s fallback test needed its expectation corrected too — it asserted `"AB"`, encoding the dropped join phrase as intended behavior for a shape that never occurs.

A parametrized unit test pins **both** shapes to the same output, so the tolerated JSON-shape branch stays covered rather than becoming untested dead code (relevant if #26 lands).

## Notes

Albums already tagged with the mangled value self-correct on the next re-tag; there is no sweep. The tags are Harmonist-owned and the correction shows in History, so it is undoable either way.

Fixes #183