### PR TITLE
Say a MusicBrainz release has been deleted, instead of reporting a 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- An album whose MusicBrainz release has been deleted now says so, and points at
+  **Wrong MusicBrainz match** to pick the current one — instead of reporting a
+  raw "HTTP Error 404" that looked like something to retry (#194).
 - An album whose second disc is a DVD no longer reports every video track as
   missing. Harmonist can't tag video files yet, but it now counts the ones you
   have, so a CD+DVD release with everything ripped reads as complete (#193).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -88,6 +88,12 @@ purchase it came from. **Sync** links these; that's the common case. If a sync
 can't find the purchase, use **Try a different URL** or **Mark purchased
 elsewhere**.
 
+**A release that's vanished from MusicBrainz.** Editors occasionally delete a
+release (usually a duplicate). The album's page says so rather than showing a
+fetch error, and **Wrong MusicBrainz match** sends it back to Needs MBID with its
+store link intact — a Recheck usually finds the replacement straight away. Your
+files keep their tags throughout.
+
 **Inconsistent** — the files in one folder disagree about album title or MBID,
 which normally means several albums share a directory. Harmonist won't guess:
 split them in Picard and refresh.

--- a/src/harmonist/mb_lookup.py
+++ b/src/harmonist/mb_lookup.py
@@ -28,6 +28,26 @@ class MBError(Exception):
     """Raised on transient MB API failures (network errors, non-404 HTTP errors)."""
 
 
+class ReleaseGoneError(MBError):
+    """MusicBrainz 404s the release: it is no longer there.
+
+    A subclass, so every existing `except MBError` keeps working and only the
+    callers that can offer a remedy have to know the difference.
+
+    **A 404 is an answer, not a failure**, and that is the whole point of
+    separating it. A network error, a timeout or a 503 means "ask again later";
+    a 404 from a service that is plainly working means the release has been
+    deleted, and asking again next startup will get the same answer forever.
+
+    Deleted, not merged: MusicBrainz *redirects* a merged MBID, so a bare 404
+    with no redirect means the entity was removed outright. Observed on
+    `7b598009-…`, an edition of Voices From the Lake's *II* that MB no longer
+    has — while the album's Bandcamp URL still resolves to two live releases,
+    one of which matches the files exactly. So this is usually recoverable, and
+    the album should be told to re-match rather than left broken.
+    """
+
+
 _USER_AGENT_RE = re.compile(r"^\s*([^/]+)/(\S+)\s*\(\s*([^)]*?)\s*\)\s*$")
 
 
@@ -85,7 +105,11 @@ def lookup_by_bandcamp_url(bandcamp_url: str) -> list[str]:
 
 
 def fetch_release(mbid: str) -> Release:
-    """Fetch a full MB release with everything the tagger needs."""
+    """Fetch a full MB release with everything the tagger needs.
+
+    Raises `ReleaseGoneError` — a subclass of `MBError` — when MusicBrainz 404s
+    the release, so a caller can tell "gone" from "try again later" (#194).
+    """
     try:
         result = musicbrainzngs.get_release_by_id(
             mbid,
@@ -98,9 +122,12 @@ def fetch_release(mbid: str) -> Release:
                 "isrcs",
             ],
         )
+    except musicbrainzngs.ResponseError as e:
+        if _is_not_found(e):
+            raise ReleaseGoneError(f"MusicBrainz no longer has release {mbid}") from e
+        raise MBError(f"MB request failed: {e}") from e
     except (
         musicbrainzngs.NetworkError,
-        musicbrainzngs.ResponseError,
         musicbrainzngs.AuthenticationError,
     ) as e:
         raise MBError(f"MB request failed: {e}") from e

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -3099,6 +3099,19 @@ def _register_routes(app: FastAPI) -> None:
             )
         try:
             release = mb_lookup.fetch_release(sc.mb_release_id)
+        except mb_lookup.ReleaseGoneError:
+            # A 404 is an ANSWER, not a failure: the release has been deleted
+            # from MusicBrainz, and no amount of retrying will bring it back.
+            # Saying "couldn't fetch" would invite the user to try again forever,
+            # so say what happened and point at the one thing that fixes it —
+            # re-matching, which keeps the store link and lets Recheck find the
+            # replacement (#194).
+            return HTMLResponse(
+                '<p class="text-2xs text-amber-700 mt-2">MusicBrainz no longer has '
+                "this release — it looks like it was deleted there. Use "
+                "<strong>Wrong MusicBrainz match</strong> above to pick the "
+                "current one; your files keep their tags until you re-tag.</p>"
+            )
         except mb_lookup.MBError as e:
             # Escaped: an MBError wraps upstream musicbrainzngs text, so the
             # message originates off-box and must not reach the DOM as markup.
