### PR TITLE
Say when an album's files describe a different release from the one it names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- An album whose files describe a different release from the one it's matched to
+  now says so on its page — tags claiming a single disc against a three-disc
+  release, say. It looks complete because by its own tags it is, so nothing else
+  would have told you (#204).
 - An album is no longer reported as incomplete when the only discs it's missing
   are video — the bonus DVD you never ripped. The album's page lists the discs
   that aren't on disk, so "complete" doesn't quietly mean "we stopped mentioning

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,6 +87,12 @@ purchase it came from. **Sync** links these; that's the common case. If a sync
 can't find the purchase, use **Try a different URL** or **Mark purchased
 elsewhere**.
 
+**Files that describe a different release.** If your tags say the album is a
+single disc while the MusicBrainz release it's matched to has three, the album's
+page says so. It isn't incomplete — by its own tags it's fine — but the tags are
+either stale (**Re-tag from MB** brings them into line) or the release is the
+wrong one (**Wrong MusicBrainz match**). Harmonist won't guess which.
+
 **A release that's vanished from MusicBrainz.** Editors occasionally delete a
 release (usually a duplicate). The album's page says so rather than showing a
 fetch error, and **Find a new release** sends it back to Needs MBID with its

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -307,6 +307,13 @@ class Album:
     # the tags; drives the bounded MusicBrainz pass that fills `video_media`
     # (#206), which is the only thing that can say whether their absence matters.
     absent_media: frozenset[int] = frozenset()
+    # How many media the files say the release has, when they agree on it.
+    # Scanner-derived. Compared against MusicBrainz's actual medium count on the
+    # album page (#204): the files claiming a 1-disc release while the sidecar
+    # names a 3-disc one is a disagreement worth surfacing, and it is invisible
+    # to everything else — the album derives COMPLETE because, by its own tags,
+    # it is.
+    disc_total: int | None = None
 
     @property
     def folders(self) -> tuple[Path, ...]:

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from stat import S_ISREG
 from typing import NamedTuple
@@ -462,8 +462,17 @@ def build_album(album_dir: Path, audio_files: list[Path], io: AlbumIO) -> Album:
         has_tag_mbid=any(sf.album_id for sf in fields),
         expected_track_count=expected.total,
         absent_media=expected.absent_media,
+        disc_total=_consistent(f.disc_total for f in fields if not f.unreadable),
         paths=tuple(sorted({f.parent for f in audio_files})) or (album_dir,),
     )
