### PR TITLE
Count video tracks towards completeness so DVD editions aren't reported short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- An album whose second disc is a DVD no longer reports every video track as
+  missing. Harmonist can't tag video files yet, but it now counts the ones you
+  have, so a CD+DVD release with everything ripped reads as complete (#193).
 - Albums adopted from an existing library can now be found with the Library's
   **Incomplete** filter. They never could before: an album with half its tracks
   read as complete. The count now comes from your files' own tags, so it works

--- a/docs/design.md
+++ b/docs/design.md
@@ -406,6 +406,14 @@ Three shapes:
 Files carrying no totals give "don't know", which derives **Complete** — an
 album Harmonist has never tagged is not accused of missing tracks.
 
+**Video files count as present tracks** (#193). Harmonist cannot tag a `.m4v`
+— that is #66, and they are deliberately absent from `album_files.audio_files`
+so nothing that writes can reach them — but Picard tags them with the same disc
+and position atoms as the audio, and the user *has* them. Without this a CD+DVD
+release reads as missing every track on the DVD. They are tracks for the purpose
+of "do you have this album", and for no other purpose: the track count, the
+tracklist and the tagger all still see audio only.
+
 There is no `incomplete` flag and no stored count. `sidecar.track_count_expected`
 held this number from v1.0.0 to v1.9.0 and was retired in #195: it duplicated
 what the tags already said, from the same source and the same moment, and the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,7 +151,9 @@ done but still wrong, each with its count:
   badges "N of M". The count comes from your files' own tags, which Harmonist and
   Picard both write, so this works on an adopted library straight away with no
   lookups. When a whole disc of a set is missing the tile just says *Incomplete* —
-  nothing on disk records how long the absent disc was.
+  nothing on disk records how long the absent disc was. Video tracks (`.m4v`)
+  count towards completeness even though Harmonist can't tag them yet, so a
+  CD+DVD release you've ripped in full reads as complete.
 - **Partially tagged** — some files carry the MusicBrainz Album Id and some don't.
   A half-finished tagging run, or Picard applied to part of a folder, leaves this.
 - **No artwork** — correctly tagged, fully linked, and still a grey square in

--- a/src/harmonist/album_files.py
+++ b/src/harmonist/album_files.py
@@ -49,6 +49,33 @@ def audio_files(album_dir: Path) -> list[Path]:
     return descendant_audio_files(album_dir)
 
 
+def video_files(album_dir: Path) -> list[Path]:
+    """This album's VIDEO files, in the same order as `audio_files`.
+
+    Harmonist cannot tag these — that is #66 — so they are deliberately absent
+    from `audio_files`, which is what the tagger, the matcher and the cover
+    reader all consume. But they are tracks the user has, tagged by Picard with
+    the same disc and position atoms as the audio, and pretending otherwise
+    reports an album whose second disc is a DVD as missing every track on it
+    (#193).
+
+    So: read for COMPLETENESS, never written. Same grouping rule as `audio_files`
+    — a sidecar'd parent with no audio of its own owns everything beneath it.
+    """
+    own = sorted(p for p in album_dir.iterdir() if formats.is_video(p))
+    if own or not (album_dir / SIDECAR_FILENAME).exists():
+        return own
+    if any(p for p in album_dir.iterdir() if formats.is_supported(p)):
+        return own
+    return descendant_video_files(album_dir)
+
+
+def descendant_video_files(album_dir: Path) -> list[Path]:
+    """Every video file below `album_dir`, ordered like `descendant_audio_files`."""
+    found = [p for p in album_dir.rglob("*") if formats.is_video(p) and p.is_file()]
+    return sorted(found, key=lambda p: sort_key(p.relative_to(album_dir)))
+
+
 def descendant_audio_files(album_dir: Path) -> list[Path]:
     """Every audio file below `album_dir`, ordered by subdirectory then name.
 

--- a/src/harmonist/formats/__init__.py
+++ b/src/harmonist/formats/__init__.py
@@ -40,6 +40,34 @@ def is_supported(path: Path) -> bool:
     return _module_for(path) is not None
 
 
+# Video containers that carry the same MP4 tag atoms as `.m4a`, so a Picard-
+# tagged video track states its disc, its position and its release exactly as an
+# audio one does. Harmonist cannot TAG these (that is #66), which is why they are
+# not `is_supported` — but it can read them, and refusing to look means an album
+# whose second disc is a DVD reads as missing every one of its tracks (#193).
+#
+# Narrow on purpose: `.mp4` is left out because it is routinely audio, and
+# guessing wrong there would feed a music file into the wrong half of the scan.
+VIDEO_EXTENSIONS = frozenset({".m4v"})
+
+
+def is_video(path: Path) -> bool:
+    """True for a video file whose tags Harmonist can read but not write."""
+    return path.suffix.lower() in VIDEO_EXTENSIONS
+
+
+def read_video_scan_fields(path: Path) -> ScanFields:
+    """`read_scan_fields` for a video container.
+
+    Routed through the MP4 reader explicitly rather than through
+    `_module_for`, which is keyed on the extensions Harmonist will WRITE. Adding
+    `.m4v` there would let the tagger try to tag it.
+    """
+    from . import m4a
+
+    return m4a.read_scan_fields(path)
+
+
 def read_album_id(path: Path) -> str | None:
     mod = _module_for(path)
     return mod.read_album_id(path) if mod else None

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
 from stat import S_ISREG
 from typing import NamedTuple
@@ -52,8 +52,8 @@ def scan(music_dir: Path, *, album_cache: AlbumCache | None = None) -> list[Albu
     Omit it (the default) for a full, uncached scan.
     """
     albums: list[Album] = []
-    for album_dir, audio_files, signature in iter_album_dirs(music_dir):
-        album = resolve_album(album_dir, audio_files, signature, album_cache)
+    for album_dir, audio, videos, signature in iter_album_dirs(music_dir):
+        album = resolve_album(album_dir, audio, videos, signature, album_cache)
         if album is not None:
             albums.append(album)
     if album_cache is not None:
@@ -61,9 +61,13 @@ def scan(music_dir: Path, *, album_cache: AlbumCache | None = None) -> list[Albu
     return albums
 
 
-def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], AlbumSignature]]:
-    """Yield (album_dir, sorted_audio_files, signature) for every album
+def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], list[Path], AlbumSignature]]:
+    """Yield (album_dir, audio_files, video_files, signature) for every album
     directory under `root`, ONE DIRECTORY AT A TIME.
