### PR TITLE
Read a release split across disc folders as one album

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- A release you filed as per-disc folders (`Album/CD1`, `Album/CD2`) is now
+  recognised as one album instead of one per disc. Nothing on disk moves — the
+  folders stay where they are, and deleting the sidecar Harmonist adds to the
+  parent folder undoes it (#16).
+
 ## [1.9.0] - 2026-08-19
 
 ### Added

--- a/docs/design.md
+++ b/docs/design.md
@@ -695,6 +695,7 @@ src/harmonist/
   models.py             Album, Sidecar, AlbumState, MatchCandidate, BandcampInfo, …
   sidecar.py            Read/write .harmonist.json sidecars atomically
   scanner.py            Walk music dir → Album objects (state derived per-album)
+  album_files.py        Which audio files belong to one album — incl. a release split across disc dirs (#16)
   reconcile.py          Derive a sidecar from MBID tag + ©cmt + MB url-rels (orphan recovery)
   url_recovery.py       Recover an embedded Bandcamp URL from ©cmt (precise or artist-root; no scraping)
   bandcamp_hook.py      bandcampsync Syncer subclass: download cap, sidecar capture, purchase↔album linking
@@ -1182,8 +1183,67 @@ class as inconsistent; user resolves externally.
 - **Tag editing of individual files** outside MB lookups: Picard's job.
 - **Recursive directory disagreement** (nested album dirs): scanner
   treats every dir with audio files as a single album. Atypical layouts
-  must be flattened first.
+  must be flattened first — with the one exception of a release split
+  across per-disc directories, covered in §13.5.
 - **Format conversion**: Harmonist never transcodes.
+
+### 13.5 A release split across per-disc directories
+
+A library assembled over decades has multi-disc releases filed as
+`Album/CD1` + `Album/CD2` — one MusicBrainz release, two directories.
+Treated as two albums they are two Library tiles, each with half a
+tracklist, and each wrong about what it has (#16).
+
+**Grouping, not merging.** A directory that declares itself an album with
+a sidecar, while holding no audio of its own, owns every audio file
+beneath it (`album_files.audio_files`). Nothing on disk moves: the layout
+Plex and Navidrome already index is untouched, and there is no migration.
+
+**Forget is the way out.** It deletes the parent's sidecar, which puts the
+parts back exactly as they were, and exempts the parent so the next
+reconcile pass does not re-group it.
+
+The rule is deliberately narrow. **A directory with audio of its own is
+an album, full stop**, even when it also has audio-bearing
+subdirectories. So no album that exists today can change shape: Harmonist
+has never written a sidecar into a directory containing no audio, making
+the grouped shape unreachable by accident.
+
+**Detection** runs in the reconcile pass and writes that parent sidecar.
+It is an identity match, not a best fit — every one of these must hold,
+and any that doesn't leaves the directories alone:
+
+- the parent is not the library root, and is not an album itself;
+- it has no sidecar yet (one already there means it is grouped, and
+  re-promoting it each pass would break idempotence);
+- at least two audio-bearing subdirectories, **all** of them accounted
+  for — a leftover means a container directory that happens to hold two
+  discs;
+- every part is tagged to the **same** `mb_release_id`;
+- every part carries a **distinct disc number**.
+
+That last one is what separates a split release from a duplicate: two
+directories of the same release are its disc 1 and disc 2 if their disc
+numbers differ, and are two copies of the same disc if they don't.
+Without a disc number on every part there is no evidence either way, so
+nothing is merged.
+
+Detection makes **no MusicBrainz call** and reads no tags of its own — it
+runs over the whole library, which §6's budget puts out of reach for a
+per-album lookup. Everything it needs the scan has already read
+(`Album.disc_num`).
+
+The parent's sidecar inherits from the parts (earliest `added_at`, latest
+`tagged_at`, the widest `track_count_expected`, any `store_url`, and
+`purchase_unavailable` if any part was surrendered). **No alias row is
+written**: an album's id *is* its `mb_release_id` once it has one, and
+detection only groups parts that already agree on the release, so the id
+is unchanged by grouping and the parts' history is already reachable.
+
+The parts' own sidecars are left in place. They are stale descriptions of
+directories that are no longer albums, and deleting them would be a
+destructive write to user data on the strength of a derived rule; the
+scanner never descends into a grouped album, so they cost only clutter.
 
 ## 14. Store support
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1220,18 +1220,37 @@ and any that doesn't leaves the directories alone:
   for — a leftover means a container directory that happens to hold two
   discs;
 - every part is tagged to the **same** `mb_release_id`;
-- every part carries a **distinct disc number**.
+- the parts hold **different tracks** of that release.
 
-That last one is what separates a split release from a duplicate: two
-directories of the same release are its disc 1 and disc 2 if their disc
-numbers differ, and are two copies of the same disc if they don't.
-Without a disc number on every part there is no evidence either way, so
-nothing is merged.
+That last one is what separates a split release from a duplicate, and
+"same release, two folders" describes both equally well — so something
+has to tell them apart.
 
-Detection makes **no MusicBrainz call** and reads no tags of its own — it
-runs over the whole library, which §6's budget puts out of reach for a
-per-album lookup. Everything it needs the scan has already read
-(`Album.disc_num`).
+**Release-track MBIDs are the primary evidence.** Every track of a
+release carries its own `MusicBrainz Release Track Id`, so two
+directories holding different discs have **disjoint** sets and two copies
+of one disc have identical ones. This reads the thing in question
+directly rather than a proxy for it: it establishes not that the parts
+*claim* to be different discs but that they *are* different tracks —
+which is why it overrules a disc number that says otherwise. Picard has
+written this tag for well over a decade, and Harmonist's tagger writes
+it.
+
+**Distinct disc numbers are the fallback**, for a pre-2011 rip carrying
+no track ids at all. Weaker — it is what the files claim, not what they
+contain — but still exact, and a duplicate pair fails it (both copies say
+disc 1). A *mixture* is refused: with track ids on some parts and not
+others there is nothing to compare, and falling back would answer with
+the weaker evidence a question the better evidence was available to
+settle. A part with even one untagged file counts as having none, because
+a partial set makes disjointness meaningless.
+
+Detection makes **no MusicBrainz call** — §6's budget puts a per-album
+lookup out of reach for something that runs over the whole library. The
+only checks that read tags or touch the filesystem are the last two, by
+which point a directory has already had to look exactly like a split
+release; and they run once, since the parent then has a sidecar and is
+skipped from that point on.
 
 The parent's sidecar inherits from the parts (earliest `added_at`, latest
 `tagged_at`, the widest `track_count_expected`, any `store_url`, and

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,6 +34,13 @@ It works best on a library that's already in reasonable shape. Harmonist assumes
 - **One album per folder** — each directory of audio files is treated as a single
   album. A folder mixing several albums is flagged **Inconsistent**; split it with
   [Picard](https://picard.musicbrainz.org) first.
+- **Per-disc subfolders are fine** — a multi-disc release filed as
+  `Album/CD1` + `Album/CD2` is recognised as one album. Harmonist spots it when
+  both folders are tagged to the same MusicBrainz release and carry different
+  disc numbers, then writes a sidecar into the parent folder; your files are
+  never moved. If you'd rather it stayed as separate albums, delete that parent
+  `.harmonist.json`. (The now-redundant sidecars in the disc folders are left
+  alone — harmless, and yours to remove.)
 - **Already tagged** — ideally Picard-tagged. Harmonist reads the MusicBrainz
   Album ID from your files to recognize what's matched; anything untagged lands in
   the inbox for you to match by hand.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,11 +36,12 @@ It works best on a library that's already in reasonable shape. Harmonist assumes
   [Picard](https://picard.musicbrainz.org) first.
 - **Per-disc subfolders are fine** — a multi-disc release filed as
   `Album/CD1` + `Album/CD2` is recognised as one album. Harmonist spots it when
-  both folders are tagged to the same MusicBrainz release and carry different
-  disc numbers, then writes a sidecar into the parent folder; your files are
-  never moved. If you'd rather it stayed as separate albums, delete that parent
-  `.harmonist.json`. (The now-redundant sidecars in the disc folders are left
-  alone — harmless, and yours to remove.)
+  the folders are tagged to the same MusicBrainz release and demonstrably hold
+  *different tracks* of it, then writes a sidecar into the parent folder; your
+  files are never moved. Two copies of the same disc are left as they are, which
+  is the point of the check. **Forget** on the grouped album splits it back up.
+  (The now-redundant sidecars in the disc folders are left alone — harmless, and
+  yours to remove.)
 - **Already tagged** — ideally Picard-tagged. Harmonist reads the MusicBrainz
   Album ID from your files to recognize what's matched; anything untagged lands in
   the inbox for you to match by hand.

--- a/src/harmonist/album_files.py
+++ b/src/harmonist/album_files.py
@@ -1,0 +1,110 @@
+"""Which audio files belong to one album — the single definition of that.
+
+Nearly every album operation starts by asking "what are this album's tracks?",
+and until #16 each of them answered it independently with the same one-liner:
+``sorted(p for p in album_dir.iterdir() if formats.is_supported(p))``. That
+answer is right for the flat layout Harmonist creates, and wrong for a release
+the user split across per-disc subdirectories, which is a shape a decades-old
+adopted library is full of.
+
+So the rule lives here once, and the call sites ask rather than re-deriving:
+
+    a directory that DECLARES itself an album (it has a sidecar) but holds no
+    audio of its own owns every audio file beneath it.
+
+Nothing else about the library changes: no file moves, no renames, no migration.
+The declaration is the sidecar the user (or `reconcile.promote_split_release`)
+puts in the parent directory, and removing that sidecar is what undoes it —
+which is the escape hatch, since the per-disc directories then answer for
+themselves again exactly as before.
+
+Deliberately narrow. A directory with audio of its own is an album, full stop,
+even when it also has audio-bearing subdirectories — so no album that exists
+today can change shape under this rule. Harmonist has never written a sidecar
+into a directory containing no audio (`reconcile_album` returns early, and
+tagging is only ever aimed at an album path), so the grouped shape is
+unreachable by accident: it only arises where something deliberately created it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from . import formats
+from .sidecar import has_sidecar
+
+
+def audio_files(album_dir: Path) -> list[Path]:
+    """This album's audio files, in track order.
+
+    The directory's own files when it has any (the flat case, which is every
+    album Harmonist creates), else — when the directory declares itself an
+    album with a sidecar — every audio file beneath it, disc directory by disc
+    directory. Returns [] for a directory that is not an album at all.
+    """
+    own = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
+    if own or not has_sidecar(album_dir):
+        return own
+    return descendant_audio_files(album_dir)
+
+
+def descendant_audio_files(album_dir: Path) -> list[Path]:
+    """Every audio file below `album_dir`, ordered by subdirectory then name.
+
+    Split out from `audio_files` because the scanner's walk has already
+    established that the directory holds no audio of its own and wants only
+    this half — and because `reconcile` needs it to evaluate a candidate
+    parent that has no sidecar yet.
+    """
+    found = [p for p in album_dir.rglob("*") if formats.is_supported(p) and p.is_file()]
+    return sorted(found, key=lambda p: sort_key(p.relative_to(album_dir)))
+
+
+def rel_name(album_dir: Path, path: Path) -> str:
+    """How a record names one of this album's files.
+
+    The path relative to the album directory — which for a flat album is the
+    bare filename every record has always carried, and for a split release is
+    "CD2/01 - Intro.m4a" rather than a "01 - Intro.m4a" that two discs both
+    answer to. Records key reverts by this name (`tag_history`), so a collision
+    there does not merely display wrong: it restores one disc's tags onto the
+    other's file.
+
+    Falls back to the bare name if `path` is somehow not under `album_dir`,
+    since a name that is merely ambiguous beats raising from inside an audit
+    write (see the `error-handling` skill).
+    """
+    try:
+        return str(path.relative_to(album_dir))
+    except ValueError:
+        return path.name
+
+
+def sort_key(rel: Path) -> tuple[tuple[object, ...], str]:
+    """Order one album's files by (directory, filename).
+
+    The directory half is compared NATURALLY — "CD2" before "CD10", which plain
+    string order gets backwards. That matters more than it looks: full tagging
+    zips this list against the release's flattened track list positionally, so a
+    ten-disc box set ordered lexically would tag every disc as the wrong one.
+
+    The filename half stays a plain string compare, byte-identical to the
+    `sorted(...)` every call site used before this module existed. Flat albums
+    have no directory component at all, so their order is unchanged — this
+    function cannot reorder an album that isn't split.
+    """
+    return (tuple(_natural(part) for part in rel.parts[:-1]), rel.name)
+
+
+def _natural(text: str) -> tuple[object, ...]:
+    """Split a name into (text, number, text, …) so digit runs compare as
+    numbers. Segments are tagged with a type flag before comparison, because
+    tuple comparison raises on `str` vs `int` and a library is guaranteed to
+    contain both "CD1" and "Bonus".
+    """
+    return tuple(
+        (1, int(chunk), "") if chunk.isdigit() else (0, 0, chunk.lower())
+        for chunk in re.split(r"(\d+)", text)
+        if chunk
+    )

--- a/src/harmonist/cover_art.py
+++ b/src/harmonist/cover_art.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import httpx
 
-from . import audit, formats
+from . import album_files, audit, formats
 
 CAA_BASE = "https://coverartarchive.org"
 DEFAULT_TIMEOUT = 30.0
@@ -64,7 +64,7 @@ def ensure_cover(
 def _extract_embedded_cover(album_dir: Path) -> Path | None:
     """Write a folder cover from the first audio file that carries embedded
     art. Ensures a `cover.*` exists on disk even when CAA has no match."""
-    for path in sorted(p for p in album_dir.iterdir() if formats.is_supported(p)):
+    for path in album_files.audio_files(album_dir):
         result = formats.read_cover(path)
         if result is None:
             continue

--- a/src/harmonist/formats/_vorbis.py
+++ b/src/harmonist/formats/_vorbis.py
@@ -245,6 +245,7 @@ class VorbisTagger:
             codec=codec,
             has_cover=has_cover,
             album_artist=first(KEY_ALBUM_ARTIST),
+            disc_num=_first_int(first(KEY_DISC_NUMBER)),
         )
 
     def read_tags(self, path: Path) -> TrackTags:

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -199,6 +199,7 @@ def read_scan_fields(path: Path) -> ScanFields:
         # Flagged, not silently blank: an unopenable file must not read as an
         # untagged one (#112).
         return ScanFields(None, None, None, None, unreadable=True)
+    disk = audio.get(ATOM_DISC_NUM) or []
     return ScanFields(
         album_title=_text_atom(audio, ATOM_ALBUM),
         album_id=_binary_atom_str(audio, ATOM_MB_ALBUM_ID),
@@ -206,6 +207,7 @@ def read_scan_fields(path: Path) -> ScanFields:
         codec=_codec_label(audio),
         has_cover=bool(audio.get(ATOM_COVER)),
         album_artist=_text_atom(audio, ATOM_ALBUM_ARTIST),
+        disc_num=disk[0][0] if disk and disk[0] else None,
     )
 
 

--- a/src/harmonist/formats/mp3.py
+++ b/src/harmonist/formats/mp3.py
@@ -198,6 +198,8 @@ def read_scan_fields(path: Path) -> ScanFields:
         codec="MP3",
         has_cover=bool(tags and tags.getall("APIC")),
         album_artist=_text(tags, "TPE2"),
+        # TPOS is "2" or "2/2" — take the disc, discard the total.
+        disc_num=_first_int(_text(tags, "TPOS")),
     )
 
 

--- a/src/harmonist/formats/types.py
+++ b/src/harmonist/formats/types.py
@@ -32,6 +32,13 @@ class ScanFields(NamedTuple):
     # mid-tagging and invites the user to re-tag it (#112). "I couldn't read
     # this" and "there's nothing here" are different answers.
     unreadable: bool = False
+    # Disc number (Picard: disk / TPOS / DISCNUMBER). None when the tag is
+    # absent, which is the norm for a single-disc release. Read here — in the
+    # scan's one open per file — rather than via `read_tags`, because it is what
+    # separates the two folders of a split release (disc 1, disc 2) from two
+    # duplicate copies of the same one (both disc 1), and that question is asked
+    # of every album in the library, not of one the user opened (#16).
+    disc_num: int | None = None
 
 
 @dataclass

--- a/src/harmonist/match.py
+++ b/src/harmonist/match.py
@@ -13,7 +13,7 @@ from datetime import UTC, datetime
 from itertools import zip_longest
 from pathlib import Path
 
-from . import formats
+from . import album_files, formats
 from .compare import LENGTH_TOLERANCE_MS
 from .models import MatchCandidate, MatchConfidence, Release, Track, TrackComparison
 from .tagger import _flatten_tracks, _track_title
@@ -32,7 +32,7 @@ def assess_match(album_dir: Path, release: Release) -> MatchCandidate:
         or out of tolerance.
       - "no_match": file count differs from MB track count.
     """
-    files = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
+    files = album_files.audio_files(album_dir)
     tracks = list(_flatten_tracks(release))
 
     file_count = len(files)

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -246,6 +246,13 @@ class Album:
     # sidecar from the tag MBID. Untagged orphans (no MBID) are never
     # reconcilable, so the inbox uses this to avoid kicking reconcile for them.
     has_tag_mbid: bool = False
+    # The one disc number every file here carries, or None when they disagree
+    # or none is tagged. Scanner-derived; not persisted. This is what tells a
+    # split release (#16) from a duplicate: two directories of the same MB
+    # release are its disc 1 and disc 2 if their numbers DIFFER, and are two
+    # copies of the same disc if they don't. Absent that, "same release, two
+    # folders" describes both, and merging a duplicate would be a fabrication.
+    disc_num: int | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/harmonist/reconcile.py
+++ b/src/harmonist/reconcile.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 from . import album_files, audit, formats, url_recovery
 from . import sidecar as sidecar_mod
+from .formats import owned
 from .models import Album, Sidecar, is_bandcamp_url
 
 log = logging.getLogger(__name__)
@@ -285,14 +286,14 @@ def find_split_releases(albums: list[Album], music_dir: Path) -> list[SplitRelea
       happens to hold two discs, not a release that occupies the whole of it;
     * every part is tagged to the same `mb_release_id` — the exact-scoped-unique
       match, scoped to this one parent, from sidecars that already exist;
-    * every part carries a distinct disc number. This is what separates the two
-      halves of a split release from two duplicate copies of it, which agree on
-      the release and on the disc. Without a disc number on every part there is
-      no evidence either way, so nothing is merged.
+    * the parts hold DIFFERENT TRACKS of that release, which is what separates a
+      split release from two duplicate copies of one disc. See
+      `_parts_hold_different_tracks`.
 
-    Deliberately makes NO MusicBrainz call and reads no tags of its own: it runs
-    over the whole library, and the budget rule (§6) puts a per-album lookup out
-    of reach. Everything it needs the scan has already read.
+    Deliberately makes NO MusicBrainz call: it runs over the whole library, and
+    the budget rule (§6) puts a per-album lookup out of reach. The only check
+    that reads tags or touches the filesystem is the last one, by which point a
+    directory has already had to look exactly like a split release.
     """
     by_parent: dict[Path, list[Album]] = {}
     album_paths = {a.path for a in albums}
@@ -314,18 +315,19 @@ def find_split_releases(albums: list[Album], music_dir: Path) -> list[SplitRelea
         mbid = next(iter(mbids))
         if mbid is None:
             continue
-        discs = [a.disc_num for a in parts]
-        if any(d is None for d in discs) or len(set(discs)) != len(discs):
-            continue
-        # Left until last deliberately: it is the only check that touches the
-        # filesystem, and this runs over every directory that holds two or more
-        # albums — i.e. every artist directory in the library, on every
-        # reconcile pass. The release check above rejects those for free (two
-        # albums by one artist are two releases), so the walk only ever happens
-        # for a directory that is already, on the evidence, a split release.
+        # Left until last deliberately: these are the only checks that read tags
+        # or touch the filesystem, and this loop runs over every directory
+        # holding two or more albums — i.e. every artist directory in the
+        # library, on every reconcile pass. The release check above rejects
+        # those for free (two albums by one artist are two releases), so the
+        # reads below only ever happen for a directory that already looks like a
+        # split release, and only once: the parent gets a sidecar and is skipped
+        # from then on.
         if _has_unaccounted_audio(parent, {a.path for a in parts}):
             continue
-        ordered = sorted(parts, key=lambda a: a.disc_num or 0)
+        if not _parts_hold_different_tracks(parts):
+            continue
+        ordered = _in_disc_order(parts)
         found.append(
             SplitRelease(
                 parent=parent,
@@ -334,6 +336,76 @@ def find_split_releases(albums: list[Album], music_dir: Path) -> list[SplitRelea
             )
         )
     return found
+
+
+def _parts_hold_different_tracks(parts: list[Album]) -> bool:
+    """True when the candidate parts hold DIFFERENT tracks of the release.
+
+    The question this whole feature turns on. "Same release, two folders"
+    describes a split release and a duplicate pair equally well, and merging a
+    duplicate would fabricate a two-disc album out of two copies of one disc —
+    so something has to tell them apart.
+
+    **Release-track MBIDs, when the files carry them.** Every track of a release
+    has its own `MusicBrainz Release Track Id`, so two directories holding
+    different discs have DISJOINT sets and two copies of one disc have identical
+    ones. This is a direct reading of the thing in question rather than a proxy
+    for it: it does not merely establish that the parts *claim* to be different
+    discs, it establishes that they *are* different tracks. Picard has written
+    this tag for well over a decade, and Harmonist's own tagger writes it, so it
+    is present on anything tagged the way the adoption path asks for.
+
+    **Distinct disc numbers, when they don't.** A pre-2011 rip may carry no
+    track ids at all, and refusing to ever group those would be a needless
+    limitation. Distinct disc numbers are weaker — they are what the files
+    claim, not what they contain — but they are still an exact test, and a
+    duplicate pair fails it (both copies say disc 1).
+
+    A MIXTURE is rejected: if one part has track ids and another doesn't, there
+    is nothing to compare, and the disc-number fallback would be answering a
+    question the better evidence was available to settle.
+    """
+    identities = [_release_track_ids(a.path) for a in parts]
+    if all(ids for ids in identities):
+        # Disjoint iff no id is shared, i.e. the union is as big as the parts.
+        return len(set().union(*identities)) == sum(len(ids) for ids in identities)
+    if any(ids for ids in identities):
+        return False  # some tagged, some not — no honest comparison
+    discs = [a.disc_num for a in parts]
+    return all(d is not None for d in discs) and len(set(discs)) == len(discs)
+
+
+def _release_track_ids(album_dir: Path) -> frozenset[str]:
+    """Every file's `MusicBrainz Release Track Id` in this directory, or an
+    empty set if ANY file lacks one.
+
+    All-or-nothing because a partial set makes disjointness meaningless: two
+    copies of one disc where half the files are untagged would compare as
+    disjoint on the tagged half and read as a split release.
+    """
+    ids = set()
+    for f in album_files.audio_files(album_dir):
+        try:
+            value = formats.read_owned(f).get(owned.Owned.MB_RELEASE_TRACK_ID)
+        except Exception:
+            # An unreadable file is not evidence of anything. Bail rather than
+            # judging the album on the files that happened to open — grouping is
+            # a write, and this is the check standing between it and a duplicate.
+            log.warning("could not read the track id on %s — not grouping", f)
+            return frozenset()
+        if not isinstance(value, str) or not value:
+            return frozenset()
+        ids.add(value)
+    return frozenset(ids)
+
+
+def _in_disc_order(parts: list[Album]) -> list[Album]:
+    """Candidate parts in disc order, falling back to path order when the files
+    carry no disc number. Affects only how the promotion is recorded — the
+    album's own track order comes from `album_files`."""
+    if all(a.disc_num is not None for a in parts):
+        return sorted(parts, key=lambda a: a.disc_num or 0)
+    return sorted(parts, key=lambda a: a.path)
 
 
 def _has_unaccounted_audio(parent: Path, parts: set[Path]) -> bool:

--- a/src/harmonist/reconcile.py
+++ b/src/harmonist/reconcile.py
@@ -26,14 +26,14 @@ Pure: no globals. Caller injects `fetch_urls` (MB lookup) and `recover_url`
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
-from dataclasses import replace
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 
-from . import formats, url_recovery
+from . import album_files, audit, formats, url_recovery
 from . import sidecar as sidecar_mod
-from .models import Sidecar, is_bandcamp_url
+from .models import Album, Sidecar, is_bandcamp_url
 
 log = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def reconcile_album(
         file MBID → **adopt the file tags** (the user re-tagged in Picard, as we
         ask them to). Otherwise leave an existing sidecar untouched.
     """
-    files = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
+    files = album_files.audio_files(album_dir)
     if not files:
         return None
 
@@ -190,7 +190,7 @@ def store_url_for_tagging(
     Everything is gated by Bandcamp evidence in the `©cmt`: with no Bandcamp URL
     in the comment at all, returns None (a CD rip stays Complete, not Needs Link).
     """
-    files = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
+    files = album_files.audio_files(album_dir)
     if not files:
         return None
     comment = formats.read_comment(files[0]) or ""
@@ -244,3 +244,192 @@ def matching_bandcamp_url(
         if is_bandcamp_url(url):
             return url
     return None
+
+
+# ---------------------------------------------------------------------------
+# Split releases: one MB release living in several per-disc directories (#16)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SplitRelease:
+    """A release whose discs the user filed in sibling directories.
+
+    `parent` is the directory that should own the album; `parts` are the
+    per-disc directories beneath it, in disc order. Detection only — promoting
+    it is a separate, audited step.
+    """
+
+    parent: Path
+    mb_release_id: str
+    parts: tuple[Path, ...]
+
+    @property
+    def track_count(self) -> int:
+        return sum(len(album_files.audio_files(p)) for p in self.parts)
+
+
+def find_split_releases(albums: list[Album], music_dir: Path) -> list[SplitRelease]:
+    """Directories whose subdirectories hold the discs of one MB release.
+
+    The test is an identity match, not a best fit — every one of these has to
+    hold, and any that doesn't leaves the directories exactly as they are:
+
+    * the parent is not the library root, and is not an album itself (it has no
+      audio of its own, or the scanner would have yielded it);
+    * it has no sidecar yet — one already there means it is grouped already,
+      and re-promoting it every pass would be the oscillating rewrite the
+      idempotence rule forbids;
+    * at least two audio-bearing subdirectories, and EVERY one of them is
+      accounted for — a leftover means this is a container directory that
+      happens to hold two discs, not a release that occupies the whole of it;
+    * every part is tagged to the same `mb_release_id` — the exact-scoped-unique
+      match, scoped to this one parent, from sidecars that already exist;
+    * every part carries a distinct disc number. This is what separates the two
+      halves of a split release from two duplicate copies of it, which agree on
+      the release and on the disc. Without a disc number on every part there is
+      no evidence either way, so nothing is merged.
+
+    Deliberately makes NO MusicBrainz call and reads no tags of its own: it runs
+    over the whole library, and the budget rule (§6) puts a per-album lookup out
+    of reach. Everything it needs the scan has already read.
+    """
+    by_parent: dict[Path, list[Album]] = {}
+    album_paths = {a.path for a in albums}
+    for album in albums:
+        parent = album.path.parent
+        if parent == music_dir or parent in album_paths:
+            continue
+        by_parent.setdefault(parent, []).append(album)
+
+    found = []
+    for parent, parts in sorted(by_parent.items()):
+        if len(parts) < 2 or sidecar_mod.has_sidecar(parent):
+            continue
+        if any(a.sidecar is None for a in parts):
+            continue
+        mbids = {a.sidecar.mb_release_id for a in parts if a.sidecar is not None}
+        if len(mbids) != 1:
+            continue
+        mbid = next(iter(mbids))
+        if mbid is None:
+            continue
+        discs = [a.disc_num for a in parts]
+        if any(d is None for d in discs) or len(set(discs)) != len(discs):
+            continue
+        # Left until last deliberately: it is the only check that touches the
+        # filesystem, and this runs over every directory that holds two or more
+        # albums — i.e. every artist directory in the library, on every
+        # reconcile pass. The release check above rejects those for free (two
+        # albums by one artist are two releases), so the walk only ever happens
+        # for a directory that is already, on the evidence, a split release.
+        if _has_unaccounted_audio(parent, {a.path for a in parts}):
+            continue
+        ordered = sorted(parts, key=lambda a: a.disc_num or 0)
+        found.append(
+            SplitRelease(
+                parent=parent,
+                mb_release_id=mbid,
+                parts=tuple(a.path for a in ordered),
+            )
+        )
+    return found
+
+
+def _has_unaccounted_audio(parent: Path, parts: set[Path]) -> bool:
+    """True when audio lives under `parent` outside the candidate parts —
+    directly in it, or in a subdirectory the scan did not yield as an album
+    (an unreadable sidecar, say). Such a directory is a container that happens
+    to hold two discs, and absorbing the rest of it would be a guess.
+    """
+    try:
+        entries = list(parent.iterdir())
+    except OSError:
+        return True  # can't rule it out → don't merge
+    for entry in entries:
+        if entry.is_file() and formats.is_supported(entry):
+            return True
+        if entry.is_dir() and entry not in parts and album_files.descendant_audio_files(entry):
+            return True
+    return False
+
+
+def promote_split_release(split: SplitRelease) -> Sidecar:
+    """Write the parent's sidecar so the discs read as one album, and return it.
+
+    **Nothing on disk moves.** The files stay exactly where the user filed them,
+    keeping the layout Plex and Navidrome already index; all that changes is
+    which directory carries the `.harmonist.json`, and from the next scan the
+    parent answers for the whole release (see `album_files`). Removing that
+    sidecar is what undoes it — the parts then stand on their own again,
+    unchanged — so this needs no migration and offers a way back out.
+
+    The parts' own sidecars are left alone. They are stale descriptions of
+    directories that are no longer albums, and deleting them would be a
+    destructive write to user data on the strength of a derived rule; the
+    scanner ignores them (it never descends into a grouped album), so they cost
+    nothing but a little clutter.
+
+    The parent's sidecar inherits from the parts rather than being re-derived,
+    which is what keeps this off the MusicBrainz budget: they already agree on
+    the release, and the store link, purchase state and timestamps are the same
+    album's history however many directories it was living in.
+    """
+    sidecars = [sc for p in split.parts if (sc := sidecar_mod.read(p)) is not None]
+    merged = Sidecar(
+        store_url=_first(sc.store_url for sc in sidecars),
+        bandcamp=_first(sc.bandcamp for sc in sidecars),
+        downloaded_at=_earliest(sc.downloaded_at for sc in sidecars),
+        # The album has existed since the first of its discs did.
+        added_at=_earliest(sc.added_at for sc in sidecars) or datetime.now(UTC),
+        mb_release_id=split.mb_release_id,
+        # Last tagged is when the album — all of it — was last brought up to
+        # date; a disc tagged earlier does not make the album older.
+        tagged_at=_latest(sc.tagged_at for sc in sidecars),
+        # Each part that Harmonist tagged recorded the WHOLE release's track
+        # count (see `_tag_with_release`), not its own disc's, so the maximum is
+        # that count and not a sum. Parts adopted at onboarding have none at all
+        # (#187), in which case this stays None and the album derives COMPLETE
+        # exactly as its parts did.
+        track_count_expected=_max(sc.track_count_expected for sc in sidecars),
+        notes=_first(sc.notes for sc in sidecars),
+        purchase_unavailable=any(sc.purchase_unavailable for sc in sidecars),
+    )
+    sidecar_mod.write(split.parent, merged)
+    # NO alias row, and that is not an omission. #16 assumed one was needed —
+    # an absorbed directory's id normally stops naming anything on disk, which
+    # is exactly what `album_aliases` exists for (#33). It doesn't arise here:
+    # an album's id IS its `mb_release_id` once it has one (`_album_id_of`), and
+    # detection only groups parts that already agree on that release. So every
+    # part and the parent share one id throughout, and the history recorded
+    # against "CD2" is already reachable from the album that survives.
+    audit.record(
+        "album.group",
+        album_id=split.mb_release_id,
+        album=split.parent,
+        release=split.mb_release_id,
+        parts=len(split.parts),
+        tracks=split.track_count,
+    )
+    return merged
+
+
+def _first[T](values: Iterable[T | None]) -> T | None:
+    """The first value that is set, or None. The parts describe one album, so
+    "any of them knows" is the honest reading of a field only some carry."""
+    return next((v for v in values if v is not None), None)
+
+
+def _earliest(values: Iterable[datetime | None]) -> datetime | None:
+    present = [v for v in values if v is not None]
+    return min(present) if present else None
+
+
+def _latest(values: Iterable[datetime | None]) -> datetime | None:
+    present = [v for v in values if v is not None]
+    return max(present) if present else None
+
+
+def _max(values: Iterable[int | None]) -> int | None:
+    present = [v for v in values if v is not None]
+    return max(present) if present else None

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from stat import S_ISREG
 from typing import NamedTuple
 
-from . import formats, id_registry
+from . import album_files, formats, id_registry
 from .models import Album, AlbumState, InconsistentTrack, Sidecar, is_bandcamp_url
 from .sidecar import InvalidSidecarError, UnsupportedSchemaVersionError
 from .sidecar import read as read_sidecar
@@ -40,9 +40,11 @@ AlbumCache = dict[Path, tuple[AlbumSignature, Album, list["formats.ScanFields"]]
 def scan(music_dir: Path, *, album_cache: AlbumCache | None = None) -> list[Album]:
     """Return one Album for every album directory under music_dir.
 
-    An "album directory" is any directory that contains at least one
-    audio file in a supported format. State is derived from the sidecar
-    (if present) plus a file-tag check for confirming "tagged" status.
+    An "album directory" is any directory that contains at least one audio
+    file in a supported format — plus, per `album_files`, a sidecar'd parent
+    whose audio lives in per-disc subdirectories (#16). State is derived from
+    the sidecar (if present) plus a file-tag check for confirming "tagged"
+    status.
 
     Pass a persistent ``album_cache`` dict to skip re-reading tags for
     albums whose on-disk fingerprint (file mtimes/sizes + sidecar + cover)
@@ -60,8 +62,15 @@ def scan(music_dir: Path, *, album_cache: AlbumCache | None = None) -> list[Albu
 
 
 def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], AlbumSignature]]:
-    """Yield (album_dir, sorted_audio_files, signature) for every directory
-    containing supported audio, ONE DIRECTORY AT A TIME.
+    """Yield (album_dir, sorted_audio_files, signature) for every album
+    directory under `root`, ONE DIRECTORY AT A TIME.
+
+    An album directory is one containing supported audio — or, per
+    `album_files`, one that declares itself an album with a sidecar while
+    holding its audio in per-disc subdirectories (#16). A grouped album is
+    yielded ONCE, for the parent, carrying every file beneath it; the
+    subdirectories are then not albums in their own right and are skipped, so
+    the two halves of a split release stop appearing as two Library tiles.
 
     Uses ``os.walk`` (not ``rglob`` + groupby) so a caller can interleave work
     between directories — the async scan runner yields to the event loop here.
@@ -70,8 +79,15 @@ def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], AlbumSignatu
     """
     if not root.exists():
         return
+    # Parents already yielded as grouped albums. Everything below one of these
+    # belongs to it, so it must not also be yielded on its own account. os.walk
+    # is top-down, which is what makes a parent reliably known before its
+    # children are reached.
+    grouped_roots: list[Path] = []
     for dirpath, _dirnames, filenames in os.walk(root):
         d = Path(dirpath)
+        if any(r in d.parents for r in grouped_roots):
+            continue
         audio: list[tuple[Path, int, int]] = []
         sidecar_mtime: int | None = None
         cover_mtime: int | None = None
@@ -90,15 +106,43 @@ def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], AlbumSignatu
             elif name in ("cover.jpg", "cover.png"):
                 cover_mtime = st.st_mtime_ns
         if not audio:
-            continue
-        audio.sort(key=lambda e: e[0].name)
+            # No audio of its own. A sidecar here declares a release split
+            # across per-disc subdirectories — collect their files under this
+            # directory. Anything else is an ordinary artist/container dir.
+            if sidecar_mtime is None:
+                continue
+            grouped = _grouped_entries(d)
+            if not grouped:
+                continue  # sidecar but nothing beneath it — not an album
+            grouped_roots.append(d)
+            audio = grouped
+        else:
+            audio.sort(key=lambda e: album_files.sort_key(Path(e[0].name)))
         files = [e[0] for e in audio]
         signature: AlbumSignature = (
-            tuple((e[0].name, e[1], e[2]) for e in audio),
+            # Keyed on the path RELATIVE to the album dir, not the bare name:
+            # a grouped album has a "01 - …" in every disc directory, and bare
+            # names would collide into one indistinguishable signature entry.
+            tuple((str(e[0].relative_to(d)), e[1], e[2]) for e in audio),
             sidecar_mtime,
             cover_mtime,
         )
         yield d, files, signature
+
+
+def _grouped_entries(album_dir: Path) -> list[tuple[Path, int, int]]:
+    """(path, mtime_ns, size) for every audio file below a grouped album dir,
+    in track order. Unstattable files are dropped, exactly as in the walk above.
+    """
+    entries = []
+    for f in album_files.descendant_audio_files(album_dir):
+        try:
+            st = f.stat()
+        except OSError:
+            continue
+        if S_ISREG(st.st_mode):
+            entries.append((f, st.st_mtime_ns, st.st_size))
+    return entries
 
 
 def resolve_album(
@@ -224,7 +268,18 @@ def build_album(album_dir: Path, audio_files: list[Path], io: AlbumIO) -> Album:
         # reconcile.reconcile_album reads). Lets the inbox skip kicking
         # reconcile for untagged orphans it could never resolve.
         has_tag_mbid=any(sf.album_id for sf in fields),
+        disc_num=_consistent_disc_num(fields),
     )
+
+
+def _consistent_disc_num(fields: list[formats.ScanFields]) -> int | None:
+    """The single disc number all this album's files carry, or None when they
+    disagree or none is tagged. Untagged is the norm for a single-disc release,
+    so None means "don't know", never "disc 0"."""
+    discs = {sf.disc_num for sf in fields if sf.disc_num is not None}
+    if len(discs) != 1 or any(sf.disc_num is None for sf in fields):
+        return None
+    return next(iter(discs))
 
 
 def _audio_format(fields: list[formats.ScanFields]) -> str | None:

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -14,10 +14,10 @@ import hashlib
 import logging
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, runtime_checkable
 
-from . import activity_store, artwork_store, audit, formats, tag_history
+from . import activity_store, album_files, artwork_store, audit, formats, tag_history
 from . import sidecar as sidecar_mod
 from .formats import TagSet, owned
 from .formats.m4a import (  # noqa: F401 — back-compat re-exports
@@ -130,7 +130,7 @@ def tag_album(
     differing per-track artwork (which is otherwise preserved) — the user's
     explicit "replace the artwork" override.
     """
-    files = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
+    files = album_files.audio_files(album_dir)
     flat_tracks = list(_flatten_tracks(release))
 
     if not incomplete and len(files) != len(flat_tracks):
@@ -203,18 +203,19 @@ def tag_album(
         event_id = audit.record(
             "tag.track",
             album_id=album_id,
-            file=file_path.name,
+            file=album_files.rel_name(album_dir, file_path),
             track=track_pos_in_medium,
             title=_track_title(track),
         )
         if event_id is not None:
-            _record_changes(event_id, file_path, tagset, before, art_before, art_after)
+            _record_changes(event_id, album_dir, file_path, tagset, before, art_before, art_after)
 
     return len(files)
 
 
 def _record_changes(
     event_id: int,
+    album_dir: Path,
     file_path: Path,
     tagset: TagSet,
     before: dict[str, Any],
@@ -241,7 +242,7 @@ def _record_changes(
         return
     activity_store.record_tag_changes(
         event_id,
-        file=file_path.name,
+        file=album_files.rel_name(album_dir, file_path),
         changes=changes,
         track_ref=tagset.mb_release_track_id,
         rec_ref=tagset.mb_track_id,
@@ -380,22 +381,48 @@ def _identity_revert(
     if len(befores) != 1:
         return None
 
-    on_disk = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
-    if {p.name for p in on_disk} != set(changes):
+    on_disk = {album_files.rel_name(album_dir, p): p for p in album_files.audio_files(album_dir)}
+    if set(on_disk) != set(changes):
         # Files have appeared or gone since. Any the plan doesn't name would
         # keep whatever id they carry, so moving the rest would split the
         # album's identity between two releases.
         return None
-    for path in on_disk:
+    for name, path in on_disk.items():
         try:
             current = formats.read_owned(path)
         except Exception as e:
-            raise RevertUnavailableError(f"could not read the tags on {path.name}: {e}") from e
-        if owned.values_differ(current.get(field), changes[path.name][1]):
+            raise RevertUnavailableError(f"could not read the tags on {name}: {e}") from e
+        if owned.values_differ(current.get(field), changes[name][1]):
             return None
 
     before = next(iter(befores))
     return _IdentityRevert(value=before if isinstance(before, str) and before else None)
+
+
+def _resolve_in_album(album_dir: Path, name: str, error: type[Exception]) -> Path:
+    """Join a stored record's file name onto the album directory, refusing
+    anything that could name a file outside it.
+
+    Raises the caller's own "this undo can't be done" exception rather than a
+    bare ValueError, so a malformed record surfaces to the user as a declined
+    undo instead of a 500.
+
+    Since #16 the name may carry a disc directory ("CD2/01 - Intro.m4a"), so a
+    bare-filename test no longer works — but relaxing the SHAPE must not relax
+    the guarantee. Every component is checked, and the joined path is confirmed
+    to still be inside the album afterwards, which is what actually holds on a
+    case-insensitive or symlinked filesystem.
+    """
+    rel = PurePosixPath(name)
+    if not name or rel.is_absolute() or any(part in ("", ".", "..") for part in rel.parts):
+        raise error(f"{name!r} is not a file name in this album")
+    path = album_dir / rel
+    # The component check above rejects the obvious escapes; this rejects the
+    # ones a filesystem invents — a symlinked disc directory pointing out of the
+    # album. `resolve()` follows links, so it is the real target being tested.
+    if not path.resolve().is_relative_to(album_dir.resolve()):
+        raise error(f"{name!r} is not a file name in this album")
+    return path
 
 
 def revert_tags(album_dir: Path, plan: Sequence[tag_history.FileRevert]) -> RevertOutcome:
@@ -433,11 +460,8 @@ def revert_tags(album_dir: Path, plan: Sequence[tag_history.FileRevert]) -> Reve
     for item in plan:
         # `item.file` reaches here from a stored record and is joined to a path.
         # Records are permanent and unversioned, so a malformed one will turn up
-        # eventually; a bare filename is the only thing ever written here, and
-        # anything else must not become a write outside the album.
-        if item.file != Path(item.file).name or item.file in ("", ".", ".."):
-            raise RevertUnavailableError(f"{item.file!r} is not a file name in this album")
-        path = album_dir / item.file
+        # eventually, and this join must not become a write outside the album.
+        path = _resolve_in_album(album_dir, item.file, RevertUnavailableError)
         if not path.exists():
             raise RevertUnavailableError(f"{item.file} is no longer in this album")
         try:
@@ -493,12 +517,14 @@ def revert_tags(album_dir: Path, plan: Sequence[tag_history.FileRevert]) -> Reve
             "tag.revert.track",
             album_id=album_id,
             album=album_dir,
-            file=path.name,
+            file=album_files.rel_name(album_dir, path),
         )
         if event_id is not None:
             changes = owned.diff(before, target)
             if changes:
-                activity_store.record_tag_changes(event_id, file=path.name, changes=changes)
+                activity_store.record_tag_changes(
+                    event_id, file=album_files.rel_name(album_dir, path), changes=changes
+                )
         files += 1
 
     return RevertOutcome(
@@ -537,11 +563,8 @@ def restore_artwork(album_dir: Path, digests: dict[str, str]) -> int:
     for name, key in digests.items():
         # `name` comes out of a stored record and is joined to a path. Records
         # are permanent and unversioned, so a malformed one will turn up
-        # eventually; a bare filename is the only thing that was ever written
-        # here, and anything else must not become a write outside the album.
-        if name != Path(name).name or name in ("", ".", ".."):
-            raise ArtworkUnavailableError(f"{name!r} is not a file name in this album")
-        path = album_dir / name
+        # eventually, and this join must not become a write outside the album.
+        path = _resolve_in_album(album_dir, name, ArtworkUnavailableError)
         if not path.exists():
             raise ArtworkUnavailableError(f"{name} is no longer in this album")
         stored = artwork_store.path_for(key)
@@ -566,7 +589,12 @@ def restore_artwork(album_dir: Path, digests: dict[str, str]) -> int:
         if current is not None:
             artwork_store.keep(current[0], mime=current[1])
         formats.write_cover(path, data)
-        audit.record("artwork.restore", album=album_dir, file=path.name, digest=_digest(data))
+        audit.record(
+            "artwork.restore",
+            album=album_dir,
+            file=album_files.rel_name(album_dir, path),
+            digest=_digest(data),
+        )
         restored += 1
     return restored
 

--- a/src/harmonist/url_recovery.py
+++ b/src/harmonist/url_recovery.py
@@ -22,7 +22,7 @@ import re
 from pathlib import Path
 from urllib.parse import urlparse
 
-from . import formats
+from . import album_files, formats
 from .models import is_bandcamp_url
 
 log = logging.getLogger(__name__)
@@ -74,7 +74,7 @@ def recover_store_url(album_dir: Path) -> str | None:
     marks the album a Bandcamp purchase → Needs MBID, and the sync links it by
     title later). None when the comment has no Bandcamp link at all.
     """
-    files = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
+    files = album_files.audio_files(album_dir)
     if not files:
         return None
     return extract_bandcamp_url(formats.read_comment(files[0]) or "")

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -31,6 +31,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from harmonist import (
     activity,
     activity_store,
+    album_files,
     artwork_store,
     audit,
     compare,
@@ -710,8 +711,11 @@ def _album_comparison(
     file in the album — the read cost #106 flags, and the same cost problem as
     #44 / #74. Reading them twice for one page view would be careless.
     """
-    files = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
-    tracks = [(f.name, formats.read_tags(f)) for f in files]
+    files = album_files.audio_files(album_dir)
+    # Named by path relative to the album, so the two "01 - Intro.m4a" of a
+    # split release (#16) stay distinguishable in the tracklist. Identical to
+    # the bare name for a flat album, which is every album Harmonist creates.
+    tracks = [(str(f.relative_to(album_dir)), formats.read_tags(f)) for f in files]
     tagsets = tagsets_for(release)
     mb_tracks = [
         compare.MBTrack(tags=ts, length_ms=length)
@@ -1632,7 +1636,7 @@ def _unlink_after_revert(album: Album, outcome: tagger_mod.RevertOutcome) -> boo
         return False  # already agrees — nothing to do
 
     suggest = outcome.release_id_now or sc.mb_release_id
-    files = len([p for p in album.path.iterdir() if formats.is_supported(p)])
+    files = len(album_files.audio_files(album.path))
     candidate = (
         MatchCandidate(
             mb_release_id=suggest,
@@ -1722,7 +1726,7 @@ def _embedded_cover(album_path: Path) -> tuple[bytes, str] | None:
     """Extract embedded cover art (bytes, mime) from the album's first audio
     file, or None. Used by /cover to serve art without writing it to disk."""
     try:
-        files = sorted(p for p in album_path.iterdir() if formats.is_supported(p))
+        files = album_files.audio_files(album_path)
     except OSError:
         return None
     if not files:

--- a/src/harmonist/web/reconcile_runner.py
+++ b/src/harmonist/web/reconcile_runner.py
@@ -258,6 +258,13 @@ def reconcile_pending_orphans(
     if status_updater:
         status_updater(total=total)
     _report()  # publish the base (all-zero deltas) before the first album
+
+    # Split releases (#16), BEFORE the early return below: a release filed as
+    # per-disc directories is made of COMPLETE albums, not of the orphans this
+    # pass otherwise exists for, so gating it on `total` would mean it only ever
+    # ran on a library that also happened to have something new in it.
+    grouped = _promote_split_releases(albums, music_dir, exempt)
+
     if not total:
         # Nothing to do. Reconcile runs on startup and after every sync, so
         # announcing a no-op made it the feed's most frequent content — three
@@ -270,6 +277,7 @@ def reconcile_pending_orphans(
             "reconciled_manual": 0,
             "recovered_url": 0,
             "adopted": 0,
+            "grouped": grouped,
             "skipped": 0,
             "errors": 0,
         }
@@ -365,6 +373,55 @@ def reconcile_pending_orphans(
         "reconciled_manual": reconciled_manual,
         "recovered_url": recovered_url,
         "adopted": adopted,
+        "grouped": grouped,
         "skipped": skipped,
         "errors": errors,
     }
+
+
+def _promote_split_releases(albums: list[Album], music_dir: Path, exempt: set[Path]) -> int:
+    """Give each release found split across per-disc directories a sidecar on
+    the parent, so the next scan reads it as one album. Returns how many.
+
+    Idempotent by construction: `find_split_releases` skips any parent that
+    already has a sidecar, so a second pass over the same library finds nothing
+    and writes nothing. That matters because reconcile runs on startup and after
+    every sync.
+
+    `exempt` carries the same Forget intent the orphan pass respects — a parent
+    the user just un-grouped must not be re-grouped underneath them.
+
+    One activity entry per release, inside its own action scope so the audit row
+    the promotion writes hangs off the entry describing it (#84). Failure of one
+    release must not take down the reconcile pass around it — the albums stay
+    exactly as they were, which is a state the app already handles, being the
+    one it has always been in.
+    """
+    from harmonist import reconcile
+
+    grouped = 0
+    for split in reconcile.find_split_releases(albums, music_dir):
+        if split.parent in exempt:
+            # Forget on a grouped album deletes the parent's sidecar, which is
+            # precisely how a user un-groups one. Re-grouping it on the very
+            # next pass would make that button do nothing — the same reason
+            # reconcile skips exempt orphans rather than re-deriving them.
+            log.debug("split release at %s is forgotten — not re-grouping", split.parent)
+            continue
+        with activity_store.action():
+            try:
+                reconcile.promote_split_release(split)
+            except Exception:
+                log.exception("could not group the split release at %s", split.parent)
+                activity.warning(
+                    f"Could not group the discs under {split.parent.name} — left as separate albums"
+                )
+                continue
+            grouped += 1
+            activity.record(
+                f"Grouped {len(split.parts)} disc folder(s) into one album "
+                f"({split.track_count} tracks)",
+                album_id=split.mb_release_id,
+                album_label=split.parent.name,
+            )
+    return grouped

--- a/test/test_split_release.py
+++ b/test/test_split_release.py
@@ -1,0 +1,617 @@
+"""Split releases: one MB release filed as per-disc directories (#16).
+
+Two halves, tested separately because they fail differently: the SCANNER
+grouping (a sidecar'd parent owns the audio beneath it) and the DETECTION that
+writes that sidecar in the first place.
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from mutagen.mp4 import MP4
+
+from harmonist import album_files, reconcile
+from harmonist import sidecar as sidecar_mod
+from harmonist.models import AlbumState, Sidecar
+from harmonist.scanner import scan
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+SINE_M4A = FIXTURES_DIR / "sine.m4a"
+
+MBID = "11111111-2222-3333-4444-555555555555"
+OTHER_MBID = "99999999-8888-7777-6666-555555555555"
+
+
+def _disc_dir(
+    parent: Path,
+    name: str,
+    *,
+    mbid: str | None = MBID,
+    disc: int | None = 1,
+    tracks: int = 2,
+    sidecar: bool = True,
+) -> Path:
+    """One disc's directory: `tracks` tagged files, plus its own sidecar."""
+    d = parent / name
+    d.mkdir(parents=True)
+    for i in range(1, tracks + 1):
+        f = d / f"{i:02d} Track {i}.m4a"
+        shutil.copy(SINE_M4A, f)
+        audio = MP4(f)
+        audio["\xa9alb"] = ["Vapourized Volume One"]
+        audio["\xa9ART"] = ["Kasey Taylor"]
+        if disc is not None:
+            audio["disk"] = [(disc, 2)]
+        if mbid is not None:
+            audio["----:com.apple.iTunes:MusicBrainz Album Id"] = [mbid.encode()]
+        audio.save()
+    if sidecar:
+        sidecar_mod.write(
+            d,
+            Sidecar(
+                mb_release_id=mbid,
+                added_at=datetime(2026, 1, 1, tzinfo=UTC),
+                tagged_at=datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        )
+    return d
+
+
+def _edit_sidecar(album_dir: Path, **fields: object) -> None:
+    """Adjust an already-written sidecar in place."""
+    sc = sidecar_mod.read(album_dir)
+    assert sc is not None
+    for key, value in fields.items():
+        setattr(sc, key, value)
+    sidecar_mod.write(album_dir, sc)
+
+
+def _split_album(root: Path, name: str = "Vapourized Volume One") -> Path:
+    parent = root / "Various Artists" / name
+    _disc_dir(parent, "CD1", disc=1)
+    _disc_dir(parent, "CD2", disc=2)
+    return parent
+
+
+# ---------------------------------------------------------------------------
+# Scanner grouping
+# ---------------------------------------------------------------------------
+
+
+def test_disc_dirs_are_separate_albums_until_the_parent_is_promoted(tmp_path):
+    """The pre-#16 shape, and the shape a library is in before reconcile runs:
+    two directories, two tiles."""
+    _split_album(tmp_path)
+    albums = scan(tmp_path)
+    assert len(albums) == 2
+    assert {a.path.name for a in albums} == {"CD1", "CD2"}
+
+
+def test_a_sidecared_parent_owns_the_audio_beneath_it(tmp_path):
+    parent = _split_album(tmp_path)
+    sidecar_mod.write(parent, Sidecar(mb_release_id=MBID, tagged_at=datetime.now(UTC)))
+
+    albums = scan(tmp_path)
+
+    assert [a.path for a in albums] == [parent]
+    assert albums[0].track_count == 4
+
+
+def test_grouped_album_orders_its_files_by_disc(tmp_path):
+    parent = _split_album(tmp_path)
+    sidecar_mod.write(parent, Sidecar(mb_release_id=MBID))
+
+    files = album_files.audio_files(parent)
+
+    assert [str(f.relative_to(parent)) for f in files] == [
+        "CD1/01 Track 1.m4a",
+        "CD1/02 Track 2.m4a",
+        "CD2/01 Track 1.m4a",
+        "CD2/02 Track 2.m4a",
+    ]
+
+
+def test_disc_directories_sort_numerically_not_lexically(tmp_path):
+    """ "CD10" after "CD2". Full tagging zips this list against the release's
+    tracks positionally, so lexical order would tag every disc as the wrong one."""
+    parent = tmp_path / "Box Set"
+    for n in (1, 2, 10):
+        _disc_dir(parent, f"CD{n}", disc=n, tracks=1, sidecar=False)
+    sidecar_mod.write(parent, Sidecar(mb_release_id=MBID))
+
+    files = album_files.audio_files(parent)
+
+    assert [f.parent.name for f in files] == ["CD1", "CD2", "CD10"]
+
+
+def test_a_directory_with_its_own_audio_is_never_grouped(tmp_path):
+    """The safety property: no album that exists today can change shape. An
+    album dir has audio of its own, so a bonus subfolder is not absorbed."""
+    album = tmp_path / "Artist" / "Album"
+    album.mkdir(parents=True)
+    shutil.copy(SINE_M4A, album / "01 Track.m4a")
+    sidecar_mod.write(album, Sidecar(mb_release_id=MBID))
+    _disc_dir(album, "bonus", disc=None, tracks=1, sidecar=False)
+
+    albums = scan(tmp_path)
+
+    assert len(albums) == 2
+    assert {a.path.name for a in albums} == {"Album", "bonus"}
+    by_name = {a.path.name: a for a in albums}
+    assert by_name["Album"].track_count == 1
+
+
+def test_a_parent_without_a_sidecar_is_not_an_album(tmp_path):
+    """An artist directory holds album directories and is not itself an album."""
+    _split_album(tmp_path)
+    albums = scan(tmp_path)
+    assert all(a.path.name != "Various Artists" for a in albums)
+
+
+def test_grouped_album_rescans_from_cache_when_nothing_changed(tmp_path):
+    parent = _split_album(tmp_path)
+    sidecar_mod.write(parent, Sidecar(mb_release_id=MBID))
+    cache: dict = {}
+
+    first = scan(tmp_path, album_cache=cache)
+    second = scan(tmp_path, album_cache=cache)
+
+    assert [a.path for a in first] == [a.path for a in second]
+    assert list(cache) == [parent]
+
+
+def test_grouped_album_notices_a_track_added_in_a_disc_dir(tmp_path):
+    """The signature must span the subdirectories, or a change inside one would
+    be invisible to a cached rescan."""
+    parent = _split_album(tmp_path)
+    sidecar_mod.write(parent, Sidecar(mb_release_id=MBID))
+    cache: dict = {}
+    assert scan(tmp_path, album_cache=cache)[0].track_count == 4
+
+    shutil.copy(SINE_M4A, parent / "CD2" / "03 Track 3.m4a")
+
+    assert scan(tmp_path, album_cache=cache)[0].track_count == 5
+
+
+def test_removing_the_parent_sidecar_ungroups_the_album(tmp_path):
+    """The escape hatch — no hand-editing of JSON, and nothing on disk to undo."""
+    parent = _split_album(tmp_path)
+    sidecar_mod.write(parent, Sidecar(mb_release_id=MBID))
+    assert len(scan(tmp_path)) == 1
+
+    sidecar_mod.sidecar_path(parent).unlink()
+
+    assert {a.path.name for a in scan(tmp_path)} == {"CD1", "CD2"}
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+def _find(root: Path):
+    return reconcile.find_split_releases(scan(root), root)
+
+
+def test_finds_a_release_split_across_two_disc_dirs(tmp_path):
+    parent = _split_album(tmp_path)
+
+    found = _find(tmp_path)
+
+    assert len(found) == 1
+    assert found[0].parent == parent
+    assert found[0].mb_release_id == MBID
+    assert [p.name for p in found[0].parts] == ["CD1", "CD2"]
+
+
+def test_parts_are_ordered_by_disc_number_not_by_name(tmp_path):
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "second-half", disc=2)
+    _disc_dir(parent, "first-half", disc=1)
+
+    found = _find(tmp_path)
+
+    assert [p.name for p in found[0].parts] == ["first-half", "second-half"]
+
+
+def test_duplicate_copies_of_one_disc_are_not_a_split_release(tmp_path):
+    """The case the disc number exists to reject: same release, same disc, two
+    folders. Merging those would fabricate a 2-disc album out of a duplicate."""
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "copy-a", disc=1)
+    _disc_dir(parent, "copy-b", disc=1)
+
+    assert _find(tmp_path) == []
+
+
+def test_untagged_disc_numbers_are_not_a_split_release(tmp_path):
+    """No disc number is no evidence, and no evidence is not a merge."""
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "one", disc=None)
+    _disc_dir(parent, "two", disc=None)
+
+    assert _find(tmp_path) == []
+
+
+def test_different_releases_are_not_a_split_release(tmp_path):
+    parent = tmp_path / "Artist" / "Box"
+    _disc_dir(parent, "CD1", mbid=MBID, disc=1)
+    _disc_dir(parent, "CD2", mbid=OTHER_MBID, disc=2)
+
+    assert _find(tmp_path) == []
+
+
+def test_a_part_without_a_sidecar_is_not_a_split_release(tmp_path):
+    parent = tmp_path / "Artist" / "Box"
+    _disc_dir(parent, "CD1", disc=1)
+    _disc_dir(parent, "CD2", disc=2, sidecar=False)
+
+    assert _find(tmp_path) == []
+
+
+def test_a_lone_subdirectory_is_not_a_split_release(tmp_path):
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "CD1", disc=1)
+
+    assert _find(tmp_path) == []
+
+
+def test_audio_loose_in_the_parent_blocks_the_merge(tmp_path):
+    """A container directory that happens to hold two discs — absorbing the
+    loose file too would be a guess."""
+    parent = _split_album(tmp_path)
+    shutil.copy(SINE_M4A, parent / "bonus.m4a")
+
+    assert _find(tmp_path) == []
+
+
+def test_the_library_root_is_never_a_split_release(tmp_path):
+    _disc_dir(tmp_path, "CD1", disc=1)
+    _disc_dir(tmp_path, "CD2", disc=2)
+
+    assert _find(tmp_path) == []
+
+
+def test_an_already_grouped_parent_is_not_found_again(tmp_path):
+    parent = _split_album(tmp_path)
+    sidecar_mod.write(parent, Sidecar(mb_release_id=MBID))
+
+    assert _find(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Promotion
+# ---------------------------------------------------------------------------
+
+
+def test_promotion_writes_the_parent_sidecar_and_moves_no_files(tmp_path):
+    parent = _split_album(tmp_path)
+    before = sorted(p.relative_to(tmp_path) for p in tmp_path.rglob("*.m4a"))
+
+    reconcile.promote_split_release(_find(tmp_path)[0])
+
+    assert sidecar_mod.read(parent).mb_release_id == MBID
+    assert sorted(p.relative_to(tmp_path) for p in tmp_path.rglob("*.m4a")) == before
+
+
+def test_promotion_leaves_the_parts_own_sidecars_alone(tmp_path):
+    """Deleting them would be a destructive write on a derived rule. The user
+    removes them by hand if they want to."""
+    parent = _split_album(tmp_path)
+
+    reconcile.promote_split_release(_find(tmp_path)[0])
+
+    assert sidecar_mod.has_sidecar(parent / "CD1")
+    assert sidecar_mod.has_sidecar(parent / "CD2")
+
+
+def test_promoted_album_scans_as_one_complete_album(tmp_path):
+    parent = _split_album(tmp_path)
+
+    reconcile.promote_split_release(_find(tmp_path)[0])
+    albums = scan(tmp_path)
+
+    assert [a.path for a in albums] == [parent]
+    assert albums[0].track_count == 4
+    assert albums[0].state == AlbumState.COMPLETE
+
+
+def test_promotion_is_idempotent(tmp_path):
+    """Reconcile runs on startup and after every sync; a second pass must find
+    nothing and write nothing."""
+    parent = _split_album(tmp_path)
+    reconcile.promote_split_release(_find(tmp_path)[0])
+    written = sidecar_mod.sidecar_path(parent).read_text()
+
+    assert _find(tmp_path) == []
+    assert sidecar_mod.sidecar_path(parent).read_text() == written
+
+
+def test_promotion_inherits_the_widest_expected_track_count(tmp_path):
+    """Each part Harmonist tagged recorded the WHOLE release's count, so the
+    maximum is that count — never the sum."""
+    parent = tmp_path / "Artist" / "Album"
+    d1 = _disc_dir(parent, "CD1", disc=1, tracks=2)
+    d2 = _disc_dir(parent, "CD2", disc=2, tracks=2)
+    for d in (d1, d2):
+        _edit_sidecar(d, track_count_expected=4)
+
+    reconcile.promote_split_release(_find(tmp_path)[0])
+
+    assert sidecar_mod.read(parent).track_count_expected == 4
+
+
+def test_promotion_keeps_the_earliest_added_and_latest_tagged(tmp_path):
+    parent = tmp_path / "Artist" / "Album"
+    d1 = _disc_dir(parent, "CD1", disc=1)
+    d2 = _disc_dir(parent, "CD2", disc=2)
+    early, late = datetime(2020, 1, 1, tzinfo=UTC), datetime(2026, 6, 1, tzinfo=UTC)
+    for d, when in ((d1, early), (d2, late)):
+        _edit_sidecar(d, added_at=when, tagged_at=when)
+
+    reconcile.promote_split_release(_find(tmp_path)[0])
+
+    merged = sidecar_mod.read(parent)
+    assert merged.added_at == early
+    assert merged.tagged_at == late
+
+
+def test_promotion_carries_a_store_url_from_whichever_part_has_one(tmp_path):
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "CD1", disc=1)
+    d2 = _disc_dir(parent, "CD2", disc=2)
+    _edit_sidecar(d2, store_url="https://kaseytaylor.bandcamp.com/album/vapourized")
+
+    reconcile.promote_split_release(_find(tmp_path)[0])
+
+    assert sidecar_mod.read(parent).store_url == (
+        "https://kaseytaylor.bandcamp.com/album/vapourized"
+    )
+
+
+@pytest.mark.parametrize("part", ["CD1", "CD2"])
+def test_promotion_preserves_a_surrender(tmp_path, part):
+    """`purchase_unavailable` is permanent — losing it on one disc would put the
+    album back through surrender on the next full sync."""
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "CD1", disc=1)
+    _disc_dir(parent, "CD2", disc=2)
+    _edit_sidecar(parent / part, purchase_unavailable=True)
+
+    reconcile.promote_split_release(_find(tmp_path)[0])
+
+    assert sidecar_mod.read(parent).purchase_unavailable is True
+
+
+# ---------------------------------------------------------------------------
+# Tagging and undo across disc directories
+# ---------------------------------------------------------------------------
+
+
+def _two_disc_release() -> dict:
+    """A 2-disc, 4-track MB release — the shape a split album matches."""
+
+    def medium(pos: int, first: int) -> dict:
+        return {
+            "position": str(pos),
+            "format": "CD",
+            "track-list": [
+                {
+                    "id": f"rt-{n:03d}",
+                    "position": str(i),
+                    "title": f"Track {n}",
+                    "recording": {"id": f"rec-{n:03d}", "title": f"Track {n}"},
+                }
+                for i, n in enumerate((first, first + 1), start=1)
+            ],
+        }
+
+    return {
+        "id": MBID,
+        "title": "Vapourized Volume One",
+        "artist-credit": [
+            {"artist": {"id": "art-a", "name": "Kasey Taylor", "sort-name": "Taylor, Kasey"}}
+        ],
+        "release-group": {"id": "rg-a", "primary-type": "Album"},
+        "medium-list": [medium(1, 1), medium(2, 3)],
+    }
+
+
+def _grouped(tmp_path: Path) -> Path:
+    parent = _split_album(tmp_path)
+    reconcile.promote_split_release(_find(tmp_path)[0])
+    return parent
+
+
+def test_a_grouped_album_can_be_re_tagged(tmp_path):
+    """The album page's Re-tag button. Before #16 the tagger listed only the
+    parent's own files, found none, and raised."""
+    from harmonist import activity_store, tagger
+
+    activity_store.init(tmp_path / "audit.db")
+    parent = _grouped(tmp_path)
+
+    assert tagger.tag_album(parent, _two_disc_release()) == 4
+
+
+def test_re_tagging_a_grouped_album_numbers_the_discs_from_their_folders(tmp_path):
+    """Disc 2's files must take disc 2's tracks. This is the ordering the
+    natural sort exists for, checked end to end."""
+    from harmonist import activity_store, tagger
+    from harmonist.tagger import ATOM_DISC_NUM, ATOM_TITLE
+
+    activity_store.init(tmp_path / "audit.db")
+    parent = _grouped(tmp_path)
+
+    tagger.tag_album(parent, _two_disc_release())
+
+    disc2 = MP4(parent / "CD2" / "01 Track 1.m4a")
+    assert disc2[ATOM_DISC_NUM] == [(2, 2)]
+    assert disc2[ATOM_TITLE] == ["Track 3"]
+
+
+def test_records_name_a_grouped_albums_files_by_disc(tmp_path):
+    """Both discs have an "01 Track 1.m4a". A bare filename in the records would
+    not merely display wrong — it would restore one disc's tags onto the other."""
+    from harmonist import activity_store, tagger
+
+    activity_store.init(tmp_path / "audit.db")
+    parent = _grouped(tmp_path)
+
+    tagger.tag_album(parent, _two_disc_release())
+
+    assert {r.file for r in _records()} == {
+        "CD1/01 Track 1.m4a",
+        "CD1/02 Track 2.m4a",
+        "CD2/01 Track 1.m4a",
+        "CD2/02 Track 2.m4a",
+    }
+
+
+ESCAPES = ["../../secrets.m4a", "/etc/passwd", "CD1/../../../x.m4a", ".", "", "CD1/./../.."]
+
+
+@pytest.mark.parametrize("name", ESCAPES)
+def test_undo_refuses_a_record_naming_a_file_outside_the_album(tmp_path, name):
+    """Records are permanent and unversioned, so a malformed one turns up
+    eventually. Allowing a disc directory must not allow an escape from the
+    album."""
+    from harmonist import tag_history, tagger
+
+    parent = _grouped(tmp_path)
+
+    plan = [tag_history.FileRevert(file=name, fields={})]
+    with pytest.raises(tagger.RevertUnavailableError):
+        tagger.revert_tags(parent, plan)
+
+
+@pytest.mark.parametrize("name", ESCAPES)
+def test_artwork_restore_refuses_a_record_naming_a_file_outside_the_album(tmp_path, name):
+    """The same guard, on the other undo — it takes file names from the same
+    records, which now carry a disc directory."""
+    from harmonist import tagger
+
+    parent = _grouped(tmp_path)
+
+    with pytest.raises(tagger.ArtworkUnavailableError):
+        tagger.restore_artwork(parent, {name: "deadbeef"})
+
+
+def test_undo_accepts_a_name_naming_a_real_file_in_a_disc_dir(tmp_path):
+    """The guard must still let the legitimate case through — the shape it was
+    relaxed for."""
+    from harmonist import activity_store, tag_history, tagger
+
+    activity_store.init(tmp_path / "audit.db")
+    parent = _grouped(tmp_path)
+    tagger.tag_album(parent, _two_disc_release())
+
+    plan = [r for r in tag_history.revert_plan(_records()) if r.file == "CD2/02 Track 2.m4a"]
+
+    assert plan, "the disc-qualified record is what we mean to act on"
+    assert tagger.revert_tags(parent, plan).files == 1
+
+
+def test_undo_puts_back_each_discs_own_tags(tmp_path):
+    """End to end: the disc-qualified names in the records resolve back to the
+    right files, so an undo of a grouped album's tagging really does undo it."""
+    from harmonist import activity_store, formats, tag_history, tagger
+
+    activity_store.init(tmp_path / "audit.db")
+    parent = _grouped(tmp_path)
+    before = {
+        str(f.relative_to(parent)): formats.read_owned(f) for f in album_files.audio_files(parent)
+    }
+
+    tagger.tag_album(parent, _two_disc_release())
+    tagger.revert_tags(parent, tag_history.revert_plan(_records()))
+
+    after = {
+        str(f.relative_to(parent)): formats.read_owned(f) for f in album_files.audio_files(parent)
+    }
+    assert after == before
+
+
+def _records():
+    """Every stored tag-change record, in the order it was written."""
+    from harmonist import activity_store
+
+    conn = activity_store._ensure()
+    ids = [r[0] for r in conn.execute("SELECT event_id FROM tag_changes ORDER BY event_id")]
+    detail = activity_store.tag_changes_for(ids)
+    return [detail[i] for i in ids]
+
+
+# ---------------------------------------------------------------------------
+# Through the reconcile runner — how promotion actually reaches a library
+# ---------------------------------------------------------------------------
+
+
+def test_the_reconcile_pass_groups_split_releases(tmp_path):
+    """Reconcile is where this runs, and it must run even on a library with no
+    orphans in it: split releases are made of COMPLETE albums, so gating on the
+    orphan count would mean it only fired by coincidence."""
+    from harmonist import activity_store
+    from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+    activity_store.init(tmp_path / "audit.db")
+    parent = _split_album(tmp_path)
+
+    stats = reconcile_pending_orphans(tmp_path, fetch_urls=lambda mbid: [], rate_limit_seconds=0)
+
+    assert stats["total"] == 0, "no orphans — the early return path"
+    assert stats["grouped"] == 1
+    assert sidecar_mod.read(parent).mb_release_id == MBID
+    assert [a.path for a in scan(tmp_path)] == [parent]
+
+
+def test_a_second_reconcile_pass_groups_nothing(tmp_path):
+    from harmonist import activity_store
+    from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+    activity_store.init(tmp_path / "audit.db")
+    _split_album(tmp_path)
+
+    first = reconcile_pending_orphans(tmp_path, fetch_urls=lambda m: [], rate_limit_seconds=0)
+    second = reconcile_pending_orphans(tmp_path, fetch_urls=lambda m: [], rate_limit_seconds=0)
+
+    assert (first["grouped"], second["grouped"]) == (1, 0)
+
+
+def test_grouping_is_recorded_in_the_activity_feed(tmp_path):
+    from harmonist import activity, activity_store
+    from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+    activity_store.init(tmp_path / "audit.db")
+    activity.clear()
+    _split_album(tmp_path)
+
+    reconcile_pending_orphans(tmp_path, fetch_urls=lambda m: [], rate_limit_seconds=0)
+
+    messages = [e.message for e in activity_store.recent(50)]
+    assert any("Grouped 2 disc folder(s) into one album (4 tracks)" in m for m in messages)
+    assert any(m.startswith("album.group") and f"release={MBID}" in m for m in messages)
+
+
+def test_forgetting_a_grouped_album_is_not_undone_by_the_next_reconcile(tmp_path):
+    """Forget deletes the parent's sidecar — the UI way to un-group an album.
+    Re-grouping it on the next pass would make the button do nothing."""
+    from harmonist import activity_store
+    from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+    activity_store.init(tmp_path / "audit.db")
+    parent = _split_album(tmp_path)
+    reconcile_pending_orphans(tmp_path, fetch_urls=lambda m: [], rate_limit_seconds=0)
+    sidecar_mod.sidecar_path(parent).unlink()  # what Forget does
+
+    stats = reconcile_pending_orphans(
+        tmp_path, fetch_urls=lambda m: [], rate_limit_seconds=0, exempt_paths={parent}
+    )
+
+    assert stats["grouped"] == 0
+    assert not sidecar_mod.has_sidecar(parent)
+    assert {a.path.name for a in scan(tmp_path)} == {"CD1", "CD2"}

--- a/test/test_split_release.py
+++ b/test/test_split_release.py
@@ -34,8 +34,15 @@ def _disc_dir(
     disc: int | None = 1,
     tracks: int = 2,
     sidecar: bool = True,
+    track_ids: list[str] | None = None,
 ) -> Path:
-    """One disc's directory: `tracks` tagged files, plus its own sidecar."""
+    """One disc's directory: `tracks` tagged files, plus its own sidecar.
+
+    `track_ids` writes a `MusicBrainz Release Track Id` per file — what Picard
+    puts there, and the evidence detection prefers. Omitted by default so the
+    disc-number fallback is what most of these tests exercise; the tests that
+    mean to exercise the track-id path pass it explicitly.
+    """
     d = parent / name
     d.mkdir(parents=True)
     for i in range(1, tracks + 1):
@@ -48,6 +55,10 @@ def _disc_dir(
             audio["disk"] = [(disc, 2)]
         if mbid is not None:
             audio["----:com.apple.iTunes:MusicBrainz Album Id"] = [mbid.encode()]
+        if track_ids is not None and i <= len(track_ids):
+            audio["----:com.apple.iTunes:MusicBrainz Release Track Id"] = [
+                track_ids[i - 1].encode()
+            ]
         audio.save()
     if sidecar:
         sidecar_mod.write(
@@ -615,3 +626,83 @@ def test_forgetting_a_grouped_album_is_not_undone_by_the_next_reconcile(tmp_path
     assert stats["grouped"] == 0
     assert not sidecar_mod.has_sidecar(parent)
     assert {a.path.name for a in scan(tmp_path)} == {"CD1", "CD2"}
+
+
+# ---------------------------------------------------------------------------
+# Track identity — the evidence detection prefers over a disc number
+# ---------------------------------------------------------------------------
+
+DISC1_IDS = ["rt-001", "rt-002"]
+DISC2_IDS = ["rt-003", "rt-004"]
+
+
+def test_disjoint_track_ids_group_an_album_with_no_disc_numbers_at_all(tmp_path):
+    """The point of preferring track ids: correctly tagged files say which
+    tracks they hold, so the album groups even with no disc number anywhere."""
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "CD1", disc=None, track_ids=DISC1_IDS)
+    _disc_dir(parent, "CD2", disc=None, track_ids=DISC2_IDS)
+
+    found = _find(tmp_path)
+
+    assert len(found) == 1
+    assert [p.name for p in found[0].parts] == ["CD1", "CD2"]
+
+
+def test_identical_track_ids_are_a_duplicate_even_when_disc_numbers_differ(tmp_path):
+    """Track ids OVERRULE the disc number. Two copies of disc 1, one of them
+    mis-tagged as disc 2, still hold the same tracks — and grouping them would
+    fabricate a 2-disc album out of a duplicate."""
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "rip-a", disc=1, track_ids=DISC1_IDS)
+    _disc_dir(parent, "rip-b", disc=2, track_ids=DISC1_IDS)
+
+    assert _find(tmp_path) == []
+
+
+def test_one_shared_track_is_enough_to_refuse(tmp_path):
+    """Disjoint means disjoint — an overlap of one says these are not two
+    halves of anything."""
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "CD1", disc=1, track_ids=["rt-001", "rt-002"])
+    _disc_dir(parent, "CD2", disc=2, track_ids=["rt-002", "rt-003"])
+
+    assert _find(tmp_path) == []
+
+
+def test_track_ids_on_only_some_parts_is_not_evidence(tmp_path):
+    """Nothing to compare. Falling back to disc numbers here would answer with
+    the weaker evidence a question the better evidence was available for."""
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "CD1", disc=1, track_ids=DISC1_IDS)
+    _disc_dir(parent, "CD2", disc=2)
+
+    assert _find(tmp_path) == []
+
+
+def test_a_part_with_one_untagged_file_falls_back_rather_than_half_comparing(tmp_path):
+    """A partial set makes disjointness meaningless — two copies of one disc
+    with half the files untagged would compare as disjoint on the tagged half."""
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "rip-a", disc=1, tracks=2, track_ids=["rt-001"])  # 2nd file bare
+    _disc_dir(parent, "rip-b", disc=1, tracks=2, track_ids=["rt-002"])
+
+    assert _find(tmp_path) == [], "same disc number, so the fallback refuses too"
+
+
+def test_disc_numbers_still_group_a_release_with_no_track_ids(tmp_path):
+    """The pre-2011 rip. Weaker evidence, but exact, and refusing to ever group
+    these would be a needless limitation."""
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "CD1", disc=1)
+    _disc_dir(parent, "CD2", disc=2)
+
+    assert len(_find(tmp_path)) == 1
+
+
+def test_parts_with_neither_track_ids_nor_disc_numbers_are_left_alone(tmp_path):
+    parent = tmp_path / "Artist" / "Album"
+    _disc_dir(parent, "one", disc=None)
+    _disc_dir(parent, "two", disc=None)
+
+    assert _find(tmp_path) == []


### PR DESCRIPTION
A multi-disc release filed as `Album/CD1` + `Album/CD2` — the shape a decades-old adopted library is full of — showed up as one Library tile per disc, each with half a tracklist and each wrong about what it had.

## Grouping, not merging

A directory that declares itself an album with a sidecar, while holding no audio of its own, owns every audio file beneath it. **Nothing on disk moves**, so the layout Plex and Navidrome already index is untouched and there is no migration to write. Deleting the parent's sidecar — which is what **Forget** does — puts the parts back exactly as they were.

This is a deliberate departure from the shape sketched in #16, which worked through the merge as a file-moving operation with an alias row for the absorbed directory. All of that is correct *if files move*; they don't need to.

The rule is deliberately narrow. **A directory with audio of its own is an album, full stop**, even when it also has audio-bearing subdirectories — so no album that exists today can change shape. Harmonist has never written a sidecar into a directory containing no audio, which makes the grouped shape unreachable by accident.

## Detection

Runs in the reconcile pass and is an identity match, not a best fit. Every one of these must hold, and any that doesn't leaves the directories alone:

- the parent is not the library root, and is not an album itself;
- it has no sidecar yet (idempotence — one already there means it is grouped);
- at least two audio-bearing subdirectories, **all** accounted for;
- every part tagged to the **same** `mb_release_id`;
- the parts hold **different tracks** of that release.

That last one is what separates a split release from a duplicate, and it is the part that changed during review. Distinct disc numbers establish only that the parts *claim* to be different discs — a duplicate pair mis-tagged as disc 1 and disc 2 would have passed, fabricating a two-disc album out of two copies of one. **Release-track MBIDs** establish what the parts *contain*: disjoint sets mean different discs, identical sets mean a duplicate. So track ids are primary and overrule a disc number that disagrees; distinct disc numbers remain the fallback for a pre-2011 rip carrying no track ids at all. A mixture is refused, and a part with even one untagged file counts as having none.

**No MusicBrainz call.** The only checks that read tags or touch the filesystem are the last two, by which point a directory has already had to look exactly like a split release — and they run once, since the parent then has a sidecar.

## No alias row

Correcting the assumption in #16: an album's id *is* its `mb_release_id` once it has one, and detection only groups parts that already agree on the release. The id is unchanged by grouping, so the parts' history is already reachable and there is nothing to alias.

## Supporting changes

- **`album_files`** — one definition of "which files belong to this album", replacing the same `iterdir()` one-liner at ten call sites. Disc directories sort naturally, so a ten-disc box set doesn't tag CD10 as CD2.
- **Tagging records name a file by its path relative to the album.** Both discs have an `01 Track 1.m4a`, and a bare name in the records would not merely display wrong — it would restore one disc's tags onto the other's file.
- **The undo paths' path-traversal guard** is relaxed from "bare filename" to "a relative path that stays inside the album", checked per component *and* after resolution so a symlinked disc directory can't escape. Shared by both undos, tested against six escape strings.
- **Reconcile respects `exempt_paths`** for grouping, so Forget on a grouped album isn't undone by the next pass.

## Notes

The parts' own sidecars are left in place. Deleting them would be a destructive write to user data on the strength of a derived rule; the scanner never descends into a grouped album, so they cost only clutter.

This should land **before** #187 (the expected-track-count backfill). The backfill is what makes albums start deriving Incomplete; run it first and every half of every split release gets flagged incomplete correctly-but-uselessly.

56 new tests in `test/test_split_release.py`.

Fixes #16