+
+
+def _consistent(values: Iterable[int | None]) -> int | None:
+    """The single value every file agrees on, or None when they disagree or any
+    lacks it. Files that disagree about the album's own shape are not evidence
+    of anything, so they get no answer rather than a majority one."""
+    seen = set(values)
+    return next(iter(seen)) if len(seen) == 1 and None not in seen else None
 
 
 class ExpectedTracks(NamedTuple):

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1736,6 +1736,31 @@ def _revertable_anchors(
     return out
 
 
+def _shape_mismatch(album: Album, release: Release) -> tuple[int, int] | None:
+    """`(what the files say, what MusicBrainz says)` when they disagree about how
+    many media the release has — else None.
+
+    TISM's *The White Albun* is the case (#204): 16 files tagged `disc 1/1`,
+    against a release MusicBrainz says is a DVD, a CD and another DVD. The album
+    derives COMPLETE because by its own tags it IS complete, and nothing else
+    ever notices — the disagreement is the only evidence, and it is discarded.
+
+    That is not an incompleteness to count. It means the album is tagged against
+    a release its own tags do not describe, which is closer to a mis-tag (#17):
+    either the tags are stale, or the release is the wrong one. Both are the
+    user's call, and both are fixed from this page — Re-tag rewrites the tags
+    from the release, Wrong MusicBrainz match picks a different one.
+
+    Checked here rather than at scan time because it needs the release, and the
+    scan has no MusicBrainz by design. Same discoverability limit as #194: it
+    surfaces when the album is opened, not before.
+    """
+    if album.disc_total is None:
+        return None  # the files do not agree on a shape, so there is none to check
+    media = len(release.get("medium-list") or [])
+    return None if media in (0, album.disc_total) else (album.disc_total, media)
+
+
 def _absent_media_summary(album: Album, release: Release) -> list[tuple[int, str, int]]:
     """The release's media that have no files on disk, as (position, format, tracks).
 
@@ -3170,6 +3195,7 @@ def _register_routes(app: FastAPI) -> None:
             comparison=comparison,
             tracklist=tracks,
             absent_media=_absent_media_summary(album, release),
+            shape_mismatch=_shape_mismatch(album, release),
             # What the note beside the hexagon reports. Harmonist has just read
             # the release, so "now" is honest — #127's cache is what will make
             # this a genuinely older timestamp worth showing.

--- a/templates/partials/library_compare.html
+++ b/templates/partials/library_compare.html
@@ -11,6 +11,23 @@
    COMPLETE, and "complete" must not quietly mean "we stopped mentioning two
    whole discs". A summary, not a track list — the point is what is absent, and
    naming 44 DVD tracks one by one would bury the album's own tracklist. #}
+{# The files describe a release of a different SHAPE from the one the sidecar
+   names (#204). Not an incompleteness — by its own tags the album is complete —
+   but a sign the tags are stale or the release is wrong, and the only evidence
+   either way. Both remedies are on this page already, so this points at them
+   rather than adding a third button. #}
+{% if shape_mismatch %}
+<div class="mb-3 px-3 py-2 rounded border border-amber-300 bg-amber-50">
+    <p class="text-2xs text-amber-900">
+        <strong>These files describe a different release.</strong>
+        Their tags say {{ shape_mismatch[0] }} disc{{ 's' if shape_mismatch[0] != 1 else '' }};
+        this MusicBrainz release has {{ shape_mismatch[1] }}. Either the tags predate a
+        MusicBrainz change — <strong>Re-tag from MB</strong> brings them into line — or this
+        is the wrong release, in which case use <strong>Wrong MusicBrainz match</strong>.
+    </p>
+</div>
+{% endif %}
+
 {% if absent_media %}
 <div class="mb-3 px-3 py-2 rounded border border-line bg-surface">
     <p class="text-2xs font-bold text-muted uppercase tracking-widest">Not on disk</p>

--- a/test/test_video_media.py
+++ b/test/test_video_media.py
@@ -250,3 +250,79 @@ def test_video_media_round_trips_and_distinguishes_empty_from_absent(tmp_path):
     assert "video_media" not in written, "the default is omitted"
     asked = json.loads(sidecar_mod.sidecar_path(tmp_path / "asked").read_text())
     assert asked["video_media"] == [], "but an empty answer is not the default"
+
+
+# ---------------------------------------------------------------------------
+# Files describing a release of a different shape (#204)
+# ---------------------------------------------------------------------------
+
+
+def _release(media: list[int]) -> dict:
+    """A release with `media` giving each medium's track count."""
+    return {
+        "id": MBID,
+        "title": "Album",
+        "artist-credit": [{"artist": {"id": "a", "name": "Artist", "sort-name": "Artist"}}],
+        "release-group": {"id": "rg", "primary-type": "Album"},
+        "medium-list": [
+            {
+                "position": str(i),
+                "format": "CD",
+                "track-list": [
+                    {"id": f"rt-{i}-{n}", "position": str(n), "title": f"T{n}"}
+                    for n in range(1, count + 1)
+                ],
+            }
+            for i, count in enumerate(media, start=1)
+        ],
+    }
+
+
+def test_files_claiming_a_different_shape_are_flagged(tmp_path):
+    """TISM: 16 files tagged `disc 1/1` against a three-medium release. By its
+    own tags the album is complete, so nothing else ever notices."""
+    from harmonist.web.main import _shape_mismatch
+
+    _album(tmp_path, tracks=16, disc=1, disc_total=1)
+    album = scan(tmp_path)[0]
+
+    assert album.state == AlbumState.COMPLETE, "the precondition — it looks fine"
+    assert _shape_mismatch(album, _release([22, 16, 31])) == (1, 3)
+
+
+def test_files_agreeing_with_the_release_are_not_flagged(tmp_path):
+    from harmonist.web.main import _shape_mismatch
+
+    _album(tmp_path, tracks=16, disc=2, disc_total=2)
+    album = scan(tmp_path)[0]
+
+    assert _shape_mismatch(album, _release([44, 16])) is None
+
+
+def test_files_that_disagree_among_themselves_are_not_flagged(tmp_path):
+    """No shape to check against. A majority answer here would be an invention."""
+    from harmonist.web.main import _shape_mismatch
+
+    d = _album(tmp_path, tracks=4, disc=1, disc_total=2)
+    odd = next(iter(sorted(d.glob("*.m4a"))))
+    a = MP4(odd)
+    a["disk"] = [(1, 5)]
+    a.save()
+    album = scan(tmp_path)[0]
+
+    assert album.disc_total is None
+    assert _shape_mismatch(album, _release([4, 4])) is None
+
+
+def test_the_mismatch_is_explained_on_the_album_page(tmp_path):
+    """It points at the two remedies already on the page rather than adding a
+    third button — the fix is the user's call either way."""
+    from harmonist.web.main import _shape_mismatch
+
+    _album(tmp_path, tracks=16, disc=1, disc_total=1)
+    album = scan(tmp_path)[0]
+    mismatch = _shape_mismatch(album, _release([22, 16, 31]))
+
+    assert mismatch == (1, 3)
+    # Rendered by library_compare.html; asserted on the values it renders from.
+    assert mismatch[0] != mismatch[1]


### PR DESCRIPTION
TISM's *The White Albun* is 16 files tagged `disc 1/1`, against a MusicBrainz release that is a DVD, a CD and another DVD — 69 tracks across three media.

The album derives **Complete**, because by its own tags it is: nothing on disk contradicts a 16-track single-disc release. So the disagreement between the two sides is the only evidence anything is wrong, and it was being discarded.

## Not an incompleteness

Which is why #206's rule doesn't reach it. It means the album is tagged against a release its own tags do not describe: either they are stale, or the release is the wrong one. Both are the user's call, and both are already fixable from this page — so this points at **Re-tag from MB** and **Wrong MusicBrainz match** rather than adding a third button.

## The signal is the shape, not the count

The files' `disc_total` against the release's medium count — deliberately **not** the track count, which #206 legitimately makes differ when video media are forgiven.

Checked against every real case; TISM is the only one flagged:

```
TISM               files disc_total=1  MB media=3  -> DISAGREE
Midnight Oil       files disc_total=2  MB media=2  -> agree
Hybrid Wide Angle  files disc_total=2  MB media=2  -> agree
Barking            files disc_total=2  MB media=2  -> agree
Pink Floyd WYWH    files disc_total=1  MB media=1  -> agree
DJ Shadow          files disc_total=2  MB media=2  -> agree
```

Files that disagree among **themselves** about the shape get no answer rather than a majority one — there is no claim to check in that case, and inventing one would flag albums on nothing.

## Where it's detected

On the album page rather than at scan time, because it needs the release and the scan has no MusicBrainz by design. Same discoverability limit as #194: it surfaces when the album is opened, not before.

`Album.disc_total` is scanner-derived and this is its reader — added deliberately a few commits after `Album.disc_num` was removed for having none.

Fixes #204