+
+    Video files are yielded separately because Harmonist reads them but never
+    writes them (#193, #66): they count toward whether an album is complete, and
+    must stay out of everything that tags.
 
     An album directory is one containing supported audio — or, per
     `album_files`, one that declares itself an album with a sidecar while
@@ -89,6 +93,7 @@ def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], AlbumSignatu
         if any(r in d.parents for r in grouped_roots):
             continue
         audio: list[tuple[Path, int, int]] = []
+        video: list[tuple[Path, int, int]] = []
         sidecar_mtime: int | None = None
         cover_mtime: int | None = None
         for name in filenames:
@@ -101,6 +106,9 @@ def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], AlbumSignatu
                 continue
             if formats.is_supported(f):
                 audio.append((f, st.st_mtime_ns, st.st_size))
+            elif formats.is_video(f):
+                # Not audio, but tracks all the same — see `album_files.video_files`.
+                video.append((f, st.st_mtime_ns, st.st_size))
             elif name == ".harmonist.json":
                 sidecar_mtime = st.st_mtime_ns
             elif name in ("cover.jpg", "cover.png"):
@@ -111,31 +119,42 @@ def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], AlbumSignatu
             # directory. Anything else is an ordinary artist/container dir.
             if sidecar_mtime is None:
                 continue
-            grouped = _grouped_entries(d)
+            grouped = _grouped_entries(d, album_files.descendant_audio_files)
             if not grouped:
                 continue  # sidecar but nothing beneath it — not an album
             grouped_roots.append(d)
             audio = grouped
+            video = _grouped_entries(d, album_files.descendant_video_files)
         else:
             audio.sort(key=lambda e: album_files.sort_key(Path(e[0].name)))
+            video.sort(key=lambda e: album_files.sort_key(Path(e[0].name)))
         files = [e[0] for e in audio]
+        videos = [e[0] for e in video]
         signature: AlbumSignature = (
             # Keyed on the path RELATIVE to the album dir, not the bare name:
             # a grouped album has a "01 - …" in every disc directory, and bare
             # names would collide into one indistinguishable signature entry.
-            tuple((str(e[0].relative_to(d)), e[1], e[2]) for e in audio),
+            #
+            # Video files ride in the SAME tuple as the audio. They are read for
+            # completeness (#193), so a video appearing or vanishing changes what
+            # the album derives — and a signature blind to them would serve a
+            # stale Album from the cache after a DVD rip landed.
+            tuple((str(e[0].relative_to(d)), e[1], e[2]) for e in [*audio, *video]),
             sidecar_mtime,
             cover_mtime,
         )
