### PR TITLE
Scan the library through one resolver, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- A re-tag done in Picard is now noticed for real. 1.10.0 announced this, but
+  the background scan dropped the file timestamp it reads, so outside the tests
+  it never fired once (#230).
 - An album whose MusicBrainz release has been deleted now shows your files' own
   tags and tracklist, instead of leaving Tracks stuck on "Checking tracks against
   MusicBrainz…" and Tags refusing to show anything. Those tags are what you'd

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -384,8 +384,8 @@ def prune_cache(album_cache: AlbumCache, seen: set[Path]) -> None:
 class AlbumIO(NamedTuple):
     """Everything for one album that requires blocking filesystem I/O —
     sidecar JSON, each track's tags, and the cover lookup. Produced by
-    `read_album_io` (safe to run in a worker thread: pure I/O, no shared
-    state) and consumed by `build_album` (CPU only, runs on the event loop)."""
+    `read_album_io` and consumed by `build_album` — both safe in a worker
+    thread, neither touching shared mutable state."""
 
     sidecar: Sidecar | None
     fields: list[formats.ScanFields]
@@ -444,8 +444,11 @@ def build_album(
     io: AlbumIO,
     files_written_at: datetime | None = None,
 ) -> Album:
-    """Assemble the Album from pre-read I/O. CPU + id-registry only (no file
-    I/O), so it runs on the event-loop thread where the shared registry lives."""
+    """Assemble the Album from pre-read I/O — CPU only, no file I/O.
+
+    Thread-agnostic: it touches no shared mutable state (an album's id is a hash
+    of its path since #114), so the background scan can build on its worker
+    thread alongside the reads, rather than hopping back to the event loop."""
     sidecar = io.sidecar
     fields = io.fields
     title = (fields[0].album_title if fields else None) or album_dir.name

--- a/src/harmonist/web/scan_runner.py
+++ b/src/harmonist/web/scan_runner.py
@@ -4,12 +4,15 @@ Walks the music dir off the request path and keeps an in-memory snapshot of
 Albums that the web routes serve instantly — so a cold scan of a large library
 over a slow filesystem never blocks `GET /` or `/tasks`.
 
-Single event loop, NO threads. Filesystem I/O (mutagen tag reads, `stat`) is
-inherently blocking — there is no true async fs walk in Python — so the scan
-yields cooperatively (`await asyncio.sleep(0)`) every ~50ms of work, letting
-request handlers interleave between reads. The one residual cost is that a
-single pathologically slow read briefly stalls the loop; that's the trade for
-not using a thread.
+Filesystem I/O (mutagen tag reads, `stat`) is inherently blocking — there is no
+true async fs walk in Python — so it runs on a single dedicated worker thread
+and the loop awaits it one directory at a time. Request handlers interleave
+freely between those awaits, and no read, however slow, stalls the loop.
+
+Each directory is resolved by `scanner.resolve_dir` — the SAME function the
+synchronous `scanner.scan` uses. That is deliberate and load-bearing: this
+module used to inline its body, the two drifted, and the background scan quietly
+stopped stamping the timestamp external-re-tag detection is built on (#230).
 
 The runner is "engaged" once `attach_loop()` runs (from the FastAPI lifespan).
 Until then — e.g. in unit tests that build a TestClient without the lifespan —
@@ -87,11 +90,16 @@ class ScanRunner:
         # backend-side so it runs without waiting for the frontend /tasks poll.
         self._on_first_complete: Callable[[], object] | None = None
         # A SINGLE worker thread runs all the scan's blocking filesystem I/O
-        # (walk/stat + tag reads), so the event loop never blocks on syscalls.
-        # One worker keeps reads serial → no parallel-I/O concurrency, and the
-        # worker functions are pure (no shared state), so the only hand-off is
-        # arg-in/result-out via the executor's Future. All mutable state (cache,
-        # snapshot, status, id registry) is touched only on the loop thread.
+        # (walk/stat + tag reads) AND the album build that follows it, so the
+        # event loop never blocks on syscalls. One worker keeps reads serial →
+        # no parallel-I/O concurrency, and the loop awaits each hand-off, so the
+        # two threads are never inside the resolver at once.
+        #
+        # The mtime cache is the one piece of mutable state the worker touches:
+        # `scanner.resolve_dir` reads and writes it there. That is the same
+        # sharing `scan_now` already relies on from FastAPI's threadpool — a
+        # dict, GIL-atomic per entry, worst case a redundant re-read of one
+        # album. The snapshot and the status stay loop-thread-only.
         self._executor: ThreadPoolExecutor | None = None
 
     # ----- engagement (lifespan) -----
@@ -245,28 +253,19 @@ class ScanRunner:
                 "tuple[Path, list[Path], list[Path], scanner.AlbumSignature]", item
             )
             status.dirs_scanned += 1
-            try:
-                cached = self._cache.get(album_dir)
-                if cached is not None and cached[0] == signature:
-                    album, io = cached[1], cached[2]  # full-signature hit → zero I/O
-                else:
-                    # Audio unchanged (only the sidecar/cover moved)? Reuse the
-                    # cached tag fields so the worker skips the per-track mutagen
-                    # reads (the expensive part) and re-reads only the cheap
-                    # sidecar + cover. This is what keeps a post-sync/reconcile
-                    # rescan fast even though every linked album's sidecar changed.
-                    reuse = None
-                    if cached is not None and cached[0][0] == signature[0]:
-                        reuse = cached[2].fields  # audio unchanged → skip the tag reads
-                    io = await loop.run_in_executor(
-                        executor, scanner.read_album_io, album_dir, files, videos, reuse
-                    )
-                    album = scanner.build_album(album_dir, files, io)  # CPU, on loop
-                    self._cache[album_dir] = (signature, album, io)
-                scanned.append(scanner.ScannedDir(album, files, io))
+            # The SAME resolver the synchronous scan uses — cache lookup, tag
+            # reuse and build in one call, on the worker thread. Inlining its
+            # body here instead let the two drift, and the background scan
+            # silently stopped stamping `files_written_at`, which is the whole
+            # of external-re-tag detection (#230). One resolver, no drift.
+            # It swallows a bad album itself (logging it) and returns None, so
+            # one unreadable directory still can't abort the scan.
+            entry = await loop.run_in_executor(
+                executor, scanner.resolve_dir, album_dir, files, videos, signature, self._cache
+            )
+            if entry is not None:
+                scanned.append(entry)
                 status.albums_found = len(scanned)
-            except Exception as e:  # one bad album must not abort the scan
-                log.warning("error scanning %s: %s", album_dir, e)
 
             now = time.monotonic()
             if now - last_log >= _LOG_INTERVAL_S:

--- a/test/test_external_retag.py
+++ b/test/test_external_retag.py
@@ -10,6 +10,7 @@ Harmonist noticed only as "library settled after change — requesting rescan".
 
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 from datetime import UTC, datetime, timedelta
@@ -23,6 +24,7 @@ from harmonist import sidecar as sidecar_mod
 from harmonist.models import Sidecar
 from harmonist.scanner import scan
 from harmonist.web.reconcile_runner import reconcile_pending_orphans
+from harmonist.web.scan_runner import ScanRunner
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 SINE_M4A = FIXTURES_DIR / "sine.m4a"
@@ -193,3 +195,46 @@ def test_the_notice_names_the_album(tmp_path, audit_db):
 
     labels = [e.album_label for e in activity_store.recent(50) if e.album_label]
     assert "Artist — Album" in labels
+
+
+# ---------------------------------------------------------------------------
+# Through the background scan (#230)
+# ---------------------------------------------------------------------------
+#
+# Everything above scans via `scanner.scan()`. Production does not: it reads the
+# snapshot the background `ScanRunner` builds, which inlined a stale copy of
+# `resolve_dir` and never stamped `files_written_at` — so detection was dead in
+# the field while this file stayed green. These go through the runner.
+
+
+async def _scan_via_runner(runner: ScanRunner) -> None:
+    runner.attach_loop()
+    for _ in range(300):
+        if runner.has_completed():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("background scan never completed")
+
+
+def test_the_background_scan_notices_it_too(tmp_path):
+    """The snapshot reconcile actually reads is the background runner's, so a
+    re-tag has to be visible in THAT album, not just in a synchronous scan."""
+    _album(tmp_path, tagged_at=datetime.now(UTC) - timedelta(days=30), files_at=datetime.now(UTC))
+    runner = ScanRunner(tmp_path)
+
+    asyncio.run(_scan_via_runner(runner))
+
+    assert reconcile.looks_externally_retagged(runner.albums()[0])
+
+
+def test_the_background_scans_cache_does_not_poison_the_sync_path(tmp_path):
+    """Both paths share one mtime cache, so an album built without its timestamp
+    doesn't just break the background scan — `scan_now()` hands the very same
+    object back on a signature hit, and inherits the blindness."""
+    _album(tmp_path, tagged_at=datetime.now(UTC) - timedelta(days=30), files_at=datetime.now(UTC))
+    runner = ScanRunner(tmp_path)
+
+    asyncio.run(_scan_via_runner(runner))  # populates the shared cache
+    albums = runner.scan_now()  # cache hit — returns what the scan built
+
+    assert reconcile.looks_externally_retagged(albums[0])


### PR DESCRIPTION
#220's external-re-tag detection never fired in production. An album re-tagged in Picard, release unchanged, still derived COMPLETE and the change passed in silence — precisely the case #220 was opened to catch.

`ScanRunner._scan_once` inlined the body of `scanner.resolve_dir` rather than calling it, and the two drifted: the resolver builds the album as `build_album(dir, files, io, _written_at(signature))`, the runner as `build_album(dir, files, io)`. Three arguments, so `files_written_at` took its `None` default — and `looks_externally_retagged` short-circuits on exactly that. `_written_at` had one caller, and it was the one the background scan didn't use.

It contaminated the synchronous path too. `_scan_once` writes what it built into `self._cache`, and `scan_now()` is `scanner.scan(music_dir, album_cache=self._cache)` — the *same* cache. On a signature hit `resolve_dir` returns the cached album without rebuilding, so once the background scan had run, the sync path served albums built without the timestamp as well.

Which is also why the suite stayed green: every test in `test_external_retag.py` called `scanner.scan()` with a cache-less scan, and so never met a poisoned entry.

## The fix

Call `resolve_dir`, so there is one resolver and nothing left to drift. It is synchronous and does its I/O inline, so it goes through the executor whole — the build lands on the worker thread with the reads.

That is safe now in a way the old comments no longer described: an album's id has been a hash of its path since #114, so `build_album` touches no shared mutable state, and the mtime cache the resolver reads and writes there is already shared with FastAPI's threadpool via `scan_now`. The stale docstrings claiming otherwise — including a module header still promising "Single event loop, NO threads" — are corrected rather than left to mislead the next reader.

The runner's own `try/except` goes with the inlined body: `resolve_dir` already catches its failures and returns `None`, and it distinguishes a bad sidecar from an I/O error where the inline version logged both the same way.

## Tests

Two, both through `ScanRunner` rather than `scanner.scan()` — the absence of which is what let this ship. One asserts on the snapshot reconcile actually reads; one on `scan_now()` after the background scan has warmed the shared cache, which is the half of the bug a runner-only test would still have missed. Both fail on the old code with `files_written_at=None`.

## Worth knowing on upgrade

This is the first time #220's detection will fire on a real library. `_adopt_external_retags` records one activity entry per album, so if anything ever rewrote files after Harmonist tagged them — an old bulk Picard pass — the first reconcile after this lands posts a batch at once. Working as designed, self-clearing after one pass, but it will look like a flood rather than a correction.

Fixes #230