### PR TITLE
Count the tracks Harmonist can tag, not the ones it can't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ versions follow [semantic versioning](https://semver.org).
 - Re-tagging an album that's missing tracks no longer picks which track a file
   is by comparing durations, which could give one file another track's title
   and ids (#232).
-
+- An album whose only missing discs are video can be re-tagged again. It used
+  to refuse — "16 audio files but MB release has 69 tracks" — counting a bonus
+  DVD's videos as audio files you were missing (#235).
 - An album page now lists the video files on disk instead of reporting a
   part-ripped DVD as a disc you don't have at all. They're marked as video and
   not compared against MusicBrainz — Harmonist reads their tags, never writes

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -134,10 +134,18 @@ def tag_album(
     `musicbrainzngs.get_release_by_id()` returns under the "release" key.
     Returns the number of files tagged.
 
-    `incomplete=True` allows file_count < track_count and assigns files
-    to a subset of MB tracks via length-similarity (positional fallback).
-    file_count > track_count is still an error in both modes (per design
-    §15.3 — "extra files on disk" is out of scope).
+    `incomplete=True` allows file_count < track_count. file_count >
+    track_count is still an error in both modes (per design §15.3 — "extra
+    files on disk" is out of scope).
+
+    Which file is which track is decided by `compare.assign` in **both** modes
+    (#235). It used to be positional in the complete mode and by the ladder in
+    the incomplete one, which meant a release could fit the files perfectly and
+    still be unpairable: an album whose only absent media are video is COMPLETE
+    (#206), so it took the positional path and `zip(..., strict=True)` raised on
+    a count that included tracks Harmonist will never write. The ladder's last
+    rung IS positional pairing, so a single-medium album is assigned exactly as
+    before.
 
     `overwrite_art=True` embeds the album cover even when the tracks carry
     differing per-track artwork (which is otherwise preserved) — the user's
@@ -146,10 +154,17 @@ def tag_album(
     files = files if files is not None else album_files.audio_files(album_dir)
     flat_tracks = list(_flatten_tracks(release))
 
-    if not incomplete and len(files) != len(flat_tracks):
+    # What the count guard is entitled to expect on disk: the release's tracks
+    # minus the ones on media Harmonist cannot tag (#235). Counting a bonus
+    # DVD's 53 videos against 16 audio files made a complete, correctly tagged
+    # album permanently un-re-taggable — and it is the albums MusicBrainz has
+    # since corrected that most need the button.
+    taggable = _taggable_tracks(album_dir, flat_tracks)
+
+    if not incomplete and len(files) != len(taggable):
         raise TagMismatchError(
             f"album {album_dir.name!r}: {len(files)} audio files but MB release "
-            f"has {len(flat_tracks)} tracks"
+            f"has {len(taggable)} tracks"
         )
     if len(files) > len(flat_tracks):
         raise TagMismatchError(
@@ -158,11 +173,11 @@ def tag_album(
             f"scope (see design §15.3)"
         )
 
-    if incomplete and len(files) < len(flat_tracks):
-        pairs = _assign_files_to_tracks(files, flat_tracks)
-    else:
-        # Counts are guaranteed equal here by the checks above.
-        pairs = list(zip(files, flat_tracks, strict=True))
+    # Assigned against EVERY track, not just the taggable ones: a file that
+    # names a video track's id is a file in the wrong place, and quietly
+    # re-pointing it at an audio track would be the invention this ladder
+    # exists to avoid.
+    pairs = _assign_files_to_tracks(files, flat_tracks)
 
     cover = cover_path.read_bytes() if cover_path else None
     # Only when there IS a cover to embed. With `cover=None` write_tags leaves
@@ -721,6 +736,26 @@ def _identity_of(flat: _FlatTrack) -> compare.TrackIdentity:
     number from the position."""
     medium, track_pos, track = flat
     return compare.TrackIdentity(track.get("id"), _disc_num(medium), track_pos + 1)
+
+
+def _taggable_tracks(album_dir: Path, flat_tracks: list[_FlatTrack]) -> list[_FlatTrack]:
+    """The release's tracks minus the ones on media Harmonist will never write.
+
+    Read from the sidecar's `video_media` (#206), which is the only record of
+    which media are video — the release dict's per-medium `format` is not the
+    test, because a medium can mix audio and video and MusicBrainz answers that
+    per TRACK (`mb_lookup.fetch_video_media`).
+
+    `None` there means "not asked yet", not "none are video", so it excludes
+    nothing and the guard behaves exactly as it did before this existed. An
+    album that has never been through that lookup is no worse off; one that has
+    stops being told its DVD's tracks are missing audio files.
+    """
+    sc = sidecar_mod.read(album_dir)
+    video = set(sc.video_media or ()) if sc else set()
+    if not video:
+        return flat_tracks
+    return [f for f in flat_tracks if _disc_num(f[0]) not in video]
 
 
 def _disc_num(medium: dict[str, Any]) -> int:

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -1034,3 +1034,92 @@ def test_reverting_does_not_touch_the_artwork(album_with_tracks, tmp_path):
     tagger.revert_tags(album_dir, _plan())
 
     assert formats.read_cover(f) == embedded
+
+
+# ---------- a bonus DVD is not missing audio (§15.3, #235) ----------
+
+
+def _release_cd_plus_dvd() -> dict:
+    """A 2-track CD and a 3-track DVD — *TISM — The White Albun* in miniature."""
+    release = _release_2_tracks()
+    release["medium-list"].append(
+        {
+            "position": "2",
+            "format": "DVD-Video",
+            "track-list": [
+                {
+                    "id": f"rt-v{i}",
+                    "position": str(i),
+                    "title": f"Video {i}",
+                    "recording": {"id": f"rec-v{i}", "title": f"Video {i}", "length": "300000"},
+                }
+                for i in range(1, 4)
+            ],
+        }
+    )
+    return release
+
+
+def _with_video_media(album_dir, media):
+    from datetime import UTC, datetime
+
+    from harmonist import sidecar as sidecar_mod
+    from harmonist.models import Sidecar
+
+    sidecar_mod.write(
+        album_dir,
+        Sidecar(
+            mb_release_id="rel-aaa",
+            tagged_at=datetime(2026, 1, 1, tzinfo=UTC),
+            video_media=media,
+        ),
+    )
+
+
+def test_tag_album_does_not_count_video_tracks_against_the_files(album_with_tracks):
+    """The whole CD is on disk and the bonus DVD never will be, which is what
+    COMPLETE means for this album (#206) — so Re-tag has to work. It used to
+    refuse: "2 audio files but MB release has 5 tracks"."""
+    album_dir = album_with_tracks(2)
+    _with_video_media(album_dir, (2,))
+
+    n = tagger.tag_album(album_dir, _release_cd_plus_dvd())
+
+    assert n == 2
+    assert _atom_str(MP4(album_dir / "01 Track 1.m4a"), ATOM_MB_RELEASE_TRACK_ID) == "rt-001"
+    assert _atom_str(MP4(album_dir / "02 Track 2.m4a"), ATOM_MB_RELEASE_TRACK_ID) == "rt-002"
+
+
+def test_tag_album_puts_the_files_on_the_audio_medium(album_with_tracks):
+    """Not merely "doesn't raise": the two files must land on the CD's tracks.
+    Pairing positionally across the flattened release would have been just as
+    quiet and just as wrong."""
+    album_dir = album_with_tracks(2)
+    _with_video_media(album_dir, (2,))
+
+    tagger.tag_album(album_dir, _release_cd_plus_dvd())
+
+    for name in ("01 Track 1.m4a", "02 Track 2.m4a"):
+        assert MP4(album_dir / name)["disk"][0][0] == 1
+
+
+def test_tag_album_still_refuses_when_audio_is_genuinely_missing(album_with_tracks):
+    """The control. Forgiving the DVD must not forgive a CD track that isn't
+    there — that is the mismatch the guard exists for."""
+    album_dir = album_with_tracks(1)  # the CD has two tracks
+    _with_video_media(album_dir, (2,))
+
+    with pytest.raises(TagMismatchError, match="1 audio files but MB release has 2 tracks"):
+        tagger.tag_album(album_dir, _release_cd_plus_dvd())
+
+
+def test_tag_album_counts_everything_when_video_media_is_unknown(album_with_tracks):
+    """`video_media=None` is "not asked yet", not "none are video" (#206). An
+    album that has never been through that lookup must behave exactly as it did
+    before this existed, rather than quietly assuming its second medium is a
+    DVD."""
+    album_dir = album_with_tracks(2)
+    _with_video_media(album_dir, None)
+
+    with pytest.raises(TagMismatchError, match="2 audio files but MB release has 5 tracks"):
+        tagger.tag_album(album_dir, _release_cd_plus_dvd())


### PR DESCRIPTION
*TISM — The White Albun* is DVD-Video 22 · CD 16 · DVD-Video 31. The CD is complete on disk and correctly tagged, and the album derives COMPLETE because its absent media are video (#206). Re-tag refused it outright, with no way out from the UI:

```
16 audio files but MB release has 69 tracks
```

It bit hardest right after #232, which taught the album page to report that these files carry a stale disc number — leaving the diagnosis on screen and the remedy behind a button that could not run.

## Two things were counting video

- **The guard** compared the audio files against every flattened track in the release. It now compares them against the tracks on media Harmonist will actually write, read from the sidecar's `video_media`. `None` there still means "not asked yet", so an album that has never been through that lookup behaves exactly as before.
- **The pairing.** Complete mode zipped files against tracks positionally, which raises on the same mismatch *and* would have walked the sixteen CD files onto the first DVD's tracks. Both modes now assign through `compare.assign`, whose last rung *is* positional pairing — so an ordinary single-medium album is paired exactly as it was.

Assignment still runs against every track, not just the taggable ones: a file naming a video track's id is a file in the wrong place, and quietly re-pointing it at an audio track would be the invention that ladder exists to avoid.

## Verified on the real album

Restored to the state it was in before Picard was used to fix it — tagged from the CD-only release, so every file says disc 1:

```
state: complete
re-tag wrote 16 files

  2-01 Everyone Else Has Had More Se   1-1 -> 2-1
  2-02 Bone Idol.m4a                   1-2 -> 2-2
  …
  2-16 TISM Are Shit.m4a               1-16 -> 2-16
```

All sixteen moved to the right disc, nothing else changed. Before this, the same album refused.

`make check` green (1227 passed). Reverting the guard reddens 3 of the 4 new tests.

## Deliberate, and worth stating

- A complete album with **mis-numbered** files is now paired by what its tags say rather than positionally. Same rule the album page has always used, and #136 is the override — but it is not only the video case whose behaviour changes.
- Complete mode previously paired without opening anything and now reads each file's tags for its identity: one extra read per file per tagging, against the path #44 / #74 care about. Small next to the writes it precedes.

Fixes #235
