### PR TITLE
Break the import cycle that made `import harmonist.sidecar` fail

### DIFF
--- a/src/harmonist/album_files.py
+++ b/src/harmonist/album_files.py
@@ -32,7 +32,7 @@ import re
 from pathlib import Path
 
 from . import formats
-from .sidecar import has_sidecar
+from .models import SIDECAR_FILENAME
 
 
 def audio_files(album_dir: Path) -> list[Path]:
@@ -44,7 +44,7 @@ def audio_files(album_dir: Path) -> list[Path]:
     directory. Returns [] for a directory that is not an album at all.
     """
     own = sorted(p for p in album_dir.iterdir() if formats.is_supported(p))
-    if own or not has_sidecar(album_dir):
+    if own or not (album_dir / SIDECAR_FILENAME).exists():
         return own
     return descendant_audio_files(album_dir)
 

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -42,7 +42,14 @@ from .formats.m4a import (
     ATOM_TITLE,
     ATOM_TRACK_NUM,
 )
-from .models import BandcampInfo, MatchCandidate, Release, Sidecar, TrackComparison
+from .models import (
+    SIDECAR_FILENAME,
+    BandcampInfo,
+    MatchCandidate,
+    Release,
+    Sidecar,
+    TrackComparison,
+)
 from .pending_downloads import PendingPurchase
 
 log = logging.getLogger(__name__)
@@ -833,7 +840,7 @@ def _on_disk_item_ids(music_dir: Path) -> set[int]:
     ids: set[int] = set()
     if not music_dir.exists():
         return ids
-    for harmonist_json in music_dir.rglob(sidecar_mod.SIDECAR_FILENAME):
+    for harmonist_json in music_dir.rglob(SIDECAR_FILENAME):
         try:
             sc = sidecar_mod.read(harmonist_json.parent)
         except Exception:
@@ -869,7 +876,7 @@ def _fill_in_existing_item_ids(
     if not music_dir.exists():
         return 0
     patched = 0
-    for harmonist_json in music_dir.rglob(sidecar_mod.SIDECAR_FILENAME):
+    for harmonist_json in music_dir.rglob(SIDECAR_FILENAME):
         album_dir = harmonist_json.parent
         try:
             sc = sidecar_mod.read(album_dir)

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -24,6 +24,18 @@ type Track = dict[str, Any]
 # it for `from harmonist.sidecar import CURRENT_SCHEMA_VERSION`.
 CURRENT_SCHEMA_VERSION = 1
 
+# The per-album sidecar's filename. Lives here, next to the schema version and
+# for the same reason: `models` imports nothing from the package, so anything
+# that needs to recognise a sidecar can read the name without importing the
+# module that reads its contents.
+#
+# `album_files` is why that matters. It has to ask whether a directory declares
+# itself an album, which is a question about a filename — but importing
+# `sidecar` for it closed a cycle (sidecar → library_index → url_recovery →
+# album_files → sidecar) that made `import harmonist.sidecar` fail outright
+# whenever it was the first harmonist import (#200).
+SIDECAR_FILENAME = ".harmonist.json"
+
 
 class AlbumState(StrEnum):
     NEW = "new"

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -16,6 +16,7 @@ from . import activity_store, audit, id_registry, library_index
 # keeps working; it's defined in models.py so Sidecar can default to it.
 from .models import (
     CURRENT_SCHEMA_VERSION,
+    SIDECAR_FILENAME,
     BandcampInfo,
     MatchCandidate,
     Sidecar,
@@ -23,8 +24,6 @@ from .models import (
 )
 
 log = logging.getLogger(__name__)
-
-SIDECAR_FILENAME = ".harmonist.json"
 
 
 class UnsupportedSchemaVersionError(Exception):

--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -1,0 +1,46 @@
+"""Every public module must import cleanly on its own.
+
+A circular import between two modules is invisible while some third module
+always gets imported first: by the time the cycle is reached, the module at the
+top of it is already fully initialised. That is exactly what happened in #200 —
+`album_files` imported `sidecar`, closing
+
+    sidecar → library_index → url_recovery → album_files → sidecar
+
+and `import harmonist.sidecar` raised ImportError, while the entire test suite,
+the app and CI stayed green because `harmonist.web.main` and `harmonist.models`
+reliably imported first.
+
+So each module is imported in a FRESH interpreter, as the first thing that
+happens. Nothing else can prime the cycle, which is the only way this class of
+bug fails loudly instead of lying in wait for whoever imports in a new order.
+"""
+
+from __future__ import annotations
+
+import pkgutil
+import subprocess
+import sys
+
+import pytest
+
+import harmonist
+
+
+def _module_names() -> list[str]:
+    return sorted(
+        m.name
+        for m in pkgutil.walk_packages(harmonist.__path__, prefix="harmonist.")
+        if not m.name.rpartition(".")[2].startswith("_")
+    )
+
+
+@pytest.mark.parametrize("module", _module_names())
+def test_module_imports_first(module: str) -> None:
+    r = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+        check=False,  # the assertion below reports the traceback, not a CalledProcessError
+    )
+    assert r.returncode == 0, f"`import {module}` fails on its own:\n{r.stderr}"


### PR DESCRIPTION
`import harmonist.sidecar`, as the first harmonist import, raised:

```
ImportError: cannot import name 'has_sidecar' from partially initialized module
'harmonist.sidecar' (most likely due to a circular import)
```

`import harmonist.url_recovery` failed the same way.

## Why nothing caught it

Introduced by #16: `album_files` imported `sidecar` for `has_sidecar`, closing

```
sidecar → library_index → url_recovery → album_files → sidecar
```

Python tolerates that cycle whenever something *else* is imported first, because `sidecar` is already fully initialised by the time `album_files` asks for it. The whole test suite, the app and CI were green — `harmonist.web.main` and `harmonist.models` reliably get there first. It only bites when `sidecar` is the entry point: a one-off script, a REPL, or a future module whose import order happens to differ.

Found writing a throwaway script to render an album page, which imported `harmonist.sidecar` on line 1.

## The fix

`album_files` never needed the module, only the **filename** — whether a directory declares itself an album is a question about a name, not about sidecar contents. `SIDECAR_FILENAME` moves to `models.py`, which imports nothing from the package, alongside `CURRENT_SCHEMA_VERSION` and for exactly the same reason.

## The guard is the point

`test/test_imports.py` imports each public module in a **fresh interpreter**, as the first thing that happens, so nothing can prime the cycle. That is the only arrangement in which this class of bug fails loudly rather than waiting for someone to import in a new order.

Mutation-checked: restoring the old import fails it on three modules (`sidecar`, `url_recovery`, `web.reconcile_runner`). Without it, no test in the suite goes red.

No changelog entry — #16 is unreleased, and no released build could reach this.

Fixes #200