### PR TITLE
Don't count an absent video disc against an album's completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- An album is no longer reported as incomplete when the only discs it's missing
+  are video — the bonus DVD you never ripped. The album's page lists the discs
+  that aren't on disk, so "complete" doesn't quietly mean "we stopped mentioning
+  them". A partly-ripped video disc still counts as incomplete (#206).
 - An album whose MusicBrainz release has been deleted now says so plainly,
   instead of reporting a raw "HTTP Error 404" that looked like something to
   retry. A banner offers to send it back to Needs MBID when you're ready, and

--- a/docs/design.md
+++ b/docs/design.md
@@ -406,6 +406,26 @@ Three shapes:
 Files carrying no totals give "don't know", which derives **Complete** — an
 album Harmonist has never tagged is not accused of missing tracks.
 
+**An absent medium that was video does not count against the album** (#206).
+A release whose bonus DVD the user never ripped is not missing 44 tracks in any
+sense they can act on — Harmonist cannot tag video (#66). So a medium that is
+*entirely* absent is forgiven when MusicBrainz says its tracks are all video.
+
+The word doing the work is *entirely*. A partly-present video medium is still
+Incomplete, on the principle that if the user has one video they should have the
+rest — which separates "I chose not to rip the DVD" from "my rip failed halfway".
+
+This is the one release fact the files cannot carry, because the files that would
+carry it are the missing ones. So it is persisted as `sidecar.video_media` (§4),
+filled by a lookup bounded to albums that actually have an absent medium —
+knowable from the tags alone, and a small set. `None` means "not asked" and `()`
+means "asked, none are video"; without that distinction a release with no video
+would be re-fetched on every pass forever.
+
+The album page **lists the absent media** regardless, off the release it has
+already fetched for its comparison. "Complete" must not quietly mean "we stopped
+mentioning two whole discs".
+
 **Video files count as present tracks** (#193). Harmonist cannot tag a `.m4v`
 — that is #66, and they are deliberately absent from `album_files.audio_files`
 so nothing that writes can reach them — but Picard tags them with the same disc

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -160,7 +160,10 @@ done but still wrong, each with its count:
   lookups. When a whole disc of a set is missing the tile just says *Incomplete* —
   nothing on disk records how long the absent disc was. Video tracks (`.m4v`)
   count towards completeness even though Harmonist can't tag them yet, so a
-  CD+DVD release you've ripped in full reads as complete.
+  CD+DVD release you've ripped in full reads as complete. If you *didn't* rip the
+  bonus DVD at all, that's not counted against you either — the album's page
+  lists the discs that aren't on disk, so nothing is hidden. A DVD you ripped
+  only part of does still count as incomplete.
 
   Some albums are incomplete on purpose and always will be — you ripped only the
   stereo mixes off a Blu-ray, or the hidden track was never ripped and the CD is

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -963,6 +963,17 @@ def fetch_release_urls(mbid: str) -> list[str]:
     return [url for url, m in URL_RELS.items() if m == mbid]
 
 
+def fetch_video_media(mbid: str) -> tuple[int, ...]:
+    """Demo counterpart of the video-only-media lookup (#206).
+
+    The seeded catalogue has no video tracks, so every release answers "none are
+    video" — which is the honest answer for it, and keeps the request off the
+    network like every other demo lookup.
+    """
+    fetch_release(mbid)  # raises ReleaseGoneError for an id the demo doesn't have
+    return ()
+
+
 def lookup_by_bandcamp_url(bandcamp_url: str) -> list[str]:
     mbid = URL_RELS.get(bandcamp_url)
     return [mbid] if mbid else []
@@ -1040,6 +1051,7 @@ def install() -> None:
 
     mb_lookup.fetch_release = fetch_release
     mb_lookup.fetch_release_urls = fetch_release_urls
+    mb_lookup.fetch_video_media = fetch_video_media
     mb_lookup.lookup_by_bandcamp_url = lookup_by_bandcamp_url
     mb_lookup.browse_release_group_releases = browse_release_group_releases
     mb_search.search_releases = search_releases

--- a/src/harmonist/mb_lookup.py
+++ b/src/harmonist/mb_lookup.py
@@ -136,6 +136,44 @@ def fetch_release(mbid: str) -> Release:
     return release
 
 
+def fetch_video_media(mbid: str) -> tuple[int, ...]:
+    """Which of the release's media hold nothing but video, by position.
+
+    The one fact about a release that CANNOT be read off the files, which is why
+    it earns a sidecar field (#206): a medium the user never ripped has no files
+    to carry it. Midnight Oil's *Best of Both Worlds* is a 44-track DVD-Video
+    plus a 16-track CD; the files say "disc 2 of 2, 16 tracks" and stop.
+
+    "Nothing but video" is the whole test, and it is deliberately per-TRACK
+    rather than per-format. `Wish You Were Here 50` is a single Blu-ray carrying
+    45 audio tracks and 4 videos — judging by the medium's format would call the
+    entire album video and expect nothing of it.
+
+    Returns positions, which is what survives: a medium's index in the release is
+    stable in a way its format string is not.
+    """
+    try:
+        result = musicbrainzngs.get_release_by_id(mbid, includes=["media", "recordings"])
+    except musicbrainzngs.ResponseError as e:
+        if _is_not_found(e):
+            raise ReleaseGoneError(f"MusicBrainz no longer has release {mbid}") from e
+        raise MBError(f"MB request failed: {e}") from e
+    except (musicbrainzngs.NetworkError, musicbrainzngs.AuthenticationError) as e:
+        raise MBError(f"MB request failed: {e}") from e
+
+    positions: list[int] = []
+    for medium in result["release"].get("medium-list") or []:
+        tracks = medium.get("track-list") or []
+        if not tracks:
+            continue
+        if all((t.get("recording") or {}).get("video") == "true" for t in tracks):
+            try:
+                positions.append(int(medium.get("position", 0)))
+            except (TypeError, ValueError):
+                continue
+    return tuple(sorted(positions))
+
+
 def fetch_release_urls(mbid: str) -> list[str]:
     """Return the list of URL relationships attached to an MB release.
 

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -228,6 +228,19 @@ class Sidecar:
     # reports the count. Not derivable at any price: it is a decision, with no
     # evidence on disk. Same shape as `purchase_unavailable` one level over.
     tracks_unavailable: bool = False
+    # Which of the release's media hold nothing but video, by position — the one
+    # fact about a release that cannot be read off the files, because a medium
+    # the user never ripped has no files to carry it (#206).
+    #
+    # `None` means "not asked"; `()` means "asked, none are video". The
+    # difference is load-bearing: it is what stops the lookup being repeated
+    # forever on a release that turns out to have no video at all.
+    #
+    # Load-bearing: an album missing ONLY video media derives COMPLETE, since
+    # Harmonist cannot tag video (#66) and telling the user forever that their
+    # CD is missing 44 DVD tracks is noise. A partially-present video medium is
+    # still INCOMPLETE — if you have one video you should have the rest.
+    video_media: tuple[int, ...] | None = None
 
 
 @dataclass
@@ -290,6 +303,10 @@ class Album:
     # anything that needs one name; `paths` is the truth about where it lives,
     # and the album page lists them (#198).
     paths: tuple[Path, ...] = ()
+    # Medium positions with no files of any kind on disk. Scanner-derived from
+    # the tags; drives the bounded MusicBrainz pass that fills `video_media`
+    # (#206), which is the only thing that can say whether their absence matters.
+    absent_media: frozenset[int] = frozenset()
 
     @property
     def folders(self) -> tuple[Path, ...]:

--- a/src/harmonist/reconcile.py
+++ b/src/harmonist/reconcile.py
@@ -33,7 +33,7 @@ from pathlib import Path
 
 from . import album_files, formats, url_recovery
 from . import sidecar as sidecar_mod
-from .models import Sidecar, is_bandcamp_url
+from .models import Album, Sidecar, is_bandcamp_url
 
 log = logging.getLogger(__name__)
 
@@ -243,3 +243,49 @@ def matching_bandcamp_url(
         if is_bandcamp_url(url):
             return url
     return None
+
+
+# ---------------------------------------------------------------------------
+# Video-only media: the one release fact the files cannot carry (#206)
+# ---------------------------------------------------------------------------
+
+
+def needs_video_media(album: Album) -> bool:
+    """True when this album is missing a whole medium and nobody has asked
+    MusicBrainz what was on it.
+
+    Bounded by exactly the albums the answer changes — an album whose media are
+    all present never needs it, which is nearly all of them. That is what makes
+    the lookup affordable where #187's per-album backfill was not.
+    """
+    sc = album.sidecar
+    return bool(
+        album.absent_media
+        and sc is not None
+        and sc.mb_release_id is not None
+        and sc.video_media is None
+    )
+
+
+def record_video_media(
+    album_dir: Path,
+    *,
+    fetch_video_media: Callable[[str], tuple[int, ...]],
+) -> tuple[int, ...] | None:
+    """Ask MusicBrainz which of the release's media are video-only, and record it.
+
+    Returns what was recorded, or None when there was nothing to do. Raises
+    whatever the lookup raises — a failed request must not be written down as
+    "none of them are video", which would silently mark the album incomplete
+    forever on evidence that was never gathered.
+
+    Re-reads the sidecar rather than trusting the caller's snapshot: a scan is
+    minutes old on a large library, and a tag or a re-match in between would
+    make this write clobber a newer one.
+    """
+    sc = sidecar_mod.read(album_dir)
+    if sc is None or sc.mb_release_id is None or sc.video_media is not None:
+        return None
+    positions = fetch_video_media(sc.mb_release_id)
+    sidecar_mod.write(album_dir, replace(sc, video_media=positions))
+    return positions

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -434,7 +434,7 @@ def build_album(album_dir: Path, audio_files: list[Path], io: AlbumIO) -> Album:
     # The sidecar is kept on disk; once the user fixes the on-disk tags
     # via Picard, the next scan re-derives state from the sidecar.
     inconsistent_tracks = _check_consistency(audio_files, fields)
-    expected = expected_tracks(fields, io.video_fields)
+    expected = expected_tracks(fields, io.video_fields, sidecar.video_media if sidecar else None)
     state = (
         AlbumState.INCONSISTENT
         if inconsistent_tracks
@@ -461,6 +461,7 @@ def build_album(album_dir: Path, audio_files: list[Path], io: AlbumIO) -> Album:
         # reconcile for untagged orphans it could never resolve.
         has_tag_mbid=any(sf.album_id for sf in fields),
         expected_track_count=expected.total,
+        absent_media=expected.absent_media,
         paths=tuple(sorted({f.parent for f in audio_files})) or (album_dir,),
     )
 
@@ -481,6 +482,11 @@ class ExpectedTracks(NamedTuple):
 
     total: int | None
     complete: bool
+    # Medium positions with no files of any kind on disk. Knowable from the tags
+    # alone (`disc_total` says how many there are, the discs present say which),
+    # and the input to #206: whether an absent medium MATTERS depends on whether
+    # it was video, which only MusicBrainz can say.
+    absent_media: frozenset[int] = frozenset()
 
 
 # What an album says when its files carry no counts at all. Complete, because
@@ -492,6 +498,7 @@ UNKNOWN_EXPECTED = ExpectedTracks(total=None, complete=True)
 def expected_tracks(
     fields: list[formats.ScanFields],
     video_fields: Sequence[formats.ScanFields] = (),
+    video_media: tuple[int, ...] | None = None,
 ) -> ExpectedTracks:
     """How many tracks the release has, read from the files' own tags (#195).
 
@@ -533,16 +540,27 @@ def expected_tracks(
 
     disc_totals = {f.disc_total for f in present if f.disc_total is not None}
     expected_media = next(iter(disc_totals)) if len(disc_totals) == 1 else len(totals)
-    if len(totals) < expected_media:
-        # A whole medium has no files at all. Certainly incomplete; the total is
-        # not knowable, because the absent disc's length was only ever recorded
-        # in the files that are missing.
-        return ExpectedTracks(total=None, complete=False)
+    absent = frozenset(range(1, expected_media + 1)) - set(totals)
+    if absent:
+        # A whole medium has no files of any kind. Whether that matters depends
+        # on what was ON it, and nothing on disk can say — the files that would
+        # have carried its length are precisely the missing ones (#206).
+        if video_media is not None and absent <= set(video_media):
+            # Every absent medium was video-only. Harmonist cannot tag video
+            # (#66), so a CD the user ripped in full is not "missing 44 tracks"
+            # because they declined the bonus DVD. The album is complete on the
+            # media it has, and its page lists the ones it hasn't.
+            pass
+        else:
+            # An absent medium that is not known to be video — or not asked
+            # about yet. The total is unknowable either way: the absent disc's
+            # length was only ever recorded in the files that are missing.
+            return ExpectedTracks(total=None, complete=False, absent_media=absent)
     if any(t is None for t in totals.values()):
         return UNKNOWN_EXPECTED  # a disc we can't size — don't guess the album's total
 
     total = sum(t for t in totals.values() if t is not None)
-    return ExpectedTracks(total=total, complete=len(present) >= total)
+    return ExpectedTracks(total=total, complete=len(present) >= total, absent_media=absent)
 
 
 def _audio_format(fields: list[formats.ScanFields]) -> str | None:
@@ -631,7 +649,7 @@ def _derive_state(
         # number. `complete` rather than a count comparison, because an album
         # missing an entire medium is knowably incomplete with no total to
         # compare against — see `expected_tracks`.
-        if not expected_tracks(fields, video_fields).complete:
+        if not expected_tracks(fields, video_fields, sidecar.video_media).complete:
             return AlbumState.INCOMPLETE
         # NEEDS_SYNC: Bandcamp-sourced album, MB release known, files tagged,
         # but Bandcamp item_id not yet linked (a Sync run resolves this).

--- a/src/harmonist/sidecar.py
+++ b/src/harmonist/sidecar.py
@@ -266,6 +266,8 @@ def _audit_sidecar_change(album_dir: Path, old: Sidecar | None, new: Sidecar) ->
     the user can't easily undo":
 
       * identity — MBID / Bandcamp item_id / store_url
+      * `video_media` — which media are video-only, so an album missing just
+        those derives COMPLETE rather than INCOMPLETE. Reclassifies the album.
       * `tracks_unavailable` — accepting an incomplete album as finished. Takes
         it out of the Library's Incomplete filter, so changing it reclassifies
         what the user is shown as needing attention.
@@ -310,8 +312,25 @@ def _audit_sidecar_change(album_dir: Path, old: Sidecar | None, new: Sidecar) ->
         changes["purchase_unavailable"] = f"{old.purchase_unavailable}->{new.purchase_unavailable}"
     if old.tracks_unavailable != new.tracks_unavailable:
         changes["tracks_unavailable"] = f"{old.tracks_unavailable}->{new.tracks_unavailable}"
+    if old.video_media != new.video_media:
+        changes["video_media"] = f"{old.video_media}->{new.video_media}"
     if changes:
         audit.record("sidecar.update", album_id=album_id, album=album_dir, **changes)
+
+
+def _int_tuple(raw: object) -> tuple[int, ...] | None:
+    """A stored list of medium positions, or None when the key is absent.
+
+    Absent and empty mean different things here — "never asked" against "asked,
+    none are video" — so a malformed value is treated as absent rather than
+    empty: re-asking is cheap and wrong-but-plausible is not.
+    """
+    if not isinstance(raw, list):
+        return None
+    try:
+        return tuple(int(x) for x in raw)
+    except (TypeError, ValueError):
+        return None
 
 
 def _normalise_identity(s: Sidecar, album_dir: Path) -> Sidecar:
@@ -372,6 +391,10 @@ def _to_dict(s: Sidecar) -> dict[str, Any]:
         d["purchase_unavailable"] = True
     if s.tracks_unavailable:
         d["tracks_unavailable"] = True
+    if s.video_media is not None:
+        # `[]` is meaningful — "asked, none are video" — so it is written, while
+        # the None default (never asked) is omitted like every other default.
+        d["video_media"] = list(s.video_media)
     return d
 
 
@@ -511,6 +534,7 @@ def _from_dict(d: dict[str, Any], source_path: Path) -> Sidecar:
         notes=d.get("notes"),
         purchase_unavailable=bool(d.get("purchase_unavailable", False)),
         tracks_unavailable=bool(d.get("tracks_unavailable", False)),
+        video_media=_int_tuple(d.get("video_media")),
     )
 
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -497,6 +497,7 @@ def create_app(
         reconcile_pending_orphans(
             cfg.paths.music_dir,
             fetch_urls=mb_lookup.fetch_release_urls,
+            fetch_video_media=mb_lookup.fetch_video_media,
             status_updater=status_updater,
             exempt_paths=forgotten_paths,
             albums=snapshot,
@@ -1732,6 +1733,31 @@ def _revertable_anchors(
     for anchor, records in tag_history.group_records(history, detail).items():
         if any(item.fields for item in tag_history.revert_plan(records)):
             out.add(anchor)
+    return out
+
+
+def _absent_media_summary(album: Album, release: Release) -> list[tuple[int, str, int]]:
+    """The release's media that have no files on disk, as (position, format, tracks).
+
+    Read off the release the page has just fetched for its comparison, so it
+    costs nothing extra. The state derivation cannot do this — it runs at scan
+    time with no MusicBrainz — which is exactly why an album missing only video
+    discs needs `sidecar.video_media` recorded to come out COMPLETE (#206).
+    Showing them is the other half: "complete" must not mean "we quietly stopped
+    mentioning two whole discs".
+    """
+    if not album.absent_media:
+        return []
+    out: list[tuple[int, str, int]] = []
+    for medium in release.get("medium-list") or []:
+        try:
+            position = int(medium.get("position", 0))
+        except (TypeError, ValueError):
+            continue
+        if position in album.absent_media:
+            tracks = medium.get("track-list") or []
+            count = len(tracks) or int(medium.get("track-count") or 0)
+            out.append((position, str(medium.get("format") or "Disc"), count))
     return out
 
 
@@ -3143,6 +3169,7 @@ def _register_routes(app: FastAPI) -> None:
             album=album,
             comparison=comparison,
             tracklist=tracks,
+            absent_media=_absent_media_summary(album, release),
             # What the note beside the hexagon reports. Harmonist has just read
             # the release, so "now" is honest — #127's cache is what will make
             # this a genuinely older timestamp worth showing.

--- a/src/harmonist/web/reconcile_runner.py
+++ b/src/harmonist/web/reconcile_runner.py
@@ -181,6 +181,7 @@ def reconcile_pending_orphans(
     music_dir: Path,
     *,
     fetch_urls: Callable[[str], list[str]],
+    fetch_video_media: Callable[[str], tuple[int, ...]] | None = None,
     recover_url: Callable[[Path], str | None] | None = None,
     status_updater: Callable[..., None] | None = None,
     rate_limit_seconds: float = MB_RATE_LIMIT_SECONDS,
@@ -263,6 +264,14 @@ def reconcile_pending_orphans(
     # per-disc directories is made of COMPLETE albums, not of the orphans this
     # pass otherwise exists for, so gating it on `total` would mean it only ever
     # ran on a library that also happened to have something new in it.
+    # Video-only media (#206), before the early return: the albums this applies
+    # to are terminal Library albums missing a whole disc, not orphans.
+    video_checked = (
+        _record_video_media(albums, exempt, fetch_video_media)
+        if fetch_video_media is not None
+        else 0
+    )
+
     if not total:
         # Nothing to do. Reconcile runs on startup and after every sync, so
         # announcing a no-op made it the feed's most frequent content — three
@@ -275,6 +284,7 @@ def reconcile_pending_orphans(
             "reconciled_manual": 0,
             "recovered_url": 0,
             "adopted": 0,
+            "video_checked": video_checked,
             "skipped": 0,
             "errors": 0,
         }
@@ -370,6 +380,61 @@ def reconcile_pending_orphans(
         "reconciled_manual": reconciled_manual,
         "recovered_url": recovered_url,
         "adopted": adopted,
+        "video_checked": video_checked,
         "skipped": skipped,
         "errors": errors,
     }
+
+
+def _record_video_media(
+    albums: list[Album],
+    exempt: set[Path],
+    fetch_video_media: Callable[[str], tuple[int, ...]],
+) -> int:
+    """Ask MusicBrainz which media are video-only, for the albums it changes.
+
+    Bounded to albums missing a WHOLE medium that have not been asked about —
+    knowable from the tags alone, and a small set. An album whose media are all
+    present never needs this, which is nearly all of them. That is the
+    difference from #187's per-album backfill, which was bounded only by library
+    size and cost ~16 minutes on a 958-album library.
+
+    Each answer removes its album from the candidate set permanently, including
+    a negative one: `()` means "asked, none are video", which is why the field
+    distinguishes that from `None`. Without it a release with no video at all
+    would be re-fetched on every pass forever.
+
+    A failure writes nothing and retries next pass — recording "no video media"
+    from a request that never succeeded would silently mark the album incomplete
+    forever on evidence nobody gathered.
+    """
+    from harmonist import reconcile
+
+    pending = [a for a in albums if reconcile.needs_video_media(a) and a.path not in exempt]
+    if not pending:
+        return 0
+
+    activity.record(f"Checking MusicBrainz for video-only discs — {len(pending)} album(s)")
+    checked = 0
+    for album in pending:
+        with activity_store.action():
+            try:
+                positions = reconcile.record_video_media(
+                    album.path, fetch_video_media=fetch_video_media
+                )
+            except Exception as e:
+                # Warning, not exception: on a library-wide pass a stack trace
+                # per unreachable album buries the run, and the next pass retries.
+                log.warning("could not check video media for %s: %s", album.path, e)
+                continue
+            if positions is None:
+                continue
+            checked += 1
+            if positions and album.absent_media <= set(positions):
+                activity.record(
+                    f"Disc(s) {', '.join(str(p) for p in sorted(album.absent_media))} "
+                    "are video-only — no longer counted as missing",
+                    album_id=sidecar.album_id_for(album.path),
+                    album_label=f"{album.artist} — {album.title}".strip(" —"),
+                )
+    return checked

--- a/templates/partials/library_compare.html
+++ b/templates/partials/library_compare.html
@@ -6,6 +6,24 @@
 
    This used to branch on whether `comparison` was in scope, so the same
    fragment could serve a smaller dialog. The dialog is gone (#129). #}
+{# Discs the release has and the disk does not. Shown whether or not they count
+   against completeness (#206): an album missing only video discs derives
+   COMPLETE, and "complete" must not quietly mean "we stopped mentioning two
+   whole discs". A summary, not a track list — the point is what is absent, and
+   naming 44 DVD tracks one by one would bury the album's own tracklist. #}
+{% if absent_media %}
+<div class="mb-3 px-3 py-2 rounded border border-line bg-surface">
+    <p class="text-2xs font-bold text-muted uppercase tracking-widest">Not on disk</p>
+    <ul class="mt-1 space-y-0.5">
+        {% for position, fmt, tracks in absent_media %}
+        <li class="text-2xs text-muted">
+            Disc {{ position }} — {{ fmt }}, {{ tracks }} track{{ 's' if tracks != 1 else '' }}
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
 {% include 'partials/_tag_comparison.html' %}
 
 {# Out-of-band: htmx swaps this into the page's Tracks section rather than

--- a/test/test_video_media.py
+++ b/test/test_video_media.py
@@ -1,0 +1,252 @@
+"""An absent medium that was video shouldn't count against completeness (#206).
+
+The rule, and the word doing the work is *complete*:
+
+    if the missing tracks form one or more COMPLETE missing media, and those
+    tracks are all video, don't mark the album incomplete — show the missing
+    discs on its page instead.
+
+A partly-present video medium stays incomplete, on the principle that if the
+user has one video they should have the rest. That is what separates "I chose
+not to rip the DVD" from "my DVD rip failed halfway".
+
+Real cases from the dogfooded library, with MusicBrainz's actual answers:
+
+    Midnight Oil — Best of Both Worlds  DVD-Video 44 + CD 16     video media (1,)
+    TISM — The White Albun              DVD 22 + CD 16 + DVD 31  video media (1, 3)
+    DJ Shadow — In Tune and on Time     CD 21 + DVD 29           video media (2,)
+    Pink Floyd — Wish You Were Here 50  Blu-ray 49 (45 audio)    video media ()
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from mutagen.mp4 import MP4
+
+from harmonist import reconcile
+from harmonist import sidecar as sidecar_mod
+from harmonist.models import AlbumState, Sidecar
+from harmonist.scanner import scan
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+SINE_M4A = FIXTURES_DIR / "sine.m4a"
+MBID = "11111111-2222-3333-4444-555555555555"
+
+
+def _album(
+    root: Path,
+    *,
+    tracks: int,
+    disc: int,
+    disc_total: int,
+    video_media: tuple[int, ...] | None = None,
+    videos: int = 0,
+    video_disc: int | None = None,
+    video_total: int | None = None,
+) -> Path:
+    """An album holding ONE medium of a multi-disc release, optionally with some
+    of another medium present as video files."""
+    d = root / "Artist" / "Album"
+    d.mkdir(parents=True, exist_ok=True)
+    for i in range(1, tracks + 1):
+        f = d / f"{disc}-{i:02d} Track {i}.m4a"
+        shutil.copy(SINE_M4A, f)
+        a = MP4(f)
+        a["\xa9alb"] = ["Album"]
+        a["\xa9ART"] = ["Artist"]
+        a["trkn"] = [(i, tracks)]
+        a["disk"] = [(disc, disc_total)]
+        a["----:com.apple.iTunes:MusicBrainz Album Id"] = [MBID.encode()]
+        a.save()
+    for i in range(1, videos + 1):
+        f = d / f"{video_disc}-{i:02d} Video {i}.m4v"
+        shutil.copy(SINE_M4A, f)
+        a = MP4(f)
+        a["trkn"] = [(i, video_total or videos)]
+        a["disk"] = [(video_disc, disc_total)]
+        a["----:com.apple.iTunes:MusicBrainz Album Id"] = [MBID.encode()]
+        a.save()
+    sidecar_mod.write(
+        d,
+        Sidecar(
+            mb_release_id=MBID,
+            tagged_at=datetime(2026, 1, 1, tzinfo=UTC),
+            video_media=video_media,
+        ),
+    )
+    return d
+
+
+# ---------------------------------------------------------------------------
+# The rule
+# ---------------------------------------------------------------------------
+
+
+def test_an_absent_video_disc_does_not_make_the_album_incomplete(tmp_path):
+    """Midnight Oil: the CD is complete, the DVD was never ripped and never
+    will be. Being told forever that 44 video tracks are missing is noise."""
+    _album(tmp_path, tracks=16, disc=2, disc_total=2, video_media=(1,))
+
+    album = scan(tmp_path)[0]
+
+    assert album.state == AlbumState.COMPLETE
+    assert album.absent_media == frozenset({1})
+
+
+def test_several_absent_video_discs_are_all_forgiven(tmp_path):
+    """TISM: a CD sandwiched between two DVDs."""
+    _album(tmp_path, tracks=16, disc=2, disc_total=3, video_media=(1, 3))
+
+    album = scan(tmp_path)[0]
+
+    assert album.state == AlbumState.COMPLETE
+    assert album.absent_media == frozenset({1, 3})
+
+
+def test_an_absent_audio_disc_still_makes_the_album_incomplete(tmp_path):
+    """The control that matters most. A half-copied 2-CD set is a real defect."""
+    _album(tmp_path, tracks=12, disc=1, disc_total=2, video_media=())
+
+    album = scan(tmp_path)[0]
+
+    assert album.state == AlbumState.INCOMPLETE
+    assert album.expected_track_count is None, "nothing on disk sizes the absent disc"
+
+
+def test_a_partly_present_video_disc_is_still_incomplete(tmp_path):
+    """DJ Shadow: 26 of the DVD's 29 videos. If you have one video you should
+    have the rest — the medium is not ABSENT, it is short."""
+    # The DVD has 29 tracks; 26 of them are on disk.
+    _album(
+        tmp_path,
+        tracks=21,
+        disc=1,
+        disc_total=2,
+        video_media=(2,),
+        videos=26,
+        video_disc=2,
+        video_total=29,
+    )
+
+    album = scan(tmp_path)[0]
+
+    assert album.absent_media == frozenset(), "disc 2 is present, just incomplete"
+    assert album.state == AlbumState.INCOMPLETE
+
+
+def test_a_fully_present_video_disc_is_complete(tmp_path):
+    """Barking, unchanged by #206: both media on disk."""
+    _album(tmp_path, tracks=9, disc=1, disc_total=2, video_media=(2,), videos=9, video_disc=2)
+
+    assert scan(tmp_path)[0].state == AlbumState.COMPLETE
+
+
+def test_before_musicbrainz_is_asked_the_album_stays_incomplete(tmp_path):
+    """`None` means "not asked". Assuming an absent disc is video would forgive
+    a genuinely missing CD on no evidence at all."""
+    _album(tmp_path, tracks=16, disc=2, disc_total=2, video_media=None)
+
+    album = scan(tmp_path)[0]
+
+    assert album.state == AlbumState.INCOMPLETE
+    assert reconcile.needs_video_media(album), "and it is queued to be asked"
+
+
+# ---------------------------------------------------------------------------
+# The bounded lookup
+# ---------------------------------------------------------------------------
+
+
+def test_only_albums_missing_a_whole_disc_are_asked(tmp_path):
+    """What makes this affordable where #187's per-album backfill was not."""
+    _album(tmp_path, tracks=16, disc=2, disc_total=2)
+    whole = tmp_path / "Artist" / "Whole"
+    whole.mkdir(parents=True)
+    shutil.copy(SINE_M4A, whole / "01 Track.m4a")
+    a = MP4(whole / "01 Track.m4a")
+    a["trkn"] = [(1, 1)]
+    a["disk"] = [(1, 1)]
+    a["----:com.apple.iTunes:MusicBrainz Album Id"] = [b"other-release"]
+    a.save()
+    sidecar_mod.write(whole, Sidecar(mb_release_id="other-release", tagged_at=datetime.now(UTC)))
+
+    pending = [a for a in scan(tmp_path) if reconcile.needs_video_media(a)]
+
+    assert len(pending) == 1
+    assert pending[0].path.name == "Album"
+
+
+def test_recording_the_answer_stops_it_being_asked_again(tmp_path):
+    d = _album(tmp_path, tracks=16, disc=2, disc_total=2)
+    calls: list[str] = []
+
+    def fetch(mbid: str) -> tuple[int, ...]:
+        calls.append(mbid)
+        return (1,)
+
+    first = reconcile.record_video_media(d, fetch_video_media=fetch)
+    second = reconcile.record_video_media(d, fetch_video_media=fetch)
+
+    assert (first, second) == ((1,), None)
+    assert len(calls) == 1
+    assert scan(tmp_path)[0].state == AlbumState.COMPLETE
+
+
+def test_a_negative_answer_is_recorded_too(tmp_path):
+    """`()` means "asked, none are video" — distinct from "not asked". Without
+    that distinction a release with no video would be re-fetched forever."""
+    d = _album(tmp_path, tracks=12, disc=1, disc_total=2)
+
+    reconcile.record_video_media(d, fetch_video_media=lambda m: ())
+
+    assert sidecar_mod.read(d).video_media == ()
+    album = scan(tmp_path)[0]
+    assert album.state == AlbumState.INCOMPLETE
+    assert not reconcile.needs_video_media(album), "asked and answered"
+
+
+def test_a_failed_lookup_records_nothing(tmp_path):
+    """Writing "none are video" from a request that never succeeded would mark
+    the album incomplete forever on evidence nobody gathered."""
+    from harmonist.mb_lookup import MBError
+
+    d = _album(tmp_path, tracks=16, disc=2, disc_total=2)
+
+    def boom(mbid: str) -> tuple[int, ...]:
+        raise MBError("MB is down")
+
+    with pytest.raises(MBError):
+        reconcile.record_video_media(d, fetch_video_media=boom)
+    assert sidecar_mod.read(d).video_media is None
+
+
+def test_the_lookup_re_reads_rather_than_trusting_a_stale_snapshot(tmp_path):
+    d = _album(tmp_path, tracks=16, disc=2, disc_total=2)
+    sidecar_mod.write(d, Sidecar(mb_release_id="moved-on", video_media=(9,)))
+
+    assert reconcile.record_video_media(d, fetch_video_media=lambda m: (1,)) is None
+    assert sidecar_mod.read(d).video_media == (9,)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def test_video_media_round_trips_and_distinguishes_empty_from_absent(tmp_path):
+    import json
+
+    for name, value in (("asked", ()), ("found", (1, 3)), ("unasked", None)):
+        d = tmp_path / name
+        d.mkdir()
+        sidecar_mod.write(d, Sidecar(mb_release_id=MBID, video_media=value))
+        assert sidecar_mod.read(d).video_media == value
+
+    written = json.loads(sidecar_mod.sidecar_path(tmp_path / "unasked").read_text())
+    assert "video_media" not in written, "the default is omitted"
+    asked = json.loads(sidecar_mod.sidecar_path(tmp_path / "asked").read_text())
+    assert asked["video_media"] == [], "but an empty answer is not the default"


### PR DESCRIPTION
A release whose bonus DVD the user never ripped is not missing 44 tracks in any sense they can act on — Harmonist cannot tag video at all (#66) — and being told so forever crowds out the albums where "incomplete" means something.

## The rule

> If the missing tracks form one or more **complete** missing media, **and** those tracks are all video, don't mark the album incomplete. Show the missing discs on its page instead.

The word doing the work is *entirely*. A **partly** present video medium stays Incomplete, on the principle that **if the user has one video they should have the rest** — which separates "I chose not to rip the DVD" from "my rip failed halfway".

## The one release fact the files cannot carry

Midnight Oil's tags say `disc 2 of 2, 16 tracks` and stop. The files that would say what was on disc 1 are precisely the missing ones. So `sidecar.video_media` records it — put through the `sidecar` skill's rule 3 explicitly, and it passes on the point `track_count_expected` failed: **not derivable from disk at any price**.

`None` means "not asked", `()` means "asked, none are video". That distinction is load-bearing twice over: without it a release with no video would be re-fetched on every pass forever, and an unasked album would be forgiven a genuinely missing CD on no evidence at all.

The lookup is **bounded to albums that actually have an absent medium** — knowable from the tags alone, and a small set. That is the difference from #187's per-album backfill, which was bounded only by library size and cost ~16 minutes on 958 albums.

## Video-only is per track, not per format

`Wish You Were Here 50` is a single Blu-ray carrying **45 audio tracks and 4 videos**. Judging by the medium's format would have called the whole album video and expected nothing of it. MusicBrainz confirms the distinction on the real releases: Midnight Oil `(1,)`, TISM `(1, 3)`, DJ Shadow `(2,)`, Pink Floyd `()`.

## Verified through the real derivation

The four real albums, plus two controls:

| Album | total | complete | absent |
| --- | --- | --- | --- |
| Midnight Oil (CD 16/16, DVD absent) | 16 | **yes** | [1] |
| TISM (CD 16/16, 2 DVDs absent) | 16 | **yes** | [1,3] |
| DJ Shadow (CD 21/21, DVD **26/29**) | 50 | no | [] |
| Barking (CD 9/9, DVD 9/9) | 18 | yes | [] |
| *control:* a genuinely absent **audio** disc | — | no | [2] |
| *control:* Pink Floyd WYWH 50 (30 of 45) | 45 | no | [] |

The absent-audio-disc control is **synthetic**, and worth saying so: the obvious real candidate — Hybrid's *Wide Angle* — is not missing a disc at all. Its disc 2 is the sibling folder `Live Angle_ Sydney`, and #197 already merges them into one complete 21-track album.

The album page **lists the absent media regardless**, off the release it has already fetched for its comparison. "Complete" must not quietly mean "we stopped mentioning two whole discs".

The demo-mode enumeration guard added in #187 caught `fetch_video_media` going un-patched the moment it existed — which is exactly what it was written for.

Fixes #206