### PR TITLE
Assign files to tracks by the id that names the track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Your files are now lined up against MusicBrainz by the per-track id they
+  carry, so an album still stays on its own tracks after MusicBrainz renumbers
+  or reorders the release's discs — where before a whole CD could be compared
+  against a bonus DVD's tracks and reported as missing (#232).
+- Re-tagging an album that's missing tracks no longer picks which track a file
+  is by comparing durations, which could give one file another track's title
+  and ids (#232).
+
 - An album page now lists the video files on disk instead of reporting a
   part-ripped DVD as a disc you don't have at all. They're marked as video and
   not compared against MusicBrainz — Harmonist reads their tags, never writes

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -26,7 +26,7 @@ inventing an answer.
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Sequence
+from collections.abc import Callable, Hashable, Sequence
 from dataclasses import dataclass, field, replace
 from difflib import SequenceMatcher
 from enum import StrEnum
@@ -805,59 +805,152 @@ def disk_tracklist(tracks: Sequence[tuple[str, TrackTags]]) -> TracklistComparis
     return TracklistComparison(tracks=tuple(rows), mb_available=False)
 
 
+@dataclass(frozen=True)
+class TrackIdentity:
+    """What a file — or a MusicBrainz track — says about which track it is.
+
+    The three things either side can offer, in descending order of how much they
+    are worth. Deliberately a value with no tags, no paths and no MusicBrainz
+    dicts in it: the ladder below is the same question for the album page and
+    for the tagger, and they must not be able to answer it differently (#232).
+    """
+
+    release_track_id: str | None = None
+    disc: int | None = None
+    track: int | None = None
+
+    @classmethod
+    def of_tagset(cls, tags: TagSet) -> TrackIdentity:
+        """The identity of a MusicBrainz track, as tagging would write it."""
+        return cls(tags.mb_release_track_id, tags.disc_num, tags.track_num)
+
+
+def identity_of(tags: TrackTags) -> TrackIdentity:
+    """The identity one file claims for itself.
+
+    An unreadable file claims nothing: it has no tags to read (#112), which is
+    not the same as a readable file that carries no numbers, and inventing
+    (disc 1, track None) for it would be a claim it never made.
+    """
+    if tags.unreadable:
+        return TrackIdentity()
+    return TrackIdentity(tags.release_track_id, tags.disc_num, tags.track_num)
+
+
+def _by_release_track_id(identity: TrackIdentity) -> Hashable | None:
+    return identity.release_track_id
+
+
+def _by_number(identity: TrackIdentity) -> Hashable | None:
+    # Paired with the disc, because track 4 exists on both halves of a 2-CD
+    # release. A file that names no track names nothing.
+    return None if identity.track is None else (identity.disc or 1, identity.track)
+
+
+#: The ladder, best rung first. Each is tried for every file before the next is
+#: tried for any — so one file's missing id can't cost another file its own.
+_RUNGS: tuple[Callable[[TrackIdentity], Hashable | None], ...] = (
+    _by_release_track_id,
+    _by_number,
+)
+
+
+def assign(files: Sequence[TrackIdentity], tracks: Sequence[TrackIdentity]) -> list[int | None]:
+    """Which MusicBrainz track each file is: the index of its track, or None.
+
+    **By the release track id first — the one rung that is not a guess** (#232).
+    That id names one position in one release, Harmonist writes it on every
+    track it tags, and Picard writes the same. For anything either has touched,
+    this is a lookup.
+
+    Nothing else here can say that. TISM's *The White Albun* was tagged when
+    MusicBrainz's release held only its CD; MusicBrainz later added two DVDs and
+    moved the CD to position 2, and every one of those files — still correctly
+    saying disc 1 — then keyed onto a video track, so a complete CD read as
+    sixteen tracks that all differed and a disc that wasn't on disk. The ids in
+    those same files named their true slots exactly, and Picard used them to
+    re-file the album without being asked.
+
+    Then, for files carrying no id — an adopted album Harmonist has never
+    tagged — **the disc-and-track number**, trusted only where it is
+    unambiguous: unique among the files, unique among MusicBrainz's tracks.
+
+    Then **file order**, for whatever is left: files with no numbers, duplicate
+    numbers, numbers MusicBrainz doesn't have, and unreadable files. An album
+    with no numbers anywhere therefore behaves exactly as positional pairing
+    always did.
+
+    The last two rungs are guesses and can be wrong — a file mis-numbered as
+    track 1 when it is really track 2 is compared against the wrong track, and
+    so is the one it displaced. #136 is the escape hatch, letting the user say
+    which track a file actually is. The first rung is what removes most albums
+    from needing it at all.
+
+    There is deliberately no length-similarity rung. A duration is not an
+    identity: two recordings of the same length are common on one release, the
+    odds get worse the longer the release, and being wrong writes another
+    track's title and ids into the file with nothing on the page to show for it.
+    """
+    out: list[int | None] = [None] * len(files)
+    taken: set[int] = set()
+
+    for rung in _RUNGS:
+        slot_of = _unique_slots(tracks, rung)
+        claims = Counter(k for k in (rung(f) for f in files) if k is not None)
+        for i, identity in enumerate(files):
+            if out[i] is not None:
+                continue
+            key = rung(identity)
+            # Two files claiming one key are two copies of a track, or a
+            # mis-tag; either way the claim isn't unique and settles nothing.
+            if key is None or claims[key] != 1:
+                continue
+            slot = slot_of.get(key)
+            if slot is None or slot in taken:
+                continue
+            out[i] = slot
+            taken.add(slot)
+
+    free = iter([i for i in range(len(tracks)) if i not in taken])
+    for i, slot in enumerate(out):
+        if slot is None:
+            out[i] = next(free, None)
+    return out
+
+
+def _unique_slots(
+    tracks: Sequence[TrackIdentity], rung: Callable[[TrackIdentity], Hashable | None]
+) -> dict[Hashable, int]:
+    """MusicBrainz's side of one rung, keeping only the keys it answers once.
+
+    A key MusicBrainz repeats identifies nothing, so it is dropped rather than
+    resolved to its first holder — the ambiguity is the finding.
+    """
+    keys = [rung(t) for t in tracks]
+    counts = Counter(k for k in keys if k is not None)
+    return {k: i for i, k in enumerate(keys) if k is not None and counts[k] == 1}
+
+
 def _assign(
     tracks: Sequence[tuple[str, TrackTags]],
     mb: Sequence[MBTrack],
 ) -> tuple[dict[int, tuple[str, TrackTags]], list[tuple[str, TrackTags]]]:
-    """Decide which file is which MusicBrainz track.
-
-    **By the file's own track number first, by file order only as a fallback.**
-    Position alone is what the matcher uses, and it is wrong the moment anything
-    is absent: one missing track three shifts every later file up a slot, and
-    the page then reports the whole rest of the album as differing — the
-    crying-wolf failure the comparison exists to avoid.
-
-    A number is only trusted when it is unambiguous: unique among the files,
-    unique among MusicBrainz's tracks, and paired with the disc, because track 4
-    exists on both halves of a 2-CD release. Everything left over — files with
-    no number, duplicate numbers, numbers MusicBrainz doesn't have, and
-    unreadable files, which have no tags to read at all — is dealt into the
-    slots still free, in file order. An album with no track numbers anywhere
-    therefore behaves exactly as positional pairing always did.
-
-    It is still a guess, and it trusts the tag: a file mis-numbered as track 1
-    when it is really track 2 will be compared against the wrong track, and so
-    will the one it displaced. The page has no way to say "these two are
-    swapped", only that both disagree. #136 is the escape hatch — letting the
-    user re-assign a file to the track it actually is.
+    """Decide which file is which MusicBrainz track — see `assign`.
 
     Returns `{mb_index: (file_name, tags)}` and the files that found no slot.
     """
-    mb_keys = [(t.tags.disc_num or 1, t.tags.track_num) for t in mb]
-    mb_counts = Counter(mb_keys)
-    slot_of: dict[tuple[int, int], int] = {
-        key: i for i, key in enumerate(mb_keys) if mb_counts[key] == 1
-    }
-
-    keyed: list[tuple[int, int] | None] = [
-        (t.disc_num or 1, t.track_num) if t.track_num is not None and not t.unreadable else None
-        for _, t in tracks
-    ]
-    file_counts = Counter(k for k in keyed if k is not None)
-
+    slots = assign(
+        [identity_of(t) for _, t in tracks],
+        [TrackIdentity.of_tagset(t.tags) for t in mb],
+    )
     assigned: dict[int, tuple[str, TrackTags]] = {}
     leftover: list[tuple[str, TrackTags]] = []
-    for (name, tags), key in zip(tracks, keyed, strict=True):
-        slot = slot_of.get(key) if key is not None and file_counts[key] == 1 else None
-        if slot is None or slot in assigned:
-            leftover.append((name, tags))
+    for entry, slot in zip(tracks, slots, strict=True):
+        if slot is None:
+            leftover.append(entry)
         else:
-            assigned[slot] = (name, tags)
-
-    free = [i for i in range(len(mb)) if i not in assigned]
-    for slot, entry in zip(free, leftover, strict=False):
-        assigned[slot] = entry
-    return assigned, leftover[len(free) :]
+            assigned[slot] = entry
+    return assigned, leftover
 
 
 def _track_fields(

--- a/src/harmonist/formats/_vorbis.py
+++ b/src/harmonist/formats/_vorbis.py
@@ -300,6 +300,7 @@ class VorbisTagger:
             disc_num=_first_int(disc_num),
             duration_ms=duration,
             comment=first(KEY_COMMENT),
+            release_track_id=first(KEY_RELEASE_TRACK_ID),
         )
 
     def read_cover(self, path: Path) -> tuple[bytes, str] | None:

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -241,6 +241,7 @@ def read_tags(path: Path) -> TrackTags:
         disc_num=disk[0][0] if disk and disk[0] else None,
         duration_ms=int(audio.info.length * 1000) if audio.info else None,
         comment=_text_atom(audio, ATOM_COMMENT),
+        release_track_id=_binary_atom_str(audio, ATOM_MB_RELEASE_TRACK_ID),
     )
 
 

--- a/src/harmonist/formats/mp3.py
+++ b/src/harmonist/formats/mp3.py
@@ -234,6 +234,7 @@ def read_tags(path: Path) -> TrackTags:
         disc_num=_first_int(_text(tags, "TPOS")),
         duration_ms=round(audio.info.length * 1000) if audio.info.length else None,
         comment=_comment_text(tags),
+        release_track_id=_txxx(tags, TXXX_RELEASE_TRACK_ID),
     )
 
 

--- a/src/harmonist/formats/types.py
+++ b/src/harmonist/formats/types.py
@@ -169,6 +169,20 @@ class TrackTags:
     #: no counterpart and it must never be rendered as a difference.
     comment: str | None = None
 
+    #: This track's `MusicBrainz Release Track Id` — the id of one position in
+    #: one release, unlike the recording id, which a release can repeat.
+    #:
+    #: What says WHICH track a file is (#232). Harmonist writes it on every
+    #: track it tags and Picard writes the same, so for anything either has
+    #: touched, "which MusicBrainz track is this file?" is a lookup and not a
+    #: guess — where disc-and-track numbers are a guess the moment MusicBrainz
+    #: renumbers a release's media, and a duration is a guess always.
+    #:
+    #: Already read into `ScanFields` for a different question (#197: two parts
+    #: of a release, or two copies of one). This is the same atom, read on the
+    #: comparison's pass instead of the scanner's.
+    release_track_id: str | None = None
+
     #: Read from a video file, which Harmonist can read but never write (#66).
     #: Not a tag — a property of the read, like `unreadable`, and here for the
     #: same reason: the tracklist has to say something different about this row

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, runtime_checkable
 
-from . import activity_store, album_files, artwork_store, audit, formats, tag_history
+from . import activity_store, album_files, artwork_store, audit, compare, formats, tag_history
 from . import sidecar as sidecar_mod
 from .formats import TagSet, owned
 from .formats.m4a import (  # noqa: F401 — back-compat re-exports
@@ -647,13 +647,7 @@ def _build_tagset(
     rg = release.get("release-group") or {}
 
     track_total = len(medium.get("track-list", []))
-
-    disc_num = 1
-    if "position" in medium:
-        try:
-            disc_num = int(medium["position"])
-        except (TypeError, ValueError):
-            disc_num = 1
+    disc_num = _disc_num(medium)
 
     return TagSet(
         mb_album_id=release["id"],
@@ -697,47 +691,48 @@ def _assign_files_to_tracks(
     files: list[Path],
     flat_tracks: list[_FlatTrack],
 ) -> list[tuple[Path, _FlatTrack]]:
-    """Best-fit assignment of files to a subset of MB tracks via length
-    similarity, preserving input file order.
+    """Which MusicBrainz track each file is, for an album missing some of them.
 
-    Falls back to positional matching when any file or track length is
-    unknown — the simpler choice is more predictable without enough data.
+    Through `compare.assign` — the same ladder the album page uses, so a file
+    cannot be one track in the tracklist and a different one in the tagger
+    (#232). Release track id, then disc-and-track number, then file order.
+
+    This used to assign by **length similarity**, which is why it is worth
+    saying what changed: on *TISM — The White Albun* that rule bound
+    `Sorted for D 'n M.m4a` to a DVD track called *Diatribe*, one file in
+    sixteen, and would have written that track's title and ids into it. The
+    file's own tags named its real slot the whole time and were never read.
+    Fifteen right out of sixteen is the worst available outcome — nobody
+    re-checks an album that looks mostly correct.
+
+    Costs one open per file, as reading their durations did.
     """
-    file_durations: list[int | None] = [formats.read_duration_ms(f) for f in files]
+    identities = [compare.identity_of(formats.read_tags(f)) for f in files]
+    slots = compare.assign(identities, [_identity_of(t) for t in flat_tracks])
+    # A file with no slot is not tagged at all. It can only happen with more
+    # files than tracks, which the caller has already refused (§15.3) — but
+    # leaving one alone beats writing another track's metadata into it.
+    return [(f, flat_tracks[s]) for f, s in zip(files, slots, strict=True) if s is not None]
 
-    track_lengths: list[int | None] = []
-    for _medium, _pos, track in flat_tracks:
-        # Per-release track length is authoritative; recording length can
-        # differ by seconds across releases (see match._mb_track_length_ms).
-        raw = track.get("length") or (track.get("recording") or {}).get("length")
-        try:
-            track_lengths.append(None if raw is None else int(raw))
-        except (TypeError, ValueError):
-            track_lengths.append(None)
 
-    if any(t is None for t in track_lengths) or any(d is None for d in file_durations):
-        # Positional fallback — first N tracks; the rest are "missing"
-        # and get no file assigned.
-        return [(files[i], flat_tracks[i]) for i in range(len(files))]
+def _identity_of(flat: _FlatTrack) -> compare.TrackIdentity:
+    """One MusicBrainz track's identity, exactly as tagging would write it —
+    `_build_tagset` derives the same disc from the medium and the same track
+    number from the position."""
+    medium, track_pos, track = flat
+    return compare.TrackIdentity(track.get("id"), _disc_num(medium), track_pos + 1)
 
-    used: set[int] = set()
-    pairs: list[tuple[Path, _FlatTrack]] = []
-    for f, dur in zip(files, file_durations, strict=True):
-        # The guard above guarantees every duration/length is set here.
-        assert dur is not None
-        best_idx = None
-        best_delta: int | None = None
-        for i, tlen in enumerate(track_lengths):
-            if i in used or tlen is None:
-                continue
-            delta = abs(dur - tlen)
-            if best_delta is None or delta < best_delta:
-                best_idx = i
-                best_delta = delta
-        assert best_idx is not None
-        used.add(best_idx)
-        pairs.append((f, flat_tracks[best_idx]))
-    return pairs
+
+def _disc_num(medium: dict[str, Any]) -> int:
+    """Which disc this medium is. 1 when MusicBrainz doesn't say, or says
+    something that isn't a number — a single-medium release often has no
+    position at all."""
+    if "position" not in medium:
+        return 1
+    try:
+        return int(medium["position"])
+    except (TypeError, ValueError):
+        return 1
 
 
 def _flatten_tracks(release: Release) -> Iterator[_FlatTrack]:

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -701,21 +701,83 @@ def test_tag_album_incomplete_uses_positional_fallback_without_lengths(
     assert _atom_str(audio, ATOM_MB_TRACK_ID) == "rec-001"
 
 
-def test_tag_album_incomplete_uses_length_similarity_when_available(
-    album_with_tracks,
-):
-    """The sine.m4a fixture is ~1000ms long. If MB track lengths differ
-    sharply, the assignment should pick the closest match — not positional.
+def test_tag_album_incomplete_ignores_length_similarity(album_with_tracks):
+    """Length is not an identity (#232).
+
+    The sine.m4a fixture is ~1000ms. Track 1 is 10s and track 2 is 1s, so the
+    old rule assigned this file to track 2 on the strength of its duration —
+    against a file that says nothing about which track it is, where file order
+    is the only thing on offer that isn't invention. Two tracks of one length
+    are ordinary on a real release, and being wrong here writes another track's
+    title and ids into the file.
     """
     album_dir = album_with_tracks(1)
     release = _release_2_tracks()
-    # Track 0 wildly mismatched (10s); track 1 matches (1s) — incomplete-mode
-    # should pick track 1 even though positional would have picked track 0.
     release["medium-list"][0]["track-list"][0]["recording"]["length"] = "10000"
     release["medium-list"][0]["track-list"][1]["recording"]["length"] = "1000"
+
     tagger.tag_album(album_dir, release, incomplete=True)
+
     audio = MP4(album_dir / "01 Track 1.m4a")
-    assert _atom_str(audio, ATOM_MB_TRACK_ID) == "rec-002"
+    assert _atom_str(audio, ATOM_MB_TRACK_ID) == "rec-001"
+
+
+def test_tag_album_incomplete_is_idempotent(album_with_tracks):
+    """Twice is the same as once, across the rung change that the first run
+    causes: the file starts with no id and is placed by file order, the tagging
+    writes that slot's id into it, and the second run then reads the id and
+    reaches the same slot by a different rung.
+
+    (Which also means a placement the user disagrees with is now written down
+    rather than re-derived. #136 is where overruling it belongs — it does not
+    become harder to correct, but it does become explicit.)
+    """
+    album_dir = album_with_tracks(1)
+    release = _release_2_tracks()
+
+    tagger.tag_album(album_dir, release, incomplete=True)
+    first = dict(MP4(album_dir / "01 Track 1.m4a"))
+    tagger.tag_album(album_dir, release, incomplete=True)
+
+    assert dict(MP4(album_dir / "01 Track 1.m4a")) == first
+
+
+def test_tag_album_incomplete_assigns_by_release_track_id(album_with_tracks):
+    """A file that already names its slot is tagged as that slot, wherever it
+    sits in the folder — the rung that isn't a guess.
+
+    Positional would call this file track 1; it says it is track 2, in the only
+    terms that can't be argued with, and it is the only file present.
+    """
+    album_dir = album_with_tracks(1)
+    f = album_dir / "01 Track 1.m4a"
+    audio = MP4(f)
+    audio[ATOM_MB_RELEASE_TRACK_ID] = [b"rt-002"]
+    audio.save()
+
+    tagger.tag_album(album_dir, _release_2_tracks(), incomplete=True)
+
+    tagged = MP4(f)
+    assert _atom_str(tagged, ATOM_MB_TRACK_ID) == "rec-002"
+    assert tagged[ATOM_TITLE][0] == "Track 2"
+
+
+def test_tag_album_incomplete_prefers_the_id_over_the_number(album_with_tracks):
+    """The TISM case, in miniature: the file's disc/track numbers are stale
+    because MusicBrainz renumbered the release, and its id is not. The id wins,
+    so the numbers get corrected instead of deciding where the file goes."""
+    album_dir = album_with_tracks(1)
+    f = album_dir / "01 Track 1.m4a"
+    audio = MP4(f)
+    audio[ATOM_MB_RELEASE_TRACK_ID] = [b"rt-002"]
+    audio["trkn"] = [(1, 2)]  # stale: it says track 1
+    audio.save()
+
+    tagger.tag_album(album_dir, _release_2_tracks(), incomplete=True)
+
+    tagged = MP4(f)
+    assert _atom_str(tagged, ATOM_MB_TRACK_ID) == "rec-002"
+    assert tagged["trkn"][0][0] == 2, "and the stale number is rewritten"
 
 
 # -- helpers used in multiple tests --

--- a/test/test_track_assignment.py
+++ b/test/test_track_assignment.py
@@ -1,0 +1,239 @@
+"""Which file is which MusicBrainz track (#232).
+
+*TISM — The White Albun* is three media: **DVD-Video 22 · CD 16 · DVD-Video 31**.
+The CD's sixteen tracks are on disk and always have been. They were tagged when
+MusicBrainz's release held only the CD — so they say disc 1 — and in May 2026 the
+two DVDs were added and the CD moved to position 2.
+
+The album page then paired all sixteen against disc 1's *videos*: "22 of 22
+tracks differ from MusicBrainz · Disc 2, Disc 3 not on disk", with a complete CD
+reported as a disc that isn't there.
+
+Every one of those files carries a `MusicBrainz Release Track Id`, which names
+one position in one release and cannot be ambiguous. Harmonist writes it on
+everything it tags, Picard writes the same — and Picard used it to re-file the
+album without being asked. Harmonist read it for a different question (#197) and
+never for this one, deciding instead from numbers MusicBrainz had just
+renumbered, and — in the tagger — from durations.
+
+So the ladder, best rung first: release track id, disc-and-track number, file
+order. No length similarity: a duration is not an identity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harmonist.compare import (
+    Agreement,
+    MBTrack,
+    Medium,
+    TrackIdentity,
+    TrackState,
+    assign,
+    identity_of,
+)
+from harmonist.compare import tracklist as compare_tracklist
+from harmonist.formats.types import TagSet, TrackTags
+
+# ---------------------------------------------------------------------------
+# The ladder
+# ---------------------------------------------------------------------------
+
+
+def _mb(disc: int, track: int, rtid: str | None = None) -> TrackIdentity:
+    return TrackIdentity(rtid or f"rt-{disc}-{track}", disc, track)
+
+
+def test_a_file_naming_its_slot_is_that_slot():
+    """The rung that is not a guess."""
+    tracks = [_mb(1, 1), _mb(1, 2), _mb(1, 3)]
+    files = [TrackIdentity("rt-1-3"), TrackIdentity("rt-1-1")]
+
+    assert assign(files, tracks) == [2, 0]
+
+
+def test_the_id_beats_a_number_that_disagrees_with_it():
+    """The TISM shape: the numbers are stale because MusicBrainz renumbered the
+    release; the id in the same file is not. Nothing else can tell them apart —
+    both are tags, both look equally authoritative, and only one of them means
+    anything outside this release's current numbering."""
+    tracks = [_mb(1, 1), _mb(1, 2)]
+    files = [TrackIdentity("rt-1-2", disc=1, track=1)]
+
+    assert assign(files, tracks) == [1]
+
+
+def test_a_number_still_answers_for_a_file_with_no_id():
+    """An adopted album Harmonist has never tagged carries no ids at all, and
+    the numbers are all it has. This is the rule as it always was."""
+    tracks = [_mb(1, 1), _mb(1, 2), _mb(1, 3)]
+    files = [TrackIdentity(disc=1, track=3), TrackIdentity(disc=1, track=1)]
+
+    assert assign(files, tracks) == [2, 0]
+
+
+def test_a_number_is_paired_with_its_disc():
+    """Track 4 exists on both halves of a 2-CD release."""
+    tracks = [_mb(1, 1), _mb(1, 2), _mb(2, 1), _mb(2, 2)]
+    files = [TrackIdentity(disc=2, track=1)]
+
+    assert assign(files, tracks) == [2]
+
+
+def test_files_with_nothing_to_say_are_dealt_in_order():
+    """An album with no ids and no numbers behaves exactly as positional pairing
+    always did — the fallback, not a rung."""
+    tracks = [_mb(1, 1), _mb(1, 2), _mb(1, 3)]
+    files = [TrackIdentity(), TrackIdentity()]
+
+    assert assign(files, tracks) == [0, 1]
+
+
+def test_a_claim_two_files_make_settles_nothing():
+    """Two files naming one id are two copies of a track, or a mis-tag. Either
+    way the claim is not unique, so it decides nothing and both fall through."""
+    tracks = [_mb(1, 1), _mb(1, 2)]
+    files = [TrackIdentity("rt-1-2"), TrackIdentity("rt-1-2")]
+
+    # Dealt in file order into the free slots, not both fighting over slot 1.
+    assert assign(files, tracks) == [0, 1]
+
+
+def test_a_slot_musicbrainz_names_twice_is_no_slot():
+    """Ambiguity on MusicBrainz's side is dropped rather than resolved to the
+    first holder."""
+    tracks = [TrackIdentity("dup", 1, 1), TrackIdentity("dup", 1, 2)]
+    files = [TrackIdentity("dup")]
+
+    assert assign(files, tracks) == [0], "falls through to file order, not to 'the first dup'"
+
+
+def test_an_id_for_a_track_this_release_does_not_have_falls_through():
+    """A file re-matched to a different release keeps the old release's ids
+    until it is re-tagged. They name nothing here."""
+    tracks = [_mb(1, 1), _mb(1, 2)]
+    files = [TrackIdentity("rt-from-another-release", disc=1, track=2)]
+
+    assert assign(files, tracks) == [1], "the number still answers"
+
+
+def test_every_file_is_tried_on_a_rung_before_the_next_rung_is_tried():
+    """One file's missing id must not cost another file its own. If the rungs
+    ran per-file, the numbered file would take slot 0 first and the file that
+    NAMES slot 0 would be pushed off it."""
+    tracks = [_mb(1, 1), _mb(1, 2)]
+    files = [TrackIdentity(disc=1, track=1), TrackIdentity("rt-1-1")]
+
+    assert assign(files, tracks) == [1, 0]
+
+
+def test_an_unreadable_file_claims_nothing():
+    """It has no tags to read (#112) — which is not the same as a readable file
+    that carries no numbers, and must not be given (disc 1, track None)."""
+    assert identity_of(TrackTags(unreadable=True, track_num=3)) == TrackIdentity()
+
+
+def test_more_files_than_tracks_leaves_the_extras_unassigned():
+    tracks = [_mb(1, 1)]
+    files = [TrackIdentity("rt-1-1"), TrackIdentity(), TrackIdentity()]
+
+    assert assign(files, tracks) == [0, None, None]
+
+
+# ---------------------------------------------------------------------------
+# The album page, on the release that started it
+# ---------------------------------------------------------------------------
+
+
+def _tism_release() -> list[MBTrack]:
+    """DVD-Video 22 · CD 16 · DVD-Video 31, as MusicBrainz has it today."""
+    out = []
+    for disc, count, kind in ((1, 22, "Video"), (2, 16, "Song"), (3, 31, "Extra")):
+        for n in range(1, count + 1):
+            out.append(
+                MBTrack(
+                    tags=TagSet(
+                        title=f"{kind} {n}",
+                        album="The White Albun",
+                        artist="TISM",
+                        mb_album_id="rel-tism",
+                        album_artist="TISM",
+                        track_total=count,
+                        mb_release_track_id=f"rt-{disc}-{n}",
+                        disc_num=disc,
+                        track_num=n,
+                    ),
+                    length_ms=200_000,
+                )
+            )
+    return out
+
+
+def _tism_media() -> list[Medium]:
+    return [Medium(1, None, "DVD-Video"), Medium(2, None, "CD"), Medium(3, None, "DVD-Video")]
+
+
+def _tism_files(*, stale_disc: bool) -> list[tuple[str, TrackTags]]:
+    """The sixteen CD files. `stale_disc` is the state they were in before the
+    re-tag: correct ids, and a disc number from when the CD was disc 1."""
+    return [
+        (
+            f"2-{n:02d} Song {n}.m4a",
+            TrackTags(
+                title=f"Song {n}",
+                artist="TISM",
+                release_track_id=f"rt-2-{n}",
+                disc_num=1 if stale_disc else 2,
+                track_num=n,
+                duration_ms=200_000,
+            ),
+        )
+        for n in range(1, 17)
+    ]
+
+
+@pytest.mark.parametrize("stale_disc", [True, False])
+def test_the_cd_is_the_cd_however_musicbrainz_has_renumbered_it(stale_disc):
+    """The reported bug. With the stale disc number the whole CD used to key
+    onto disc 1's videos; the ids in the same files said medium 2 all along."""
+    t = compare_tracklist(_tism_files(stale_disc=stale_disc), _tism_release(), _tism_media())
+    cd = t.discs[1]
+
+    assert cd.medium.position == 2
+    assert cd.absent is False, "a complete CD is not a disc that isn't on disk"
+    assert [r.state for r in cd.tracks] == [TrackState.PRESENT] * 16
+    assert [r.fields[1].disk for r in cd.tracks] == [f"Song {n}" for n in range(1, 17)]
+    assert [r.fields[1].mb for r in cd.tracks] == [f"Song {n}" for n in range(1, 17)]
+
+
+def test_a_stale_disc_number_is_reported_as_the_difference_it_is():
+    """What the page should have been saying all along: these are the right
+    tracks, and one tag on them has gone out of date. The disc number is a
+    finding about the file — not the thing that decides which track it is."""
+    t = compare_tracklist(_tism_files(stale_disc=True), _tism_release(), _tism_media())
+    row = t.discs[1].tracks[4]
+
+    number, title = row.fields[0], row.fields[1]
+    assert (number.disk, number.mb) == ("1-5", "2-5"), "the tag that is stale"
+    assert title.agreement is Agreement.MATCHES, "the tags that aren't"
+    assert [f.label for f in row.fields if f.differs] == ["#"]
+
+
+def test_a_re_tagged_album_then_agrees_completely():
+    """The state the album is in once the correction is written back. The two
+    DVDs are still missing, which is a fact about the library and not about
+    these files."""
+    t = compare_tracklist(_tism_files(stale_disc=False), _tism_release(), _tism_media())
+
+    assert [r for r in t.discs[1].tracks if r.differs] == []
+    assert t.summary == "All 16 tracks match MusicBrainz · Disc 1, Disc 3 not on disk"
+
+
+def test_the_videos_are_still_reported_as_absent_discs():
+    """The other half of the same page: the two DVDs genuinely aren't on disk,
+    and #216 collapses each into one line. That must survive the re-assignment."""
+    t = compare_tracklist(_tism_files(stale_disc=True), _tism_release(), _tism_media())
+
+    assert [g.absent for g in t.discs] == [True, False, True]
+    assert "Disc 1, Disc 3 not on disk" in t.summary


### PR DESCRIPTION
*TISM — The White Albun* was tagged when MusicBrainz's release held only its CD. MusicBrainz later added two DVDs and moved the CD to position 2, and the album page then paired all sixteen CD files against disc 1's *videos* — "22 of 22 tracks differ · Disc 2, Disc 3 not on disk", for a CD that is complete and correctly tagged.

Every one of those files carries a `MusicBrainz Release Track Id` naming its exact slot. Harmonist writes it on everything it tags, Picard writes the same — and Picard used it to re-file the album unprompted. Harmonist read that id for a different question (#197) and never for this one.

## What this does

Two places decided which file is which track, and neither asked:

- `compare._assign` keyed on `(disc, track)` — precisely the pair MusicBrainz had just renumbered.
- `tagger._assign_files_to_tracks` compared **durations**. On this release that bound `Sorted for D 'n M.m4a` to a DVD track called *Diatribe*, and would have written that track's title and ids into it. One file in sixteen — the worst available outcome, because nobody re-checks an album that looks mostly right.

Both now go through one ladder in `compare.assign`: **release track id → disc-and-track number → file order**, each rung tried for every file before the next is tried for any, and a key that isn't unique on both sides deciding nothing. Length similarity is gone: a duration is not an identity, two recordings of one length are ordinary on a release, and the odds get worse the longer it is.

The first rung is the only one that isn't a guess, which is the point — the no-guessing rule applied to a question nobody had noticed was being guessed. The rungs below it remain guesses and #136 remains their escape hatch, but it is no longer needed for anything Harmonist has tagged.

## Verified on the real albums

TISM, reconstructed in its pre-re-tag state:

```
before:  22 of 22 tracks differ · Disc 2, Disc 3 not on disk    (every title wrong)
after:   16 of 16 tracks differ · Disc 1, Disc 3 not on disk    (every title right)
         disc 2   1-5 -> 2-5   2-05 I Rooted a Girl…   <-- differs: #
```

Every file on its own track, and the only difference reported is the stale disc number — which a re-tag then corrects. Through the tagger, 0 of 16 files now land on another medium's track (was 1). *DJ Shadow — In Tune and on Time* is unchanged at "3 of 50 · 3 not on disk" with its 26 video rows, so #226's behaviour survives.

`make check` green. Dropping the id rung reddens 8 tests. The idempotency test covers the case where the rung *changes* between runs: the first tagging places a file by order and writes that slot's id into it, and the second then reaches the same slot by id.

## Known and deliberate

Retiring length similarity is not a pure win. For files with no id *and* no numbers — an adopted album, partly present — length was occasionally right where file order shifts everything. Predictably wrong beats silently wrong, and #136 covers the gap.

Not fixed here: `tag_album`'s file-count guard still counts video media, so TISM (COMPLETE, because its absent media are video) can't be re-tagged at all — `16 audio files but MB release has 69 tracks`. Its own issue to follow.

Fixes #232