-        yield d, files, signature
+        yield d, files, videos, signature
 
 
-def _grouped_entries(album_dir: Path) -> list[tuple[Path, int, int]]:
-    """(path, mtime_ns, size) for every audio file below a grouped album dir,
-    in track order. Unstattable files are dropped, exactly as in the walk above.
+def _grouped_entries(
+    album_dir: Path, collect: Callable[[Path], list[Path]]
+) -> list[tuple[Path, int, int]]:
+    """(path, mtime_ns, size) for every file `collect` finds below a grouped
+    album dir, in track order. Unstattable files are dropped, exactly as in the
+    walk above.
     """
     entries = []
-    for f in album_files.descendant_audio_files(album_dir):
+    for f in collect(album_dir):
         try:
             st = f.stat()
         except OSError:
@@ -148,6 +167,7 @@ def _grouped_entries(album_dir: Path) -> list[tuple[Path, int, int]]:
 def resolve_album(
     album_dir: Path,
     audio_files: list[Path],
+    video_files: list[Path],
     signature: AlbumSignature,
     album_cache: AlbumCache | None,
 ) -> Album | None:
@@ -163,7 +183,7 @@ def resolve_album(
     # re-read below.
     reuse = cached[2] if (cached is not None and cached[0][0] == signature[0]) else None
     try:
-        io = read_album_io(album_dir, audio_files, reuse)
+        io = read_album_io(album_dir, audio_files, video_files, reuse)
         album = build_album(album_dir, audio_files, io)
     except (InvalidSidecarError, UnsupportedSchemaVersionError) as e:
         log.warning("skipping %s: %s", album_dir, e)
@@ -191,11 +211,18 @@ class AlbumIO(NamedTuple):
     sidecar: Sidecar | None
     fields: list[formats.ScanFields]
     cover_path: Path | None
+    # Read from the album's video files, which Harmonist never tags. Kept apart
+    # from `fields` so nothing that writes can reach them, and consulted only by
+    # the completeness derivation (#193).
+    # A tuple, not a list: `AlbumIO` is a NamedTuple, so a mutable default
+    # would be shared by every instance that omits it.
+    video_fields: tuple[formats.ScanFields, ...] = ()
 
 
 def read_album_io(
     album_dir: Path,
     audio_files: list[Path],
+    video_files: list[Path] | None = None,
     reuse_fields: list[formats.ScanFields] | None = None,
 ) -> AlbumIO:
     """Do an album's blocking reads in one place: the sidecar, each track's tags
@@ -212,6 +239,7 @@ def read_album_io(
         if reuse_fields is not None
         else [formats.read_scan_fields(f) for f in audio_files],
         cover_path=_find_cover(album_dir),
+        video_fields=tuple(formats.read_video_scan_fields(f) for f in (video_files or [])),
     )
 
 
@@ -243,11 +271,11 @@ def build_album(album_dir: Path, audio_files: list[Path], io: AlbumIO) -> Album:
     # The sidecar is kept on disk; once the user fixes the on-disk tags
     # via Picard, the next scan re-derives state from the sidecar.
     inconsistent_tracks = _check_consistency(audio_files, fields)
