### PR TITLE
Show the tags when MusicBrainz has lost the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- An album whose MusicBrainz release has been deleted now shows your files' own
+  tags and tracklist, instead of leaving Tracks stuck on "Checking tracks against
+  MusicBrainz…" and Tags refusing to show anything. Those tags are what you'd
+  search on to find the replacement release (#228).
+- A MusicBrainz fetch that fails now says so in both the Tags and Tracks
+  sections, rather than leaving Tracks looking like it's still working (#228).
+
 ## [1.10.0] - 2026-08-21
 
 ### Added

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,7 +99,9 @@ fetch error, and **Find a new release** sends it back to Needs MBID with its
 store link intact — a Recheck usually finds the replacement straight away. Re-tag
 is disabled meanwhile, since there's nothing to re-tag from. Nothing happens
 until you press the button: your files keep their tags, and the album stays in
-the Library if you'd rather deal with it later.
+the Library if you'd rather deal with it later. Tags and Tracks still list what's
+on your files, with no MusicBrainz column beside them — that's what you'll be
+searching on to find the replacement release.
 
 ![The banner shown on such an album: "This release is gone from MusicBrainz — it
 was deleted there, usually because it was a duplicate. Your files are untouched

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -404,6 +404,14 @@ class AlbumComparison:
     """Every field of one album, plus the headline the section needs."""
 
     fields: tuple[FieldComparison, ...] = field(default_factory=tuple)
+    #: Whether there was a MusicBrainz release to compare against at all. False
+    #: for the disk-only view (#228): the tags are still shown — they never
+    #: depended on MusicBrainz — but nothing here was compared, and every field
+    #: lands in ONLY_DISK for want of a counterpart rather than because
+    #: MusicBrainz has nothing to say about it. Without this the summary would
+    #: read "All 7 fields match MusicBrainz" for a release MusicBrainz has
+    #: deleted, since ONLY_DISK is deliberately not a finding.
+    mb_available: bool = True
 
     @property
     def differing(self) -> tuple[FieldComparison, ...]:
@@ -434,6 +442,8 @@ class AlbumComparison:
         "9 of 7 differ", since every field goes UNREADABLE while only seven of
         them were ever comparable.
         """
+        if not self.mb_available:
+            return "No comparison — showing your files' tags"
         fields = self.comparable
         n = len([f for f in fields if f.differs])
         if not fields:
@@ -583,6 +593,10 @@ class TracklistComparison:
     #: The release's media, in position order. Empty for a caller that has none
     #: to give, in which case `discs` falls back to what the tracks say.
     media: tuple[Medium, ...] = field(default_factory=tuple)
+    #: Whether there was a MusicBrainz release to compare against at all — the
+    #: tracklist half of `AlbumComparison.mb_available` (#228). False for the
+    #: disk-only view built by `disk_tracklist`.
+    mb_available: bool = True
 
     @property
     def discs(self) -> tuple[DiscGroup, ...]:
@@ -613,6 +627,9 @@ class TracklistComparison:
         being folded into the count: "3 of 10 tracks differ" is true of an album
         with a dead file, but it isn't what the user needs to be told.
         """
+        if not self.mb_available:
+            n = len(self.tracks)
+            return f"No comparison — showing your {n} track{'s' if n != 1 else ''}"
         if not self.tracks:
             return "Nothing to compare against MusicBrainz"
 
@@ -728,6 +745,35 @@ def tracklist(
             )
         )
     return TracklistComparison(tracks=tuple(rows), media=tuple(media))
+
+
+def disk_tracklist(tracks: Sequence[tuple[str, TrackTags]]) -> TracklistComparison:
+    """The album's own tracks, with no MusicBrainz release to compare them to.
+
+    For a release MusicBrainz has DELETED (#228). The tracks never depended on
+    MusicBrainz — Harmonist read them off the files, and they are still there —
+    so declining to show them drops the wrong half: this is exactly the evidence
+    the user needs to go and find the replacement release.
+
+    Deliberately not `tracklist(tracks, mb=[])`. That reaches a similar shape by
+    a different route, and calls every row EXTRA — "not in MusicBrainz", which
+    is a finding about the track. Nothing here is a finding: MusicBrainz was
+    never asked. The rows are PRESENT with no counterpart, and `mb_available`
+    tells the summary and the template to say so once, at the top.
+    """
+    multi_disc = any((t.disc_num or 1) > 1 for _, t in tracks)
+    rows = [
+        ComparedTrack(
+            TrackState.UNREADABLE if tags.unreadable else TrackState.PRESENT,
+            _track_fields(
+                None if tags.unreadable else tags, None, multi_disc, unreadable=tags.unreadable
+            ),
+            file_name=name,
+            disc=tags.disc_num or 1,
+        )
+        for name, tags in tracks
+    ]
+    return TracklistComparison(tracks=tuple(rows), mb_available=False)
 
 
 def _assign(

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -745,6 +745,27 @@ def _album_comparison(
     )
 
 
+def _album_disk_view(
+    album_dir: Path, paths: Sequence[Path] | None = None
+) -> tuple[compare.AlbumComparison, compare.TracklistComparison]:
+    """The same two halves as `_album_comparison`, from the files ALONE (#228).
+
+    For an album whose MusicBrainz release has been deleted. Both panels used to
+    decline to show anything, which drops the wrong half: the banner says "your
+    files are untouched and still carry its tags" and the page then declines to
+    show them, when those tags are the evidence the user would use to find the
+    replacement release.
+
+    One pass over the files, for the same reason `_album_comparison` makes one.
+    """
+    files = album_files.for_paths(paths) if paths else album_files.audio_files(album_dir)
+    tracks = [(_rel_to(f, album_dir), formats.read_tags(f)) for f in files]
+    return (
+        compare.AlbumComparison(fields=compare.album_fields(tracks, None), mb_available=False),
+        compare.disk_tracklist(tracks),
+    )
+
+
 def _merge_unscoped_audit(events: list[activity.Event], since: datetime) -> list[activity.Event]:
     """Fold audit rows that belong to no action into a page of activity entries,
     newest first (#123).
@@ -3183,26 +3204,39 @@ def _register_routes(app: FastAPI) -> None:
             # Saying "couldn't fetch" would invite the user to try again forever.
             #
             # This is the only place that finds out, so it carries the whole
-            # response to it (#210): the note here, a banner out-of-band, and a
-            # disabled Re-tag out-of-band — nothing behind that button can
-            # succeed. The banner ASKS rather than sending the album to the
-            # inbox: the user may have opened this page for something else.
+            # response to it (#210): the tags here, the tracklist and a banner
+            # out-of-band, and a disabled Re-tag out-of-band — nothing behind
+            # that button can succeed. The banner ASKS rather than sending the
+            # album to the inbox: the user may have opened this page for
+            # something else.
+            #
+            # Both panels still render, from the files alone (#228). MusicBrainz
+            # is gone; the tags are not, and they are what the user needs to go
+            # find the replacement release.
             log.warning(
                 "album %s names release %s, which MusicBrainz no longer has",
                 album.path,
                 sc.mb_release_id,
             )
+            comparison, tracks = _album_disk_view(album.path, album.folders)
             return _templates(request).TemplateResponse(
                 request,
                 "partials/_release_gone.html",
-                _ctx(request, album=album),
+                _ctx(request, album=album, comparison=comparison, tracklist=tracks),
             )
         except mb_lookup.MBError as e:
-            # Escaped: an MBError wraps upstream musicbrainzngs text, so the
-            # message originates off-box and must not reach the DOM as markup.
-            return HTMLResponse(
-                '<p class="text-2xs text-red-700 mt-2">Couldn\'t fetch from '
-                f"MusicBrainz: {html.escape(str(e))}</p>"
+            # A template rather than a bare string so the failure reaches BOTH
+            # halves of the page (#228): the in-band note here settled Tags, and
+            # Tracks was left on its "checking…" placeholder forever, reading as
+            # a request still in flight when this one had already failed.
+            #
+            # Jinja autoescapes `error`, which is what keeps upstream
+            # musicbrainzngs text — off-box, unsanitised — out of the DOM as
+            # markup.
+            return _templates(request).TemplateResponse(
+                request,
+                "partials/_compare_failed.html",
+                _ctx(request, album=album, error=str(e)),
             )
         # No `assess_match` here any more (#135). It re-opened every file in the
         # album for a duration and a title that `_album_comparison` had just

--- a/templates/partials/_compare_failed.html
+++ b/templates/partials/_compare_failed.html
@@ -1,0 +1,22 @@
+{# A MusicBrainz fetch that FAILED — not a release MusicBrainz has deleted.
+
+   The distinction is the whole point: a deleted release is an answer and gets
+   the disk-only view (`_release_gone.html`), but a failed fetch may well
+   succeed on a reload, so it keeps saying so rather than quietly degrading to a
+   view that would look authoritative (#228).
+
+   Two destinations from one response, because the /compare fetch fills both
+   halves of the page: this note in-band in Tags, and its counterpart
+   out-of-band into Tracks. Without the second, the Tracks placeholder sits on
+   "Checking tracks against MusicBrainz…" forever — reading as a request still
+   in flight when the request has in fact already failed, and no other is
+   coming (#228). #}
+<p class="text-2xs text-red-700 mt-2">Couldn't fetch from MusicBrainz: {{ error }}</p>
+
+<section id="album-tracks" hx-swap-oob="true"
+         class="border border-line rounded-lg p-4 space-y-3">
+    <h2 class="text-sm font-bold text-ink uppercase tracking-widest">Tracks</h2>
+    <p class="text-2xs text-red-700">
+        Couldn't fetch from MusicBrainz — reload the page to try again.
+    </p>
+</section>

--- a/templates/partials/_release_gone.html
+++ b/templates/partials/_release_gone.html
@@ -4,9 +4,16 @@
    page cannot know at render time without an MB call, and doing that
    server-side would block the paint on a 1 req/sec budget.
 
-   Three destinations from one response, extending the two the compare fragment
-   already writes to: this note in-band in the Tags section, a banner out-of-band
-   at the top of the page, and a disabled Re-tag out-of-band in the actions row.
+   Four destinations from one response: the Tags section in-band, and
+   out-of-band the Tracks section, a banner at the top of the page, and a
+   disabled Re-tag in the actions row.
+
+   Tags and Tracks both render their real contents, from the files alone (#228).
+   MusicBrainz being gone is not a reason to stop showing the user their own
+   tags — those tags are what they will use to go and find the replacement
+   release, and until this they had to open Picard to see them. "No comparison"
+   is still true, so it stays; it just sits above the values instead of in place
+   of them, which `mb_available` is what tells the two partials to do.
 
    The banner ASKS rather than acts. The album does need an MBID and the inbox is
    where it belongs, but the user may have opened this page for something else
@@ -14,9 +21,17 @@
    interactive case. When periodic background re-scanning lands, detecting this
    with nobody present SHOULD file it automatically — that is a different
    situation, not an inconsistency. #}
-<p class="text-2xs text-muted italic">
-    No comparison — MusicBrainz no longer has this release.
-</p>
+{% include 'partials/_tag_comparison.html' %}
+
+{# Out-of-band into the page's Tracks section, exactly as the success path does
+   — the placeholder there is otherwise never replaced, and no further request
+   is coming, so it claims to be working while the rest of the page has already
+   given the answer (#228). #}
+<section id="album-tracks" hx-swap-oob="true"
+         class="border border-line rounded-lg p-4 space-y-3">
+    <h2 class="text-sm font-bold text-ink uppercase tracking-widest">Tracks</h2>
+    {% include 'partials/_track_list.html' %}
+</section>
 
 <div id="album-alert-{{ album.id }}" hx-swap-oob="true">
     <div class="border border-amber-300 bg-amber-50 rounded-lg p-3 mb-3 flex items-start gap-3">

--- a/templates/partials/_tag_comparison.html
+++ b/templates/partials/_tag_comparison.html
@@ -4,7 +4,13 @@
 
    Deliberately NOT a code diff. Most real differences here are formatting — a
    Bandcamp "A | B" credit against MusicBrainz's join phrases, a featured credit
-   MB keeps out of the title — so nothing is coloured as a mistake. #}
+   MB keeps out of the title — so nothing is coloured as a mistake.
+
+   Also serves the DISK-ONLY view, where there is no MusicBrainz release to
+   compare against because MusicBrainz has deleted it (#228). Every field is
+   then ONLY_DISK, which this already renders as a lone plain line — the
+   degenerate case reached from a different direction, not a second layout. The
+   only branch it needs is `comparison.mb_available`, above. #}
 
 {# The hexagon note: what this section is comparing against, how much differs,
    and when Harmonist last read it. The timestamp answers "is my own MusicBrainz
@@ -21,7 +27,12 @@
         </svg>
     </span>
     <span class="mb-note__legend">{{ comparison.summary }}</span>
+    {# No timestamp when there was nothing to read (#228): "read just now" beside
+       a note saying nothing was compared is a claim about a fetch that returned
+       a 404. The summary already says what happened; the banner says why. #}
+    {% if comparison.mb_available %}
     <span class="mb-note__when">read {{ ago(mb_read_at) }}</span>
+    {% endif %}
 </div>
 
 <dl class="tag-fields">

--- a/templates/partials/_track_list.html
+++ b/templates/partials/_track_list.html
@@ -9,7 +9,12 @@
    the cells that actually differ. Both values keep the same left edge and the
    same column, so a difference is a vertical scan rather than a comparison.
    Same register as the album panel above — most of these are formatting
-   differences, not errors, and nothing is coloured as a mistake. #}
+   differences, not errors, and nothing is coloured as a mistake.
+
+   Also serves the DISK-ONLY view, where MusicBrainz has deleted the release
+   (#228). Every row is then PRESENT with no MusicBrainz counterpart, so
+   `shows_mb` is false throughout and the table renders one plain line per
+   track — no second layout, just the existing one with nothing to stack. #}
 
 {# The hexagon note, matching the album section's. Missing, unreadable and extra
    tracks get their own clause in the summary: they are different problems with

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -26,6 +26,7 @@ from harmonist.compare import (
     compare_field,
     consensus,
     diff_runs,
+    disk_tracklist,
     tracklist,
 )
 from harmonist.formats.types import TagSet, TrackTags
@@ -660,3 +661,56 @@ def test_an_unreadable_file_takes_the_slot_left_free_by_the_numbered_ones():
 
 def test_an_album_with_no_release_to_compare_against_says_so():
     assert tracklist([], []).summary == "Nothing to compare against MusicBrainz"
+
+
+# ---------- the disk-only view: MusicBrainz has deleted the release (#228) ----------
+
+
+def test_a_disk_only_tracklist_shows_the_tracks_without_calling_them_extra():
+    """The tracks never depended on MusicBrainz, so they still render — but
+    nothing here is a finding: MusicBrainz was never asked. `tracklist(t, [])`
+    reaches a similar shape by calling every row EXTRA ("not in MusicBrainz"),
+    which is a claim about the track rather than about the release."""
+    tl = disk_tracklist([_file(1, "Nightcall"), _file(2, "Odd Look")])
+
+    assert [t.state for t in tl.tracks] == [TrackState.PRESENT, TrackState.PRESENT]
+    assert [t.fields[1].disk for t in tl.tracks] == ["Nightcall", "Odd Look"]
+    assert not tl.mb_available
+    assert not any(t.shows_mb for t in tl.tracks), "no MusicBrainz line to draw"
+
+
+def test_a_disk_only_tracklist_says_it_compared_nothing():
+    """The header note is the one place the absence is stated. Left to the
+    default it would have said "All 2 tracks match MusicBrainz"."""
+    assert disk_tracklist([_file(1, "Nightcall"), _file(2, "Odd Look")]).summary == (
+        "No comparison — showing your 2 tracks"
+    )
+    assert disk_tracklist([_file(1, "Nightcall")]).summary == (
+        "No comparison — showing your 1 track"
+    )
+
+
+def test_a_disk_only_tracklist_keeps_the_unreadable_state():
+    """A file that won't open is still a file that won't open — that answer
+    doesn't come from MusicBrainz, so losing it here would report a dead file as
+    a track shown normally."""
+    tl = disk_tracklist([("01 Nightcall.flac", TrackTags(unreadable=True))])
+    (row,) = tl.tracks
+    assert row.state is TrackState.UNREADABLE
+    assert row.file_name == "01 Nightcall.flac"
+
+
+def test_a_disk_only_tracklist_groups_by_the_files_own_discs():
+    tl = disk_tracklist([_file(1, "Nightcall", disc=1), _file(1, "Protovision", disc=2)])
+    assert [g.medium.position for g in tl.discs] == [1, 2]
+
+
+def test_a_disk_only_album_panel_says_it_compared_nothing():
+    """`album_fields(tracks, None)` already leaves every field ONLY_DISK, which
+    is deliberately not a finding — so without `mb_available` the summary read
+    "All 7 fields match MusicBrainz" for a release MusicBrainz has deleted."""
+    fields = album_fields([_file(1, "Nightcall")], None)
+    assert AlbumComparison(fields=fields).summary.startswith("All ")
+    assert AlbumComparison(fields=fields, mb_available=False).summary == (
+        "No comparison — showing your files' tags"
+    )

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6391,7 +6391,8 @@ def test_album_page_explains_a_deleted_release_instead_of_showing_a_404(client, 
     r = client.get(f"/library/{_id_for(cfg, d)}/compare")
 
     assert r.status_code == 200
-    assert "no longer has this release" in r.text
+    assert "It was deleted there" in r.text, "the page says what happened"
+    assert "No comparison" in r.text, "and each panel says it wasn't able to compare"
     assert "404" not in r.text
 
 
@@ -6422,6 +6423,79 @@ def test_a_deleted_release_disables_retag(client, cfg, monkeypatch):
     swapped = r.text.split(f'id="retag-btn-{aid}"')[1].split(">")[0]
     assert "hx-swap-oob" in swapped and "disabled" in swapped
     assert "hx-post" not in swapped, "cannot fire at all, rather than firing and failing"
+
+
+def _gone_album_with_tags(cfg, name="Gone", *, mbid="rel-gone"):
+    """A deleted-release album whose files carry tags worth showing."""
+    d = _make_tagged_album(cfg, name, mbid=mbid, tagged_at=datetime.now(UTC))
+    audio = MP4(d / "01 Track.m4a")
+    audio[ATOM_ALBUM] = ["Silent Season Sampler"]
+    audio[ATOM_TITLE] = ["Drifting Under Ice"]
+    audio.save()
+    return d
+
+
+def test_a_deleted_release_still_shows_the_files_own_tags(client, cfg, monkeypatch):
+    """#228: the banner says the files "still carry its tags", and the page then
+    declined to show them. Those tags are the evidence for finding the
+    replacement release — dropping them sent the user to Picard."""
+    d = _gone_album_with_tags(cfg)
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", _gone)
+
+    r = client.get(f"/library/{_id_for(cfg, d)}/compare")
+
+    assert "Silent Season Sampler" in r.text, "the album's own tags, not an empty note"
+    assert "No comparison — showing your files" in r.text
+    assert "read " not in r.text, "nothing was read from MusicBrainz — don't claim a timestamp"
+
+
+def test_a_deleted_release_settles_the_tracks_placeholder(client, cfg, monkeypatch):
+    """The original #228 symptom: Tracks sat on "Checking tracks against
+    MusicBrainz…" forever, so the one panel still claiming to be working
+    contradicted the three that had already answered."""
+    d = _gone_album_with_tags(cfg)
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", _gone)
+
+    r = client.get(f"/library/{_id_for(cfg, d)}/compare")
+
+    assert 'id="album-tracks" hx-swap-oob="true"' in r.text, "the fourth destination"
+    assert "Drifting Under Ice" in r.text, "the file-derived tracklist"
+    assert "Not in MusicBrainz" not in r.text, "MB was never asked — that's not a finding"
+
+
+def test_a_failed_mb_fetch_settles_the_tracks_placeholder_too(client, cfg, monkeypatch):
+    """Same stuck placeholder, different cause. It must NOT degrade to the
+    disk-only view: a fetch that failed may succeed on a reload, and a view that
+    quietly drops MusicBrainz would look authoritative."""
+
+    def _boom(mbid):
+        raise mb_lookup.MBError("upstream said no")
+
+    d = _gone_album_with_tags(cfg)
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", _boom)
+
+    r = client.get(f"/library/{_id_for(cfg, d)}/compare")
+
+    assert 'id="album-tracks" hx-swap-oob="true"' in r.text
+    assert r.text.count("Couldn't fetch from MusicBrainz") == 2, "both halves settle"
+    assert "reload" in r.text, "retryable, unlike a deleted release"
+    assert "album-alert-" not in r.text, "no deleted-release banner for a transient failure"
+
+
+def test_a_failed_mb_fetch_escapes_the_upstream_message(client, cfg, monkeypatch):
+    """An MBError wraps musicbrainzngs text, which originates off-box and must
+    not reach the DOM as markup."""
+
+    def _boom(mbid):
+        raise mb_lookup.MBError("<script>alert(1)</script>")
+
+    d = _make_tagged_album(cfg, "Boom", mbid="rel-boom", tagged_at=datetime.now(UTC))
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", _boom)
+
+    r = client.get(f"/library/{_id_for(cfg, d)}/compare")
+
+    assert "<script>" not in r.text
+    assert "&lt;script&gt;" in r.text
 
 
 def test_a_healthy_album_gets_no_banner_and_a_live_retag(client, cfg, monkeypatch):


### PR DESCRIPTION
The Tracks section on an album whose MusicBrainz release has been deleted sat on its "Checking tracks against MusicBrainz…" placeholder forever. `GET /library/{id}/compare` fills both halves from one request, and the deleted-release path wrote three destinations — the in-band Tags note, the banner, the disabled Re-tag — but not `#album-tracks`. One panel claimed to be working while the other three had already answered.

Fixing only that would have settled the placeholder on an empty note, which is the wrong half to drop. The banner says "your files are untouched and still carry its tags" and the page then declined to show them — and those tags are exactly the evidence you'd use to go and find the replacement release. Until now the only way to see them was Picard.

## What changed

Both panels render from the files alone. That's cheaper than it sounds: `album_fields(tracks, None)` already leaves every field `ONLY_DISK`, and `_tag_comparison.html` already draws that as a lone plain line — the existing degenerate case, reached from a different direction.

The tracklist needed a builder. `tracklist(tracks, [])` reaches a similar shape but calls every row `EXTRA` — "not in MusicBrainz", which is a finding *about the track* when MusicBrainz was simply never asked. `disk_tracklist` produces `PRESENT` rows with no counterpart instead.

`mb_available` carries the fact to both summaries. Without it they'd read "All 7 fields match MusicBrainz" for a release that no longer exists, since `ONLY_DISK` is deliberately not a finding. It also suppresses the "read just now" timestamp, which would be a claim about a fetch that 404'd.

The `MBError` branch beside it stranded the same placeholder for a different reason, so it gets the same fourth destination — but **not** this view. A fetch that failed may succeed on a reload, and a disk-only view would look authoritative about a question that hasn't been answered yet. It moved to a template so the upstream musicbrainzngs text is escaped by Jinja rather than by hand.

## Verification

`make check` green. Exercised in demo mode on the seeded deleted-release album (*Man of Constant Sorrow*): banner, disabled Re-tag, Tags listing the album's own fields, and Tracks listing both tracks with no MusicBrainz column.

New coverage: five unit tests over `disk_tracklist` / `mb_available` in `test_compare.py`, and four web tests — the tags still showing, the placeholder settling, the `MBError` path settling *without* degrading, and the upstream message staying escaped.

Fixes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016emoJJZvLEb5dw83voQcEW