### PR TITLE
Stop showing one track's value as if the album got it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ versions follow [semantic versioning](https://semver.org).
 - Artist sort and Album artist sort no longer run a collaboration's artists
   together — "zakè & rhubiqs" was tagged as "zakèrhubiqs". Re-tag an affected
   album to correct it (#183).
+- An album's history no longer shows one track's value as though the whole album
+  got it. A field that changed differently on each track — Recording and Release
+  track always do — now reads "38 different values", with the values themselves
+  under "Show which tracks" (#185).
 
 ## [1.8.0] - 2026-08-18
 

--- a/src/harmonist/tag_history.py
+++ b/src/harmonist/tag_history.py
@@ -107,13 +107,32 @@ class FieldChange:
     after_runs: tuple[Run, ...] = ()
     #: Every file's version of this change, in the order recorded. Populated
     #: only when they DIFFER — when the whole album moved the same way, the
-    #: representative pair above already says everything.
+    #: pair above already says everything. When they differ, these are the only
+    #: honest values there are: the row shows `varied_summary` instead.
     variants: tuple[TrackChange, ...] = ()
 
     @property
     def uniform(self) -> bool:
         """Whether every file that changed changed the same way."""
         return not self.variants
+
+    @property
+    def varied_summary(self) -> str:
+        """What to show in place of the values when the files DON'T agree.
+
+        Showing one file's pair as though it were the album's is a guess
+        dressed as a fact, and `reach` can't take it back — a field that
+        reached every track with a different value each time is annotated
+        exactly like one that reached every track with the same value (#185).
+        Identifier fields make it plainest: 38 tracks legitimately carry 38
+        different recording MBIDs, and none of them is the album's.
+
+        So the count goes where the value would be. It's a fact about the
+        change that holds for the whole row, and the per-track disclosure
+        underneath carries the values themselves — which is where a list that
+        long belongs anyway.
+        """
+        return f"{len({(v.before, v.after) for v in self.variants})} different values"
 
     @property
     def summary(self) -> str:
@@ -365,9 +384,9 @@ def _row(field: str, entries: list[tuple[str, str | None, Any, Any]], total: int
     variants: tuple[TrackChange, ...] = ()
     if len(set(pairs)) > 1:
         # Only when they actually differ — a compilation where every track's
-        # artist changed to something different has no single answer, and
-        # showing one track's as if it were the album's would be the quiet lie
-        # the count pill exists to prevent.
+        # artist changed to something different has no single answer, so the
+        # row states how many answers there are (`varied_summary`) and these
+        # carry the values.
         variants = tuple(
             TrackChange(file=f, position=p, before=display(b), after=display(a))
             for f, p, b, a in entries
@@ -376,9 +395,10 @@ def _row(field: str, entries: list[tuple[str, str | None, Any, Any]], total: int
     opaque = field == ARTWORK
     before_runs: tuple[Run, ...] = ()
     after_runs: tuple[Run, ...] = ()
-    if before is not None and after is not None and not opaque:
+    if before is not None and after is not None and not opaque and not variants:
         # Two sha256 digests differ in nearly every character, so emphasis on
-        # them would be noise on top of noise.
+        # them would be noise on top of noise — and a row whose files disagree
+        # shows no pair to emphasise.
         before_runs, after_runs = diff_runs(before, after)
 
     return FieldChange(
@@ -397,17 +417,22 @@ def _row(field: str, entries: list[tuple[str, str | None, Any, Any]], total: int
 
 
 def _representative(pairs: list[tuple[str | None, str | None]]) -> tuple[str | None, str | None]:
-    """The change to show when the files don't all agree.
+    """The album's `(before, after)` for this field, where it has one.
 
-    The most common `(before, after)` pair; on a tie, **the first file's**.
-    Deliberately the same rule `compare.consensus` uses for the album panel,
-    stated the same way — "when your tracks disagree evenly, Harmonist shows
-    what the first one says" — because a reader who has learned it in one place
-    should not find a different rule in the other.
+    When every file agrees this is trivially that pair — the ordinary case, and
+    the only one the value cell renders since #185: a row whose files disagree
+    shows `varied_summary` instead, because no single pair is the album's.
+
+    It still resolves the disagreeing case for **artwork**, whose row shows
+    what happened rather than a value, and whose `before` decides whether the
+    restore button is offered at all. There the most common `(before, after)`
+    is the right answer — an album where one track never had an image should
+    still offer to put back the image the other seventeen lost.
 
     The pair is kept together rather than resolved field-by-field: taking the
     most common `before` and the most common `after` independently could
-    manufacture a transition that no track actually made.
+    manufacture a transition that no track actually made. On a tie it is **the
+    first file's**, the same rule `compare.consensus` uses for the album panel.
     """
     counts = Counter(pairs)
     top = max(counts.values())

--- a/static/input.css
+++ b/static/input.css
@@ -400,7 +400,9 @@ button[disabled],
 .tag-changes__after { color: var(--color-mb-purple); }
 .tag-changes__arrow { color: var(--color-muted); margin: 0 .35rem; }
 .tag-changes__absent { color: var(--color-muted); font-style: italic; }
-/* Artwork: what happened, not two sha256s that would swamp every row near it. */
+/* Stands in for the values on a row that has none to show: artwork (what
+   happened, not two sha256s that would swamp every row near it) and a field
+   whose files disagree (how many answers there are, not one track's). */
 .tag-changes__opaque { color: var(--color-ink); }
 
 /* Undo, on the row that says what happened. Rare and reversible, so it is

--- a/templates/partials/_tag_changes.html
+++ b/templates/partials/_tag_changes.html
@@ -66,6 +66,14 @@
                 aria-label="Undo this artwork change">Undo</button>
         {% endif %}
 
+        {% elif not c.uniform %}
+        {# The files disagree, so there is no value to put here — 38 tracks
+           legitimately carry 38 different recording MBIDs, and printing the
+           first one beside "all tracks" reads as though the whole album got it
+           (#185). The count is the fact that holds for the row; the values are
+           in the disclosure below, which is where a list that long belongs. #}
+        <span class="tag-changes__opaque">{{ c.varied_summary }}</span>
+
         {% else %}
         {# A field with nothing before it shows only what was written. On a first
            tagging that is EVERY row, so "— →" would prefix the whole list with

--- a/test/test_tag_history.py
+++ b/test/test_tag_history.py
@@ -72,8 +72,7 @@ def test_album_fields_sort_before_track_fields_and_artwork_sits_last():
 
 def test_a_field_that_changed_differently_per_track_keeps_every_version():
     """A compilation where each track's artist changed to something different
-    has no album-wide answer. Showing one track's as if it were everyone's is
-    the quiet lie the count pill exists to prevent."""
+    has no album-wide answer."""
     records = _album(4, lambda i: {"artist": [f"old {i}", f"new {i}"]})
 
     row = _row(summarise(records), "artist")
@@ -82,15 +81,46 @@ def test_a_field_that_changed_differently_per_track_keeps_every_version():
     assert len(row.variants) == 4
     assert row.variants[0].before == "old 1"
     assert row.variants[0].position == "1"
-    # A representative pair is still shown — a row with no value at all reads as
-    # broken, and the variants are one disclosure away.
-    assert row.before is not None and row.after is not None
 
 
-def test_an_even_split_shows_the_first_file_the_same_rule_as_the_album_panel():
-    """`compare.consensus` breaks a tie by track order and says so in one
-    sentence. A reader who learned that rule on the album panel must not meet a
-    different one here."""
+def test_a_field_whose_files_disagree_counts_the_answers_instead_of_picking_one():
+    """#185: 38 tracks legitimately carry 38 different recording MBIDs, and
+    printing the first one beside "all tracks" reads as though the whole album
+    got it. The reach can't take that back — it says the same thing whether the
+    value was the same on every track or different on every track."""
+    records = _album(38, lambda i: {"mb_track_id": [None, f"mbid-{i}"]})
+
+    row = _row(summarise(records), "mb_track_id")
+
+    assert row.varied_summary == "38 different values"
+    assert row.reach == "all tracks"
+    # No emphasis runs either: there is no pair on show to emphasise.
+    assert row.before_runs == () and row.after_runs == ()
+
+
+def test_the_answer_count_is_of_distinct_values_not_of_files():
+    """Four tracks that moved two different ways is two answers, not four —
+    the count says how many things happened, not how many files there were."""
+    records = _album(4, lambda i: {"artist": ["A", "X" if i < 3 else "Y"]})
+
+    assert _row(summarise(records), "artist").varied_summary == "2 different values"
+
+
+def test_a_uniform_field_still_shows_its_value():
+    """The suppression is for disagreement only. An album that moved as one has
+    exactly one answer, and hiding it behind a count would make the common case
+    unreadable to save the rare one."""
+    row = _row(summarise(_album(18, lambda i: {"artist": ["A", "B"]})), "artist")
+
+    assert row.uniform
+    assert (row.before, row.after) == ("A", "B")
+
+
+def test_an_even_split_resolves_to_the_first_files_pair():
+    """The tie rule behind `_representative`, which since #185 the value cell no
+    longer consults — it survives for the artwork row below. Kept the same rule
+    `compare.consensus` uses on the album panel: a reader who learned it there
+    must not find a different one here."""
     records = [
         TagChanges(file="01.flac", changes={"artist": ["A", "X"]}, position="1"),
         TagChanges(file="02.flac", changes={"artist": ["B", "Y"]}, position="2"),
@@ -117,6 +147,25 @@ def test_the_representative_pair_is_a_transition_some_track_actually_made():
     row = _row(summarise(records), "artist")
 
     assert (row.before, row.after) in {("A", "X"), ("A", "Y"), ("B", "Z"), ("C", "Z")}
+
+
+def test_the_artwork_row_keeps_the_image_most_of_the_album_lost():
+    """Artwork is the one row that still needs a representative on a disagreeing
+    album: it shows what happened rather than a value, and `before` is what
+    decides whether the restore button is offered (#131). A track that never had
+    an image must not talk the other three out of getting theirs back."""
+    records = [
+        TagChanges(file="01.flac", changes={ARTWORK: [None, "b" * 64]}, position="1"),
+        *(
+            TagChanges(file=f"0{i}.flac", changes={ARTWORK: ["a" * 64, "b" * 64]}, position=str(i))
+            for i in (2, 3, 4)
+        ),
+    ]
+
+    row = _row(summarise(records), ARTWORK)
+
+    assert not row.uniform
+    assert row.before == "a" * 64
 
 
 def test_artwork_states_what_happened_instead_of_reciting_digests():

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3365,6 +3365,10 @@ def test_album_page_shows_what_a_tagging_changed_under_its_activity_entry(client
     # A field that differs per track gets the expansion; one that doesn't, doesn't.
     assert "Show which tracks" in body
     assert "rec-1" in body and "rec-2" in body
+    # ...and its own row states how many answers there are rather than passing
+    # track 1's off as the album's (#185). The values live in the expansion.
+    assert "2 different values" in body
+    assert body.index("2 different values") < body.index("rec-1")
 
     # Anchored to the activity entry, so it renders ONCE, not once per file.
     assert body.count('class="tag-changes"') == 1


### PR DESCRIPTION
An album's history renders a tagging field-first: one row per field, with how far it reached beside it. The value in that row came from `_representative` — the most common `(before, after)` across the files — which is right when the album moved as one and quietly wrong when it didn't. Where every file's pair is unique, "most common" degenerates to "track 1's", and the row printed a single recording MBID annotated `all tracks`, which reads as *this MBID was written to every track*. The disclosure directly below it said otherwise, 38 times.

`reach` couldn't correct for it either: it branches on `tracks < total` and on scope, never on `uniform`, so a field that reached every track with a different value each time was annotated exactly like one that reached every track with the same value.

A row whose files disagree now states how many answers there are — `38 different values` — and leaves the values to the per-track table underneath, which is where a list that long belongs. Identifier fields (recording, release track) are where this bites every time; they have no album-wide value by construction.

**Two judgment calls worth review:**

- This reverses the note on `test_a_field_that_changed_differently_per_track_keeps_every_version` ("a row with no value at all reads as broken"). A count is not no value, and being unreadable beats being wrong.
- Artwork keeps its representative pair. That row shows what happened rather than a value, and its `before` decides whether the restore button is offered — an album where one track never had an image must still offer to put back the image the others lost. That is now the consumer `_representative` documents, and it has a test.

Verified in demo mode on a 3-track album with the recording IDs stripped and re-tagged: the rows read `3 different values · all tracks`, and "Show which tracks" lists each track's own MBID.

Fixes #185