-    expected = expected_tracks(fields)
+    expected = expected_tracks(fields, io.video_fields)
     state = (
         AlbumState.INCONSISTENT
         if inconsistent_tracks
-        else _derive_state(sidecar, fields, album_dir)
+        else _derive_state(sidecar, fields, album_dir, io.video_fields)
     )
 
     return Album(
@@ -298,7 +326,10 @@ class ExpectedTracks(NamedTuple):
 UNKNOWN_EXPECTED = ExpectedTracks(total=None, complete=True)
 
 
-def expected_tracks(fields: list[formats.ScanFields]) -> ExpectedTracks:
+def expected_tracks(
+    fields: list[formats.ScanFields],
+    video_fields: Sequence[formats.ScanFields] = (),
+) -> ExpectedTracks:
     """How many tracks the release has, read from the files' own tags (#195).
 
     MusicBrainz told us this at tagging time and the tagger wrote it into every
@@ -318,8 +349,14 @@ def expected_tracks(fields: list[formats.ScanFields]) -> ExpectedTracks:
 
     Files carrying no totals give `UNKNOWN_EXPECTED`, so an album Harmonist has
     never tagged is not accused of missing tracks.
+
+    `video_fields` are counted as present tracks (#193). Harmonist cannot tag a
+    video file, but the user HAS it, and a release whose second medium is a DVD
+    otherwise reads as missing every track on it — *Barking* is nine CD tracks
+    and nine DVD ones, all on disk, reported as "missing 9 of 18". They are
+    tracks for the purpose of "do you have this album", and for no other purpose.
     """
-    present = [f for f in fields if not f.unreadable]
+    present = [f for f in [*fields, *video_fields] if not f.unreadable]
     if not present:
         return UNKNOWN_EXPECTED
     # Per disc, the track_total its files agree on. A disc whose files disagree
@@ -403,7 +440,10 @@ def _album_id(album_dir: Path, sidecar: Sidecar | None) -> str:
 
 
 def _derive_state(
-    sidecar: Sidecar | None, fields: list[formats.ScanFields], album_dir: Path
+    sidecar: Sidecar | None,
+    fields: list[formats.ScanFields],
+    album_dir: Path,
+    video_fields: Sequence[formats.ScanFields] = (),
 ) -> AlbumState:
     if sidecar is None:
         return AlbumState.NEW
@@ -438,7 +478,7 @@ def _derive_state(
         # number. `complete` rather than a count comparison, because an album
         # missing an entire medium is knowably incomplete with no total to
         # compare against — see `expected_tracks`.
-        if not expected_tracks(fields).complete:
+        if not expected_tracks(fields, video_fields).complete:
             return AlbumState.INCOMPLETE
         # NEEDS_SYNC: Bandcamp-sourced album, MB release known, files tagged,
         # but Bandcamp item_id not yet linked (a Sync run resolves this).

--- a/src/harmonist/web/scan_runner.py
+++ b/src/harmonist/web/scan_runner.py
@@ -236,8 +236,8 @@ class ScanRunner:
             item = await loop.run_in_executor(executor, next, walk, _DONE)
             if item is _DONE:
                 break
-            album_dir, files, signature = cast(
-                "tuple[Path, list[Path], scanner.AlbumSignature]", item
+            album_dir, files, videos, signature = cast(
+                "tuple[Path, list[Path], list[Path], scanner.AlbumSignature]", item
             )
             status.dirs_scanned += 1
             try:
@@ -254,7 +254,7 @@ class ScanRunner:
                     if cached is not None and cached[0][0] == signature[0]:
                         reuse = cached[2]  # audio unchanged → skip the tag reads
                     io = await loop.run_in_executor(
-                        executor, scanner.read_album_io, album_dir, files, reuse
+                        executor, scanner.read_album_io, album_dir, files, videos, reuse
                     )
                     album = scanner.build_album(album_dir, files, io)  # CPU, on loop
                     self._cache[album_dir] = (signature, album, io.fields)

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -730,3 +730,78 @@ def test_expected_count_needs_no_musicbrainz_call(tmp_path, monkeypatch):
 
     album = scan(tmp_path)[0]
     assert (album.state, album.expected_track_count) == (AlbumState.INCOMPLETE, 5)
+
+
+def _video_disc(album_dir, disc: int, disc_total: int, n: int, track_total: int) -> None:
+    """Lay down `n` Picard-tagged .m4v files for one medium of a release."""
+    from mutagen.mp4 import MP4
+
+    for i in range(1, n + 1):
+        f = album_dir / f"{disc}-{i:02d} Video {i}.m4v"
+        shutil.copy(SINE_M4A, f)  # an MP4 container either way
+        audio = MP4(f)
+        audio[ATOM_MB_ALBUM_ID] = [b"rel-aaa"]
+        audio["trkn"] = [(i, track_total)]
+        audio["disk"] = [(disc, disc_total)]
+        audio.save()
+
+
+def test_a_video_medium_on_disk_completes_the_album(tmp_path):
+    """The Barking case (#193): 9 CD tracks and 9 DVD ones, every file present,
+    reported as "missing 9 of 18" because the DVD half is not audio."""
+    album_dir = _make_album_dir(tmp_path, "Underworld", "Barking", n_tracks=9)
+    _tag_files(album_dir, track_total=9, disc_num=1, disc_total=2)
+    _video_disc(album_dir, disc=2, disc_total=2, n=9, track_total=9)
+    _tagged_sidecar(album_dir)
+
+    album = scan(tmp_path)[0]
+    assert album.expected_track_count == 18
+    assert album.state == AlbumState.COMPLETE
+
+
+def test_a_video_medium_never_ripped_stays_incomplete(tmp_path):
+    """The other half of the same rule. No files of any kind for the medium, so
+    the album really is short and must keep saying so."""
+    album_dir = _make_album_dir(tmp_path, "Artist", "Album", n_tracks=9)
+    _tag_files(album_dir, track_total=9, disc_num=1, disc_total=2)
+    _tagged_sidecar(album_dir)
+
+    assert scan(tmp_path)[0].state == AlbumState.INCOMPLETE
+
+
+def test_a_partly_ripped_video_medium_is_incomplete(tmp_path):
+    """7 of the DVD's 9 videos present — counted, and still short."""
+    album_dir = _make_album_dir(tmp_path, "Artist", "Album", n_tracks=9)
+    _tag_files(album_dir, track_total=9, disc_num=1, disc_total=2)
+    _video_disc(album_dir, disc=2, disc_total=2, n=7, track_total=9)
+    _tagged_sidecar(album_dir)
+
+    album = scan(tmp_path)[0]
+    assert album.expected_track_count == 18
+    assert album.state == AlbumState.INCOMPLETE
+
+
+def test_video_files_are_not_offered_to_anything_that_tags(tmp_path):
+    """Harmonist cannot write these (#66). They must stay out of `audio_files`,
+    which is what the tagger, the matcher and the cover reader consume."""
+    from harmonist import album_files
+
+    album_dir = _make_album_dir(tmp_path, "Artist", "Album", n_tracks=2)
+    _video_disc(album_dir, disc=2, disc_total=2, n=2, track_total=2)
+
+    assert all(f.suffix == ".m4a" for f in album_files.audio_files(album_dir))
+    assert all(f.suffix == ".m4v" for f in album_files.video_files(album_dir))
+
+
+def test_a_new_video_file_invalidates_the_scan_cache(tmp_path):
+    """Videos change what the album derives, so a signature blind to them would
+    serve a stale Album after a DVD rip landed."""
+    album_dir = _make_album_dir(tmp_path, "Artist", "Album", n_tracks=9)
+    _tag_files(album_dir, track_total=9, disc_num=1, disc_total=2)
+    _tagged_sidecar(album_dir)
+    cache: dict = {}
+    assert scan(tmp_path, album_cache=cache)[0].state == AlbumState.INCOMPLETE
+
+    _video_disc(album_dir, disc=2, disc_total=2, n=9, track_total=9)
+
+    assert scan(tmp_path, album_cache=cache)[0].state == AlbumState.COMPLETE


### PR DESCRIPTION
A release whose second medium is a DVD reported every track on it as missing. *Underworld — Barking* is nine CD tracks and nine DVD ones, **all present on disk**, and it read as "missing 9 of 18" — because `.m4v` is not an audio format, so `album_files.audio_files` never saw the DVD half and the scan concluded a whole medium was absent.

Across the dogfooded library this accounted for **every** large gap: the missing count equalled the release's video-track count exactly in all five cases.

## Smaller than the issue proposed, because the files are already tagged

Picard writes `trkn`, `disk` and the MB Album Id onto a `.m4v` exactly as onto a `.m4a`:

```
2-01 Bird 1.m4v      trkn=(1, 9)  disk=(2, 2)  mbid=yes
```

So a video track states its medium and its position itself. That means:

- **no MusicBrainz lookup** — the alternative was fetching `recordings` per album just to read `video` flags;
- **no dependence on MB's `video` flags**, which are not reliably set (`3c75b98f` is a *Barking* DVD medium whose seven tracks carry none);
- **no reliance on medium `format`**, which would have been catastrophic for *Wish You Were Here 50* — one Blu-ray medium carrying 45 audio tracks and 4 videos. Excluding by format would have dropped that album to zero expected tracks.

## Read, never written

Videos stay out of `audio_files`, which is what the tagger, the matcher and the cover reader consume, and ride in a separate `AlbumIO.video_fields` consulted only by `expected_tracks`. They are tracks for the purpose of *"do you have this album"* and for no other purpose — the track count, the tracklist and the tagger still see audio only. Tagging them is #66.

`VIDEO_EXTENSIONS` is deliberately just `.m4v`: `.mp4` is routinely audio, and guessing wrong there would feed a music file into the half of the scan that cannot tag it.

Videos ride in the **same signature tuple** as the audio, since they change what the album derives — a signature blind to them would serve a stale `Album` from the cache after a DVD rip landed. There is a test for exactly that.

## Verified against the real library

| Album | audio | video | total | complete |
| --- | --- | --- | --- | --- |
| Underworld — Barking | 9 | 9 | 18 | **yes** |
| Foo Fighters — Greatest Hits | 16 | 21 | 37 | **yes** |
| DJ Shadow — In Tune and on Time | 21 | 26 | 50 | no — 3 videos genuinely absent |
| Midnight Oil — Best of Both Worlds | 16 | 0 | — | no — DVD never ripped |

TISM stays complete for an unrelated reason, now filed as #204: its files claim a single-disc 16-track release while its sidecar names a three-disc box. That is a disagreement worth surfacing, not an incompleteness to count.

Fixes #193