### PR TITLE
Backfill the expected track count so adopted albums can derive INCOMPLETE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ versions follow [semantic versioning](https://semver.org).
   folders stay where they are, and deleting the sidecar Harmonist adds to the
   parent folder undoes it (#16).
 
+### Fixed
+
+- Albums adopted from an existing library can now be found with the Library's
+  **Incomplete** filter. They never could before: onboarding recorded no
+  expected track count, so an album with half its tracks read as complete.
+  Harmonist fills the gap in behind you on the next reconcile, and says which
+  albums turned out to be short (#187).
+
 ## [1.9.0] - 2026-08-19
 
 ### Added

--- a/docs/design.md
+++ b/docs/design.md
@@ -526,6 +526,25 @@ File: `<album_dir>/.harmonist.json`. UTF-8, two-space indent, written atomically
   (`file_count < track_count_expected`). There is no `incomplete` flag;
   state is the marker, and `track_count_expected` is what persists user
   intent across MB upstream changes.
+
+  **Absent means "not yet asked", not "complete"** — and the difference is
+  load-bearing. `reconcile_album` leaves it unset (one rate-limited MB call per
+  album would put the whole-library walk out of budget), and the external-re-tag
+  branch clears it, so albums keep arriving without one. While it is absent the
+  scanner has nothing to compare against and derives **Complete** however many
+  tracks are missing, which made the Library's Incomplete filter report zero for
+  an entire adopted library (#187).
+
+  So the reconcile pass **backfills it**: for every tagged album with no count,
+  one `media`-only lookup (`mb_lookup.fetch_release_track_count`, ~25x smaller
+  than a full release fetch) records the number. Bounded by the albums that lack
+  the field rather than by library size, and each success removes itself from
+  the candidate set permanently — a long first pass over an adopted library and
+  nothing at all thereafter. A failed lookup writes nothing and retries next
+  pass, because a wrong count mislabels the album permanently and is worse than
+  no count. It runs **after** split-release grouping (§13.5), which is
+  load-bearing: measuring each half of a split release against the whole
+  release's count would flag both halves incomplete, which is true of neither.
 - `purchase_unavailable` (optional, bool) is set when the user accepts a
   **surrendered** album via **Move to Library** — a full sync found no purchase
   and there is none to find (the Bandcamp release was withdrawn, or it was bought

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,7 +148,11 @@ Finished isn't the same as right, so the filter chips find the albums that are
 done but still wrong, each with its count:
 
 - **Incomplete** — fewer tracks on disk than the MusicBrainz release has. The tile
-  badges "N of M".
+  badges "N of M". Knowing this needs the release's track count, which albums
+  Harmonist tagged itself already have; for albums adopted from your existing
+  library it's filled in by the first reconcile after upgrading, one MusicBrainz
+  lookup each. Until that finishes, some incomplete albums won't be listed —
+  the Activity feed reports the pass, and names each album it finds short.
 - **Partially tagged** — some files carry the MusicBrainz Album Id and some don't.
   A half-finished tagging run, or Picard applied to part of a folder, leaves this.
 - **No artwork** — correctly tagged, fully linked, and still a grey square in

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -926,6 +926,15 @@ def fetch_release_urls(mbid: str) -> list[str]:
     return [url for url, m in URL_RELS.items() if m == mbid]
 
 
+def fetch_release_track_count(mbid: str) -> int:
+    """Demo counterpart of the media-only lookup the track-count backfill uses
+    (#187). Counted off the same seeded releases the rest of demo mode serves,
+    so a demo library backfills exactly as a real one does — and, crucially,
+    without a single request leaving the machine."""
+    release = fetch_release(mbid)
+    return sum(len(m.get("track-list", [])) for m in release.get("medium-list", []))
+
+
 def lookup_by_bandcamp_url(bandcamp_url: str) -> list[str]:
     mbid = URL_RELS.get(bandcamp_url)
     return [mbid] if mbid else []
@@ -1003,6 +1012,7 @@ def install() -> None:
 
     mb_lookup.fetch_release = fetch_release
     mb_lookup.fetch_release_urls = fetch_release_urls
+    mb_lookup.fetch_release_track_count = fetch_release_track_count
     mb_lookup.lookup_by_bandcamp_url = lookup_by_bandcamp_url
     mb_lookup.browse_release_group_releases = browse_release_group_releases
     mb_search.search_releases = search_releases

--- a/src/harmonist/mb_lookup.py
+++ b/src/harmonist/mb_lookup.py
@@ -109,6 +109,44 @@ def fetch_release(mbid: str) -> Release:
     return release
 
 
+def fetch_release_track_count(mbid: str) -> int:
+    """Return how many tracks the MB release has, across every medium.
+
+    Much lighter than `fetch_release` — asks for `media` alone, which comes back
+    as a per-medium `track-count` with no track data at all. Measured on a
+    2-disc release: 719 bytes against 17,835 for the full fetch. That ratio is
+    the whole point, because the caller is the expected-track-count backfill
+    (#187), which runs this once for EVERY adopted album in the library; pulling
+    the full release for a number MusicBrainz will state directly would move
+    tens of megabytes to learn nothing more.
+
+    Still one rate-limited request like any other — lighter, not free.
+    """
+    try:
+        result = musicbrainzngs.get_release_by_id(mbid, includes=["media"])
+    except (
+        musicbrainzngs.NetworkError,
+        musicbrainzngs.ResponseError,
+        musicbrainzngs.AuthenticationError,
+    ) as e:
+        raise MBError(f"MB request failed: {e}") from e
+
+    media = result["release"].get("medium-list") or []
+    total = 0
+    for medium in media:
+        try:
+            total += int(medium.get("track-count", 0))
+        except (TypeError, ValueError):
+            # A medium whose count won't parse makes the TOTAL wrong, and a
+            # wrong total is worse than no total: it is what COMPLETE vs
+            # INCOMPLETE is derived from, so it would mislabel the album
+            # permanently. Refuse the whole answer rather than return a partial.
+            raise MBError(f"release {mbid} has an unreadable track count") from None
+    if not total:
+        raise MBError(f"release {mbid} reports no tracks")
+    return total
+
+
 def fetch_release_urls(mbid: str) -> list[str]:
     """Return the list of URL relationships attached to an MB release.
 

--- a/src/harmonist/reconcile.py
+++ b/src/harmonist/reconcile.py
@@ -505,3 +505,50 @@ def _latest(values: Iterable[datetime | None]) -> datetime | None:
 def _max(values: Iterable[int | None]) -> int | None:
     present = [v for v in values if v is not None]
     return max(present) if present else None
+
+
+# ---------------------------------------------------------------------------
+# Expected track counts: what COMPLETE vs INCOMPLETE is derived from (#187)
+# ---------------------------------------------------------------------------
+
+
+def needs_track_count(album: Album) -> bool:
+    """True when this album is tagged but has no `track_count_expected`, so the
+    scanner has nothing to compare its file count against.
+
+    Every album adopted at onboarding is in this position. `reconcile_album`
+    derives a sidecar from the file tags and deliberately leaves the count
+    unset — filling it in there would mean one rate-limited MB call per album
+    during the walk, the ~16-minutes-for-960-albums cost that path exists to
+    avoid. Nothing filled it in later, so INCOMPLETE could never be derived for
+    an adopted library and the Library's Incomplete filter reported zero for a
+    shelf full of half-albums.
+
+    The external-re-tag branch above clears the field for the same reason, so
+    this is not a one-off migration: albums keep arriving in this state.
+    """
+    sc = album.sidecar
+    return sc is not None and sc.mb_release_id is not None and sc.track_count_expected is None
+
+
+def backfill_track_count(
+    album_dir: Path,
+    *,
+    fetch_count: Callable[[str], int],
+) -> int | None:
+    """Record the MB release's track count on an already-tagged album's sidecar.
+
+    Returns the count written, or None when there was nothing to do. Raises
+    whatever `fetch_count` raises — a failed lookup must not be recorded as a
+    successful one, and the caller decides whether to retry.
+
+    Re-reads the sidecar rather than trusting the caller's snapshot: the scan
+    that produced it may be minutes old on a large library, and a tag or a sync
+    in between would make this write clobber a newer one.
+    """
+    sc = sidecar_mod.read(album_dir)
+    if sc is None or sc.mb_release_id is None or sc.track_count_expected is not None:
+        return None  # already answered, or no longer an album this applies to
+    count = fetch_count(sc.mb_release_id)
+    sidecar_mod.write(album_dir, replace(sc, track_count_expected=count))
+    return count

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -482,6 +482,7 @@ def create_app(
         reconcile_pending_orphans(
             cfg.paths.music_dir,
             fetch_urls=mb_lookup.fetch_release_urls,
+            fetch_track_count=mb_lookup.fetch_release_track_count,
             status_updater=status_updater,
             exempt_paths=forgotten_paths,
             albums=snapshot,

--- a/src/harmonist/web/reconcile_runner.py
+++ b/src/harmonist/web/reconcile_runner.py
@@ -181,6 +181,7 @@ def reconcile_pending_orphans(
     music_dir: Path,
     *,
     fetch_urls: Callable[[str], list[str]],
+    fetch_track_count: Callable[[str], int] | None = None,
     recover_url: Callable[[Path], str | None] | None = None,
     status_updater: Callable[..., None] | None = None,
     rate_limit_seconds: float = MB_RATE_LIMIT_SECONDS,
@@ -194,6 +195,13 @@ def reconcile_pending_orphans(
     scanner just finished, so a second full scan is pure wasted minutes (and a
     second copy of the snapshot in memory). Only falls back to scanning when no
     snapshot is supplied (e.g. direct callers / tests).
+
+    `fetch_track_count` is injected, and omitting it SKIPS the track-count
+    backfill rather than falling back to the real lookup. Defaulting it to
+    `mb_lookup.fetch_release_track_count` reads as a convenience and behaves as
+    a trap: every test that reconciles anything would start talking to
+    MusicBrainz at one request per second, having asked for no such thing. The
+    one caller that wants the network says so.
 
     Albums whose path is in `exempt_paths` are skipped. This is the
     mechanism that respects user intent after a Forget — without it, the
@@ -265,6 +273,17 @@ def reconcile_pending_orphans(
     # ran on a library that also happened to have something new in it.
     grouped = _promote_split_releases(albums, music_dir, exempt)
 
+    # Expected track counts (#187), also before the early return: the albums
+    # missing one are adopted COMPLETE albums, not orphans. AFTER the grouping
+    # above, and that order is load-bearing — backfilling first would measure
+    # each half of a split release against the whole release's track count and
+    # flag both halves incomplete, which is true of neither.
+    counted, newly_incomplete = (
+        _backfill_track_counts(albums, exempt, fetch_track_count)
+        if fetch_track_count is not None
+        else (0, 0)
+    )
+
     if not total:
         # Nothing to do. Reconcile runs on startup and after every sync, so
         # announcing a no-op made it the feed's most frequent content — three
@@ -278,6 +297,8 @@ def reconcile_pending_orphans(
             "recovered_url": 0,
             "adopted": 0,
             "grouped": grouped,
+            "counted": counted,
+            "newly_incomplete": newly_incomplete,
             "skipped": 0,
             "errors": 0,
         }
@@ -374,6 +395,8 @@ def reconcile_pending_orphans(
         "recovered_url": recovered_url,
         "adopted": adopted,
         "grouped": grouped,
+        "counted": counted,
+        "newly_incomplete": newly_incomplete,
         "skipped": skipped,
         "errors": errors,
     }
@@ -425,3 +448,73 @@ def _promote_split_releases(albums: list[Album], music_dir: Path, exempt: set[Pa
                 album_label=split.parent.name,
             )
     return grouped
+
+
+def _backfill_track_counts(
+    albums: list[Album],
+    exempt: set[Path],
+    fetch_count: Callable[[str], int],
+) -> tuple[int, int]:
+    """Record the MB track count on every tagged album that has none, so the
+    scanner can finally derive INCOMPLETE for it. Returns
+    `(counted, newly_incomplete)`.
+
+    One MusicBrainz request per album, which is a lot of requests — but bounded
+    by the albums that lack the field, not by library size, and each one that
+    succeeds removes itself from the candidate set permanently. So this is a
+    long first pass over an adopted library and nothing at all thereafter. It
+    reaches for the `media`-only lookup rather than the full release, which is
+    ~25x smaller for the one number it needs.
+
+    A failed lookup leaves the album alone and retries next pass. That is the
+    right default for the overwhelmingly likely cause — the network, or MB
+    being briefly unavailable — and the cost of being wrong is one repeated
+    request per pass for a release MusicBrainz genuinely can't answer for.
+
+    **No per-album activity entry for the ordinary case.** Reconcile runs on
+    startup and after every sync, and several hundred "recorded a track count"
+    lines is the flood the skip case is already careful to avoid; the sidecar
+    write audits itself (`track_count_expected` is load-bearing), so the detail
+    is on each album's own history page. An album that turns out to be
+    INCOMPLETE does get its own entry — that is a defect the user has been
+    unable to see until now, and it is the whole reason for the pass.
+    """
+    from harmonist import reconcile
+    from harmonist.models import AlbumState
+
+    pending = [a for a in albums if reconcile.needs_track_count(a) and a.path not in exempt]
+    if not pending:
+        log.debug("Track counts: nothing to backfill")
+        return (0, 0)
+
+    activity.record(f"Checking MusicBrainz for expected track counts — {len(pending)} album(s)")
+    counted = 0
+    newly_incomplete = 0
+    for album in pending:
+        with activity_store.action():
+            try:
+                count = reconcile.backfill_track_count(album.path, fetch_count=fetch_count)
+            except Exception as e:
+                # Warning, not exception: on a library-wide pass a stack trace
+                # per unreachable album buries the run. The summary reports how
+                # many were left, and the next pass retries them.
+                log.warning("could not fetch the track count for %s: %s", album.path, e)
+                continue
+            if count is None:
+                continue
+            counted += 1
+            if album.track_count < count:
+                newly_incomplete += 1
+                # COMPLETE until this instant only because nothing had ever
+                # asked; keep the Library's counts honest between scans.
+                live_counts.move(AlbumState.COMPLETE, AlbumState.INCOMPLETE)
+                activity.record(
+                    f"Missing {count - album.track_count} of {count} tracks",
+                    album_id=sidecar.album_id_for(album.path),
+                    album_label=f"{album.artist} — {album.title}".strip(" —"),
+                )
+    activity.record(
+        f"Track counts recorded for {counted} album(s)"
+        + (f" — {newly_incomplete} turned out to be incomplete" if newly_incomplete else "")
+    )
+    return (counted, newly_incomplete)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,6 +19,7 @@ SINE_M4A = FIXTURES_DIR / "sine.m4a"
 _PRISTINE_GLOBALS = {
     (mb_lookup, "fetch_release"): mb_lookup.fetch_release,
     (mb_lookup, "fetch_release_urls"): mb_lookup.fetch_release_urls,
+    (mb_lookup, "fetch_release_track_count"): mb_lookup.fetch_release_track_count,
     (mb_lookup, "lookup_by_bandcamp_url"): mb_lookup.lookup_by_bandcamp_url,
     (mb_search, "search_releases"): mb_search.search_releases,
     (cover_art, "ensure_cover"): cover_art.ensure_cover,

--- a/test/test_demo.py
+++ b/test/test_demo.py
@@ -498,3 +498,39 @@ def test_demo_mode_off_no_demo_routes(tmp_path):
     # No banner
     home = client.get("/")
     assert "Demo Mode" not in home.text
+
+
+def test_demo_mode_patches_every_musicbrainz_entry_point():
+    """Demo mode's whole promise is that no request leaves the machine. A new
+    lookup added to `mb_lookup` and not patched here breaks that silently — the
+    demo goes on working, just slowly and against the real MusicBrainz, which
+    is how #187's `fetch_release_track_count` shipped un-patched for an hour.
+
+    Enumerated rather than listed, so the next one is caught by this test
+    instead of by someone noticing the test suite got slower.
+    """
+    import inspect
+
+    from harmonist import mb_lookup
+
+    network = {
+        name
+        for name, fn in inspect.getmembers(mb_lookup, inspect.isfunction)
+        if (name.startswith(("fetch_", "lookup_", "browse_", "search_")))
+        and fn.__module__ == mb_lookup.__name__
+    }
+    assert network, "the detector itself must not silently match nothing"
+
+    demo.install()
+
+    unpatched = {n for n in network if getattr(mb_lookup, n).__module__ == mb_lookup.__name__}
+    assert not unpatched, f"demo mode leaves these talking to the real MusicBrainz: {unpatched}"
+
+
+def test_demo_track_count_matches_the_seeded_release():
+    from harmonist import demo as demo_mod
+
+    mbid, release = next(iter(demo_mod.MB_RELEASES.items()))
+    expected = sum(len(m.get("track-list", [])) for m in release.get("medium-list", []))
+
+    assert demo_mod.fetch_release_track_count(mbid) == expected

--- a/test/test_track_count_backfill.py
+++ b/test/test_track_count_backfill.py
@@ -1,0 +1,301 @@
+"""Backfilling `track_count_expected` on adopted albums (#187).
+
+Onboarding derives a sidecar from the file tags and deliberately leaves the
+expected track count unset — filling it in there costs one rate-limited MB call
+per album. Nothing filled it in later, so INCOMPLETE could never be derived for
+an adopted library and the Library's Incomplete filter reported zero for a shelf
+full of half-albums.
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from mutagen.mp4 import MP4
+
+from harmonist import reconcile
+from harmonist import sidecar as sidecar_mod
+from harmonist.models import AlbumState, Sidecar
+from harmonist.scanner import scan
+from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+SINE_M4A = FIXTURES_DIR / "sine.m4a"
+
+MBID = "3da95637-a647-42d6-a1e7-81a20c9dbfd4"
+
+
+@pytest.fixture
+def audit_db(tmp_path):
+    """The reconcile pass opens action scopes and records activity, so the
+    store has to exist for it. Per-test file, so runs can't see each other."""
+    from harmonist import activity, activity_store
+
+    activity_store.init(tmp_path / "audit.db")
+    activity.clear()
+    yield
+
+
+def _adopted_album(root: Path, name: str = "Album", *, tracks: int = 2, mbid: str = MBID) -> Path:
+    """An album as ONBOARDING leaves it: tagged files, a sidecar naming the
+    release, and no `track_count_expected` — exactly `reconcile_album`'s output.
+    """
+    d = root / "Artist" / name
+    d.mkdir(parents=True)
+    for i in range(1, tracks + 1):
+        f = d / f"{i:02d} Track {i}.m4a"
+        shutil.copy(SINE_M4A, f)
+        audio = MP4(f)
+        audio["\xa9alb"] = [name]
+        audio["\xa9ART"] = ["Artist"]
+        audio["----:com.apple.iTunes:MusicBrainz Album Id"] = [mbid.encode()]
+        audio.save()
+    sidecar_mod.write(
+        d,
+        Sidecar(
+            mb_release_id=mbid,
+            added_at=datetime(2026, 1, 1, tzinfo=UTC),
+            tagged_at=datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+    )
+    return d
+
+
+def _counter(count: int):
+    """A stub lookup that records how many times it was asked."""
+    calls: list[str] = []
+
+    def fetch(mbid: str) -> int:
+        calls.append(mbid)
+        return count
+
+    fetch.calls = calls
+    return fetch
+
+
+# ---------------------------------------------------------------------------
+# The gap itself
+# ---------------------------------------------------------------------------
+
+
+def test_an_adopted_album_starts_with_no_expected_track_count(tmp_path):
+    """The defect, stated as a test: half an album reads as COMPLETE."""
+    _adopted_album(tmp_path, tracks=2)
+
+    album = scan(tmp_path)[0]
+
+    assert album.sidecar.track_count_expected is None
+    assert album.state == AlbumState.COMPLETE, "nothing to compare 2 files against"
+    assert reconcile.needs_track_count(album)
+
+
+def test_a_tagged_album_that_already_has_a_count_is_not_a_candidate(tmp_path):
+    d = _adopted_album(tmp_path)
+    sc = sidecar_mod.read(d)
+    sidecar_mod.write(d, Sidecar(**{**sc.__dict__, "track_count_expected": 2}))
+
+    assert not reconcile.needs_track_count(scan(tmp_path)[0])
+
+
+def test_an_untagged_album_is_not_a_candidate(tmp_path):
+    """No release to ask MusicBrainz about."""
+    d = tmp_path / "Artist" / "Album"
+    d.mkdir(parents=True)
+    shutil.copy(SINE_M4A, d / "01 Track.m4a")
+
+    assert not reconcile.needs_track_count(scan(tmp_path)[0])
+
+
+# ---------------------------------------------------------------------------
+# The backfill
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_records_the_releases_track_count(tmp_path):
+    d = _adopted_album(tmp_path, tracks=2)
+
+    assert reconcile.backfill_track_count(d, fetch_count=lambda m: 21) == 21
+    assert sidecar_mod.read(d).track_count_expected == 21
+
+
+def test_a_backfilled_album_derives_incomplete(tmp_path):
+    """The point of the whole exercise: the Library can finally see it."""
+    d = _adopted_album(tmp_path, tracks=11)
+    reconcile.backfill_track_count(d, fetch_count=lambda m: 21)
+
+    album = scan(tmp_path)[0]
+
+    assert album.state == AlbumState.INCOMPLETE
+    assert (album.track_count, album.sidecar.track_count_expected) == (11, 21)
+
+
+def test_a_genuinely_complete_album_stays_complete(tmp_path):
+    d = _adopted_album(tmp_path, tracks=2)
+    reconcile.backfill_track_count(d, fetch_count=lambda m: 2)
+
+    assert scan(tmp_path)[0].state == AlbumState.COMPLETE
+
+
+def test_backfill_keeps_the_rest_of_the_sidecar(tmp_path):
+    """It records one number; it must not quietly rewrite an album's identity,
+    store link or history."""
+    d = _adopted_album(tmp_path)
+    before = sidecar_mod.read(d)
+
+    reconcile.backfill_track_count(d, fetch_count=lambda m: 9)
+
+    after = sidecar_mod.read(d)
+    assert after.track_count_expected == 9
+    for field in ("mb_release_id", "store_url", "added_at", "tagged_at", "bandcamp"):
+        assert getattr(after, field) == getattr(before, field), field
+
+
+def test_backfill_is_a_no_op_second_time(tmp_path):
+    d = _adopted_album(tmp_path)
+    fetch = _counter(21)
+
+    first = reconcile.backfill_track_count(d, fetch_count=fetch)
+    second = reconcile.backfill_track_count(d, fetch_count=fetch)
+
+    assert (first, second) == (21, None)
+    assert len(fetch.calls) == 1, "the second pass must not re-ask MusicBrainz"
+
+
+def test_backfill_re_reads_the_sidecar_rather_than_trusting_a_stale_snapshot(tmp_path):
+    """A scan is minutes old on a large library. If a tag landed in between,
+    this write must not clobber the newer sidecar."""
+    d = _adopted_album(tmp_path)
+    sidecar_mod.write(d, Sidecar(mb_release_id="other-mbid", track_count_expected=5))
+
+    assert reconcile.backfill_track_count(d, fetch_count=lambda m: 21) is None
+    assert sidecar_mod.read(d).track_count_expected == 5
+
+
+def test_a_failed_lookup_writes_nothing(tmp_path):
+    """A failed lookup must not be recorded as a successful one — a wrong count
+    mislabels the album permanently."""
+    from harmonist.mb_lookup import MBError
+
+    d = _adopted_album(tmp_path)
+
+    def boom(mbid: str) -> int:
+        raise MBError("MB is down")
+
+    with pytest.raises(MBError):
+        reconcile.backfill_track_count(d, fetch_count=boom)
+    assert sidecar_mod.read(d).track_count_expected is None
+
+
+# ---------------------------------------------------------------------------
+# Through the reconcile pass
+# ---------------------------------------------------------------------------
+
+
+def _run(tmp_path, fetch_count, **kw):
+    return reconcile_pending_orphans(
+        tmp_path,
+        fetch_urls=lambda m: [],
+        fetch_track_count=fetch_count,
+        rate_limit_seconds=0,
+        **kw,
+    )
+
+
+def test_the_reconcile_pass_backfills_every_adopted_album(tmp_path, audit_db):
+    _adopted_album(tmp_path, "One", tracks=11)
+    _adopted_album(tmp_path, "Two", tracks=2)
+
+    stats = _run(tmp_path, lambda m: 21)
+
+    assert stats["total"] == 0, "no orphans — this runs on the early-return path"
+    assert stats["counted"] == 2
+    assert stats["newly_incomplete"] == 2
+    assert {a.state for a in scan(tmp_path)} == {AlbumState.INCOMPLETE}
+
+
+def test_the_pass_counts_only_the_albums_that_are_short(tmp_path, audit_db):
+    _adopted_album(tmp_path, "Short", tracks=1)
+    _adopted_album(tmp_path, "Whole", tracks=3)
+
+    stats = _run(tmp_path, lambda m: 3)
+
+    assert (stats["counted"], stats["newly_incomplete"]) == (2, 1)
+
+
+def test_a_second_pass_asks_musicbrainz_nothing(tmp_path, audit_db):
+    """Bounded by the albums lacking the field, and each success removes itself
+    from the candidate set — so this is a long first pass and nothing after."""
+    _adopted_album(tmp_path, tracks=2)
+    fetch = _counter(21)
+
+    _run(tmp_path, fetch)
+    second = _run(tmp_path, fetch)
+
+    assert len(fetch.calls) == 1
+    assert second["counted"] == 0
+
+
+def test_omitting_the_lookup_skips_the_backfill_entirely(tmp_path, audit_db):
+    """`None` means skip, never "fall back to the real MusicBrainz" — the trap
+    that had the test suite quietly making live requests."""
+    d = _adopted_album(tmp_path)
+
+    stats = reconcile_pending_orphans(tmp_path, fetch_urls=lambda m: [], rate_limit_seconds=0)
+
+    assert stats["counted"] == 0
+    assert sidecar_mod.read(d).track_count_expected is None
+
+
+def test_a_failed_lookup_leaves_the_album_for_the_next_pass(tmp_path, audit_db):
+    d = _adopted_album(tmp_path)
+    attempts = []
+
+    def flaky(mbid: str) -> int:
+        attempts.append(mbid)
+        if len(attempts) == 1:
+            raise RuntimeError("network")
+        return 21
+
+    assert _run(tmp_path, flaky)["counted"] == 0
+    assert sidecar_mod.read(d).track_count_expected is None
+
+    assert _run(tmp_path, flaky)["counted"] == 1
+    assert sidecar_mod.read(d).track_count_expected == 21
+
+
+def test_a_forgotten_album_is_not_backfilled(tmp_path, audit_db):
+    d = _adopted_album(tmp_path)
+
+    stats = _run(tmp_path, lambda m: 21, exempt_paths={d})
+
+    assert stats["counted"] == 0
+    assert sidecar_mod.read(d).track_count_expected is None
+
+
+def test_the_pass_announces_itself_and_names_the_incomplete_albums(tmp_path, audit_db):
+    from harmonist import activity_store
+
+    _adopted_album(tmp_path, "Short", tracks=11)
+
+    _run(tmp_path, lambda m: 21)
+
+    messages = [e.message for e in activity_store.recent(50)]
+    assert any("expected track counts — 1 album(s)" in m for m in messages)
+    assert any("Missing 10 of 21 tracks" in m for m in messages)
+    assert any("1 turned out to be incomplete" in m for m in messages)
+
+
+def test_the_count_is_audited_on_the_albums_own_history(tmp_path, audit_db):
+    """The sidecar write audits itself — `track_count_expected` is load-bearing,
+    so a change to it reclassifies the album and has to be reconstructable."""
+    from harmonist import activity_store
+
+    _adopted_album(tmp_path, tracks=11)
+
+    _run(tmp_path, lambda m: 21)
+
+    messages = [e.message for e in activity_store.recent(50)]
+    assert any("sidecar.update" in m and "track_count_expected=None->21" in m for m in messages)


### PR DESCRIPTION
`INCOMPLETE` is derived from one sidecar field, `track_count_expected`, and until now only `_tag_with_release` ever wrote it — i.e. only albums Harmonist tagged itself.

Albums adopted at onboarding go through `reconcile_album`, which leaves it unset because filling it in there costs one rate-limited MB call per album during the walk (the ~16-minutes-for-960-albums cost that path exists to avoid). Nothing filled it in later, so the scanner had nothing to compare a file count against and derived `COMPLETE` however many tracks were missing.

The result: the Library's **Incomplete** filter reported `0` for an entire adopted library, while an album's own page listed ten missing tracks one click away. The album page knows because it does a per-album MB fetch through `compare.py`; the Library grid can't, by #140's no-MB-on-the-request-path constraint.

## The backfill

The reconcile pass now records the count for every tagged album that lacks one.

- **Bounded by the albums that lack the field**, not by library size, and each success removes itself from the candidate set permanently — a long first pass over an adopted library and nothing at all after.
- **A failed lookup writes nothing** and retries next pass. A wrong count mislabels the album permanently, which is worse than no count.
- **Runs after split-release grouping (#16)**, and that order is load-bearing: measuring each half of a split release against the whole release's count would flag both halves incomplete, which is true of neither.

`mb_lookup.fetch_release_track_count` asks for `media` alone, which MusicBrainz answers with a per-medium `track-count` and no track data — measured at **719 bytes against 17,835** for a full fetch of the same 2-disc release. Over a whole library that's ~700KB rather than ~17MB to learn a number MB states directly.

**Activity:** no per-album entry for the ordinary case — several hundred lines is the flood the skip case already avoids, and the sidecar write audits itself (`track_count_expected` is load-bearing, so `_audit_write` records `None->21`). An album that turns out to be `INCOMPLETE` does get its own entry, since that's a defect the user has been unable to see until now.

## Two things this shook out

- **`fetch_track_count` is injected, and omitting it skips the backfill** rather than defaulting to the real lookup. The default read as a convenience and behaved as a trap: every test that reconciled anything started talking to MusicBrainz at 1 req/sec, taking the suite from 28s to 114s.
- **Demo mode did not patch the new lookup**, so a demo library would have backfilled against the real MusicBrainz — precisely what demo mode exists to prevent. Patched, and `test_demo_mode_patches_every_musicbrainz_entry_point` now *enumerates* `mb_lookup` rather than listing names, so the next one is caught by a test instead of by someone noticing the suite got slower.

## Note for review

The first pass is bounded by library size rather than by a constant, which is the one place this brushes against the MB call budget (§6). It's one-time, self-terminating, paced by the shared rate limiter, announced in the feed, and the same shape as the onboarding reconcile that already walks the library — but it is automatic rather than user-initiated, and that's the reviewable decision. Making it a Settings button instead is a one-line change at the single call site in `web/main.py`.

20 new tests across `test/test_track_count_backfill.py` and `test/test_demo.py`.

Fixes #187