### PR TITLE
Add a regression test for the phantom per-disc incompleteness reports

### DIFF
--- a/test/test_split_release.py
+++ b/test/test_split_release.py
@@ -782,3 +782,35 @@ def test_album_folders_is_empty_for_an_ordinary_one_folder_album(tmp_path):
     album = next(a for a in scan(tmp_path) if a.path == d)
 
     assert _album_folders(album) == []
+
+
+def test_grouping_does_not_also_report_each_disc_separately(tmp_path):
+    """#190: the reconcile pass grouped a release and then reported each of its
+    disc folders as an album in its own right, because the backfill that ran
+    after grouping was handed the SAME pre-grouping snapshot. Every grouped
+    album produced one bogus entry per disc.
+
+    The backfill is gone with #195, so the stale snapshot has no consumer left —
+    the orphan pass only looks at NEW/TAGGING albums, and a disc folder of a
+    tagged release is neither. Asserted rather than reasoned about, because
+    reasoning is exactly what got #190 wrong: the code carried a comment
+    explaining this failure mode and then failed that way anyway.
+    """
+    from harmonist import activity, activity_store
+    from harmonist.web.reconcile_runner import reconcile_pending_orphans
+
+    activity_store.init(tmp_path / "audit.db")
+    activity.clear()
+    parent = _split_album(tmp_path)
+
+    reconcile_pending_orphans(tmp_path, fetch_urls=lambda m: [], rate_limit_seconds=0)
+
+    messages = [e.message for e in activity_store.recent(100)]
+    grouped = [m for m in messages if "Grouped" in m]
+    assert len(grouped) == 1, f"one entry for the release, got {grouped}"
+    assert not [m for m in messages if "Missing" in m], "no per-disc incompleteness claims"
+
+    # And the album really is one complete album afterwards.
+    albums = scan(tmp_path)
+    assert [a.path for a in albums] == [parent]
+    assert albums[0].state == AlbumState.COMPLETE


### PR DESCRIPTION
**#190 dissolved with #195 rather than needing a fix** — this locks that in.

The pass grouped a split release and then reported each of its disc folders as an album in its own right:

```
Vapourized Volume One · Grouped 2 disc folder(s) into one album (21 tracks)
...
Kasey Taylor — Vapourized Volume 1 · Missing 10 of 21 tracks
Kasey Taylor — Vapourized Volume 1 · Missing 11 of 21 tracks
```

The cause was that the track-count backfill ran *after* grouping but was handed the **same pre-grouping snapshot**, which still listed the individual disc folders. #195 removed that backfill entirely, so the stale snapshot has no consumer left: the orphan pass only looks at `NEW`/`TAGGING` albums, and a disc folder of a tagged release is neither.

**Asserted rather than reasoned about.** The original code carried a comment explaining precisely this failure mode, immediately above the call that caused it:

```python
grouped = _promote_split_releases(albums, music_dir, exempt)
# ... AFTER the grouping above, and that order is load-bearing — backfilling
# first would measure each half of a split release against the whole release's
# track count and flag both halves incomplete, which is true of neither.
counted, newly_incomplete = _backfill_track_counts(albums, exempt, fetch_track_count)
```

So "I have thought about it and it cannot happen" is demonstrably not sufficient evidence in this area. The test runs the real pass over a split release and asserts one grouping entry, no per-disc incompleteness claims, and one complete album afterwards.

Test-only; no `src` change.

Fixes #190