@@ -3226,6 +3239,20 @@ def _register_routes(app: FastAPI) -> None:
                 # `incomplete=False` and the §15.3 guard still applies to it.
                 incomplete=album.state == AlbumState.INCOMPLETE,
                 overwrite_art=overwrite_art,
+            )
+        except mb_lookup.ReleaseGoneError:
+            # Not a failure to report as one: MusicBrainz has deleted the release
+            # this album names, so re-tagging from it is impossible now and will
+            # stay impossible. "Re-tag failed: HTTP Error 404" reads as something
+            # to retry; this says what is actually true and names the way out
+            # (#194).
+            log.warning("retag: MusicBrainz no longer has release %s", sc.mb_release_id)
+            return _flash_response(
+                "That release is gone from MusicBrainz",
+                "use Wrong MusicBrainz match to pick the current one",
+                level=Level.WARNING,
+                tasks_changed=False,
+                album=album,
             )
         except Exception as e:
             log.exception("retag failed")

--- a/test/test_mb_lookup.py
+++ b/test/test_mb_lookup.py
@@ -372,3 +372,65 @@ def test_fetch_release_urls_raises_on_error(monkeypatch):
     monkeypatch.setattr(musicbrainzngs, "get_release_by_id", explode)
     with pytest.raises(MBError):
         fetch_release_urls("rel-aaa")
+
+
+def test_fetch_release_raises_release_gone_on_404(monkeypatch):
+    """A 404 is an ANSWER — the release has been deleted — and must be
+    distinguishable from "ask again later", or the caller can only offer a retry
+    that will never succeed (#194)."""
+    import musicbrainzngs
+
+    from harmonist import mb_lookup
+
+    err = musicbrainzngs.ResponseError("not found")
+    err.cause = _http_error(404)
+
+    def boom(*a, **kw):
+        raise err
+
+    monkeypatch.setattr(musicbrainzngs, "get_release_by_id", boom)
+
+    with pytest.raises(mb_lookup.ReleaseGoneError):
+        mb_lookup.fetch_release("7b598009-b155-416d-8e3a-f71647228a43")
+
+
+@pytest.mark.parametrize("status", [500, 503])
+def test_fetch_release_keeps_other_http_errors_transient(monkeypatch, status):
+    """A 503 means the service is unwell, not that the release is gone. It must
+    stay a plain MBError so nothing tells the user to re-match over an outage."""
+    import musicbrainzngs
+
+    from harmonist import mb_lookup
+
+    err = musicbrainzngs.ResponseError("server error")
+    err.cause = _http_error(status)
+
+    def boom(*a, **kw):
+        raise err
+
+    monkeypatch.setattr(musicbrainzngs, "get_release_by_id", boom)
+
+    with pytest.raises(mb_lookup.MBError) as excinfo:
+        mb_lookup.fetch_release("some-mbid")
+    assert not isinstance(excinfo.value, mb_lookup.ReleaseGoneError)
+
+
+def test_fetch_release_keeps_network_errors_transient(monkeypatch):
+    import musicbrainzngs
+
+    from harmonist import mb_lookup
+
+    def boom(*a, **kw):
+        raise musicbrainzngs.NetworkError("connection refused")
+
+    monkeypatch.setattr(musicbrainzngs, "get_release_by_id", boom)
+
+    with pytest.raises(mb_lookup.MBError) as excinfo:
+        mb_lookup.fetch_release("some-mbid")
+    assert not isinstance(excinfo.value, mb_lookup.ReleaseGoneError)
+
+
+def _http_error(status: int):
+    from urllib.error import HTTPError
+
+    return HTTPError("http://mb", status, "Not Found", {}, None)  # type: ignore[arg-type]

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6368,3 +6368,85 @@ def test_the_album_page_offers_the_way_back_once_accepted(client, cfg):
 
     page = client.get(f"/album/{aid}").text
     assert "Mark incomplete again" in page, "escape hatch, per review gate item 5"
