### PR TITLE
Name the album, not the folder, when grouping a split release

### DIFF
--- a/src/harmonist/reconcile.py
+++ b/src/harmonist/reconcile.py
@@ -258,11 +258,29 @@ class SplitRelease:
     `parent` is the directory that should own the album; `parts` are the
     per-disc directories beneath it, in disc order. Detection only — promoting
     it is a separate, audited step.
+
+    `artist` and `title` come from the parts' TAGS, not from any directory name.
+    The grouping parent is often a container the user named for something else —
+    the LOTR trilogy's discs sit directly under `Howard Shore/`, so the entry
+    announcing it read "Howard Shore · Grouped 3 disc folder(s)" for an album
+    actually called *The Lord of the Rings Trilogy: The Motion Picture Trilogy
+    Soundtrack* (#191). Every other entry in the feed names an album from its
+    tags; this one had only a path to hand.
     """
 
     parent: Path
     mb_release_id: str
     parts: tuple[Path, ...]
+    artist: str = ""
+    title: str = ""
+
+    @property
+    def label(self) -> str:
+        """ "Artist — Title" for the feed, falling back to the parent's directory
+        name when the tags carry neither (an album with no album title at all —
+        the scanner already falls back to the directory name for that case)."""
+        joined = f"{self.artist} — {self.title}".strip(" —")
+        return joined or self.parent.name
 
     @property
     def track_count(self) -> int:
@@ -332,6 +350,10 @@ def find_split_releases(albums: list[Album], music_dir: Path) -> list[SplitRelea
                 parent=parent,
                 mb_release_id=mbid,
                 parts=tuple(a.path for a in ordered),
+                # From the scan's own reading of the tags — `build_album` has
+                # already resolved album-artist vs per-track artist for these.
+                artist=ordered[0].artist,
+                title=ordered[0].title,
             )
         )
     return found

--- a/src/harmonist/web/reconcile_runner.py
+++ b/src/harmonist/web/reconcile_runner.py
@@ -414,7 +414,7 @@ def _promote_split_releases(albums: list[Album], music_dir: Path, exempt: set[Pa
             except Exception:
                 log.exception("could not group the split release at %s", split.parent)
                 activity.warning(
-                    f"Could not group the discs under {split.parent.name} — left as separate albums"
+                    f"Could not group the discs of {split.label} — left as separate albums"
                 )
                 continue
             grouped += 1
@@ -422,6 +422,6 @@ def _promote_split_releases(albums: list[Album], music_dir: Path, exempt: set[Pa
                 f"Grouped {len(split.parts)} disc folder(s) into one album "
                 f"({split.track_count} tracks)",
                 album_id=split.mb_release_id,
-                album_label=split.parent.name,
+                album_label=split.label,
             )
     return grouped

--- a/test/test_split_release.py
+++ b/test/test_split_release.py
@@ -601,6 +601,50 @@ def test_a_second_reconcile_pass_groups_nothing(tmp_path):
     assert (first["grouped"], second["grouped"]) == (1, 0)
 
 
+def test_the_grouping_entry_names_the_album_not_the_folder(tmp_path):
+    """The LOTR case (#191): the parent is often a container named for something
+    else — an artist directory — so the feed must read the title off the tags,
+    as every other entry does."""
+    from harmonist import activity, activity_store
+    from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+    activity_store.init(tmp_path / "audit.db")
+    activity.clear()
+    # Discs filed straight under the artist, which is what makes the parent's
+    # directory name the wrong label.
+    parent = tmp_path / "Kasey Taylor"
+    _disc_dir(parent, "CD1", disc=1)
+    _disc_dir(parent, "CD2", disc=2)
+
+    reconcile_pending_orphans(tmp_path, fetch_urls=lambda m: [], rate_limit_seconds=0)
+
+    labels = [e.album_label for e in activity_store.recent(50) if e.album_label]
+    assert "Kasey Taylor — Vapourized Volume One" in labels
+    assert "Kasey Taylor" not in labels, "the bare directory name is the bug"
+
+
+def test_the_grouping_label_falls_back_to_the_folder_when_untagged(tmp_path):
+    """No album title in the tags at all — the scanner already falls back to the
+    directory name there, and this must not produce a blank label."""
+    parent = tmp_path / "Artist" / "Mystery"
+    for name, disc in (("CD1", 1), ("CD2", 2)):
+        d = parent / name
+        d.mkdir(parents=True)
+        for i in (1, 2):
+            f = d / f"{i:02d} Track {i}.m4a"
+            shutil.copy(SINE_M4A, f)
+            audio = MP4(f)
+            audio["disk"] = [(disc, 2)]
+            audio["----:com.apple.iTunes:MusicBrainz Album Id"] = [MBID.encode()]
+            audio.save()
+        sidecar_mod.write(d, Sidecar(mb_release_id=MBID, tagged_at=datetime.now(UTC)))
+
+    found = _find(tmp_path)
+
+    assert len(found) == 1
+    assert found[0].label, "never blank"
+
+
 def test_grouping_is_recorded_in_the_activity_feed(tmp_path):
     from harmonist import activity, activity_store
     from harmonist.web.reconcile_runner import reconcile_pending_orphans


### PR DESCRIPTION
The entry announcing a grouped release read:

```
Howard Shore · Grouped 3 disc folder(s) into one album (56 tracks)
```

for an album called *The Lord of the Rings Trilogy: The Motion Picture Trilogy Soundtrack*. `Howard Shore` is the **artist directory**, which is where the user had filed the three discs — and grouping is entitled to choose such a parent, since an artist directory holding exactly one release's discs is indistinguishable on disk from an album directory with disc subfolders.

`SplitRelease` carried paths only, so the parent's directory name was the sole label available. It now carries the artist and title the scan has already read from the parts' tags, which is how every other entry in the feed names an album. The later per-album entries for the same release always got it right, precisely because they came from a scanned `Album` rather than from a path.

Falls back to the directory name when the tags carry no album title at all — the same fallback `build_album` makes — so the label is never blank.

No changelog entry: #16 is unreleased, so the wrong label never shipped, and the feature's existing `[Unreleased]` entry covers it.

Fixes #191