+
+
+# ---------------------------------------------------------------------------
+# A release MusicBrainz has deleted (#194)
+# ---------------------------------------------------------------------------
+
+
+def _gone(mbid):
+    from harmonist import mb_lookup
+
+    raise mb_lookup.ReleaseGoneError(f"MusicBrainz no longer has release {mbid}")
+
+
+def test_album_page_explains_a_deleted_release_instead_of_showing_a_404(client, cfg, monkeypatch):
+    """Real case: Voices From the Lake — II names `7b598009-…`, which MB has
+    deleted. The page used to render "Couldn't fetch from MusicBrainz: HTTP
+    Error 404: Not Found", which reads as something to retry forever."""
+    d = _make_tagged_album(cfg, "Gone", mbid="rel-gone", tagged_at=datetime.now(UTC))
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", _gone)
+
+    r = client.get(f"/library/{_id_for(cfg, d)}/compare")
+
+    assert r.status_code == 200
+    assert "no longer has this release" in r.text
+    assert "404" not in r.text
+    assert "Wrong MusicBrainz match" in r.text, "names the way out"
+
+
+def test_album_page_still_says_try_again_for_a_transient_failure(client, cfg, monkeypatch):
+    """The control. An outage must not tell the user their release was deleted."""
+    from harmonist import mb_lookup
+
+    d = _make_tagged_album(cfg, "Flaky", mbid="rel-flaky", tagged_at=datetime.now(UTC))
+
+    def unwell(mbid):
+        raise mb_lookup.MBError("MB request failed: HTTP Error 503")
+
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", unwell)
+
+    r = client.get(f"/library/{_id_for(cfg, d)}/compare")
+
+    assert "Couldn't fetch from MusicBrainz" in r.text
+    assert "no longer has this release" not in r.text
+
+
+def test_retag_reports_a_deleted_release_as_gone_not_as_a_failure(client, cfg, monkeypatch):
+    d = _make_tagged_album(cfg, "Gone", mbid="rel-gone", tagged_at=datetime.now(UTC))
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", _gone)
+
+    r = client.post(f"/retag/{_id_for(cfg, d)}")
+
+    assert r.status_code == 200
+    assert "gone from MusicBrainz" in r.text
+    assert "Re-tag failed" not in r.text
+    assert "Wrong MusicBrainz match" in r.text
+
+
+def test_retag_still_reports_a_real_failure_as_a_failure(client, cfg, monkeypatch):
+    d = _make_tagged_album(cfg, "Boom", mbid="rel-boom", tagged_at=datetime.now(UTC))
+
+    def boom(mbid):
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", boom)
+
+    r = client.post(f"/retag/{_id_for(cfg, d)}")
+
+    assert "Re-tag failed" in r.text
+
+
+def test_a_deleted_release_leaves_the_album_alone(client, cfg, monkeypatch):
+    """No automatic demotion. MusicBrainz being briefly odd must not dump albums
+    out of the Library, and the user's tags are not rewritten behind them —
+    the remedy is offered, not applied."""
+    d = _make_tagged_album(cfg, "Gone", mbid="rel-gone", tagged_at=datetime.now(UTC))
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", _gone)
+    before = sc.read(d)
+
+    client.get(f"/library/{_id_for(cfg, d)}/compare")
+    client.post(f"/retag/{_id_for(cfg, d)}")
+
+    assert sc.read(d) == before


### PR DESCRIPTION
An album whose release MusicBrainz no longer has showed the raw upstream text on its page:

```
Couldn't fetch from MusicBrainz: MB request failed: caused by: HTTP Error 404: Not Found
```

and `Re-tag failed: … 404` from the button. Both read as something to try again, and trying again gets the same answer forever.

## A 404 is an answer, not a failure

That is the distinction the code was missing. A network error, a timeout or a 503 means *ask later*; a 404 from a service that is plainly working means the release is **gone**.

`fetch_release` now raises `ReleaseGoneError` — a subclass of `MBError`, so every existing `except MBError` keeps working and only the callers that can offer a remedy have to know the difference.

## Diagnosed on the real case

*Voices From the Lake — II* names `7b598009-b155-416d-8e3a-f71647228a43`:

- the API 404s it, with **no redirect** — and MusicBrainz *redirects* merged MBIDs, so this release was **deleted outright**, not merged away;
- the website returns 200 for the same URL, which turns out to be a bot-check page rather than a release. The API is the honest signal.

**And it is recoverable**, which is why naming the remedy is worth doing. The album's Bandcamp URL is still in its sidecar and still resolves, to two live releases — one an 11-track edition matching the 11 files on disk exactly:

```
url-rel -> ['d74fa182-…' (10 tracks), '10867aa5-…' (11 tracks)]
```

So the page now points at **Wrong MusicBrainz match**, which keeps the store link and hands the album to Needs MBID, where a Recheck finds the replacement.

## Nothing is demoted automatically

MusicBrainz being briefly odd must not dump albums out of the Library, and rewriting someone's tags on the strength of one 404 would be worse. The remedy is offered, not applied — there is a test asserting the sidecar is byte-identical after both the page load and the re-tag attempt.

The control tests matter as much as the main ones: a 503 and a network error must both still say "couldn't fetch", or an outage would tell every user their releases had been deleted.

## Scope note

The "retries forever on every startup" half of the issue is **already gone**: it lived in #187's backfill, which #195 removed.

Fixes #194