### PR TITLE
Ask the release which discs are video, not the sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ versions follow [semantic versioning](https://semver.org).
   and ids (#232).
 - An album whose only missing discs are video can be re-tagged again. It used
   to refuse — "16 audio files but MB release has 69 tracks" — counting a bonus
-  DVD's videos as audio files you were missing (#235).
+  DVD's videos as audio files you were missing (#235, #237).
 - An album page now lists the video files on disk instead of reporting a
   part-ripped DVD as a disc you don't have at all. They're marked as video and
   not compared against MusicBrainz — Harmonist reads their tags, never writes

--- a/src/harmonist/mb_lookup.py
+++ b/src/harmonist/mb_lookup.py
@@ -161,8 +161,23 @@ def fetch_video_media(mbid: str) -> tuple[int, ...]:
     except (musicbrainzngs.NetworkError, musicbrainzngs.AuthenticationError) as e:
         raise MBError(f"MB request failed: {e}") from e
 
+    return video_media_of(result["release"])
+
+
+def video_media_of(release: Release) -> tuple[int, ...]:
+    """`fetch_video_media`'s answer, read off a release already in hand.
+
+    Pure — no request. `fetch_release` asks for `recordings`, so the per-track
+    `video` flag is already on every release the album page and the tagger hold,
+    and asking MusicBrainz again for a fact sitting in memory would spend a
+    rate-limited request on nothing (#237).
+
+    Kept beside the fetch rather than in `models`, because what counts as a
+    video medium is a MusicBrainz question and the answer must not drift between
+    the two callers.
+    """
     positions: list[int] = []
-    for medium in result["release"].get("medium-list") or []:
+    for medium in release.get("medium-list") or []:
         tracks = medium.get("track-list") or []
         if not tracks:
             continue

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -17,7 +17,16 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, runtime_checkable
 
-from . import activity_store, album_files, artwork_store, audit, compare, formats, tag_history
+from . import (
+    activity_store,
+    album_files,
+    artwork_store,
+    audit,
+    compare,
+    formats,
+    mb_lookup,
+    tag_history,
+)
 from . import sidecar as sidecar_mod
 from .formats import TagSet, owned
 from .formats.m4a import (  # noqa: F401 — back-compat re-exports
@@ -159,7 +168,7 @@ def tag_album(
     # DVD's 53 videos against 16 audio files made a complete, correctly tagged
     # album permanently un-re-taggable — and it is the albums MusicBrainz has
     # since corrected that most need the button.
-    taggable = _taggable_tracks(album_dir, flat_tracks)
+    taggable = _taggable_tracks(release, flat_tracks)
 
     if not incomplete and len(files) != len(taggable):
         raise TagMismatchError(
@@ -738,21 +747,28 @@ def _identity_of(flat: _FlatTrack) -> compare.TrackIdentity:
     return compare.TrackIdentity(track.get("id"), _disc_num(medium), track_pos + 1)
 
 
-def _taggable_tracks(album_dir: Path, flat_tracks: list[_FlatTrack]) -> list[_FlatTrack]:
+def _taggable_tracks(release: Release, flat_tracks: list[_FlatTrack]) -> list[_FlatTrack]:
     """The release's tracks minus the ones on media Harmonist will never write.
 
-    Read from the sidecar's `video_media` (#206), which is the only record of
-    which media are video — the release dict's per-medium `format` is not the
-    test, because a medium can mix audio and video and MusicBrainz answers that
-    per TRACK (`mb_lookup.fetch_video_media`).
+    Read from the RELEASE (#237), not from the sidecar's `video_media` (#206),
+    even though that field records the same fact. The sidecar's copy exists for
+    the scanner, which has no MusicBrainz; here the release is already in hand
+    and carries the per-track `video` flag, so asking the sidecar buys nothing
+    and can be wrong: it is only written for albums that look like they are
+    missing a medium (`reconcile.needs_video_media`), and an album whose tags
+    predate the release gaining discs does not look like that. TISM's *The White
+    Albun*, restored from a backup, says "disc 1 of 1, all present" — nothing
+    absent, so nothing asked, so the guard counted 53 videos as missing audio
+    and refused the re-tag for good.
 
-    `None` there means "not asked yet", not "none are video", so it excludes
-    nothing and the guard behaves exactly as it did before this existed. An
-    album that has never been through that lookup is no worse off; one that has
-    stops being told its DVD's tracks are missing audio files.
+    Per TRACK rather than per medium format, exactly as
+    `mb_lookup.fetch_video_media` is: `Wish You Were Here 50` is one Blu-ray of
+    45 audio tracks and 4 videos, and judging by format would expect nothing of
+    it.
     """
-    sc = sidecar_mod.read(album_dir)
-    video = set(sc.video_media or ()) if sc else set()
+    # `mb_lookup` for a PURE function: this makes no request, and the release it
+    # reads was fetched by the caller.
+    video = set(mb_lookup.video_media_of(release))
     if not video:
         return flat_tracks
     return [f for f in flat_tracks if _disc_num(f[0]) not in video]

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -1051,7 +1051,16 @@ def _release_cd_plus_dvd() -> dict:
                     "id": f"rt-v{i}",
                     "position": str(i),
                     "title": f"Video {i}",
-                    "recording": {"id": f"rec-v{i}", "title": f"Video {i}", "length": "300000"},
+                    "recording": {
+                        "id": f"rec-v{i}",
+                        "title": f"Video {i}",
+                        "length": "300000",
+                        # What MusicBrainz actually returns, and the only honest
+                        # test of a video medium — the medium's `format` is not
+                        # one, since a Blu-ray can carry 45 audio tracks and 4
+                        # videos (#206).
+                        "video": "true",
+                    },
                 }
                 for i in range(1, 4)
             ],
@@ -1113,13 +1122,21 @@ def test_tag_album_still_refuses_when_audio_is_genuinely_missing(album_with_trac
         tagger.tag_album(album_dir, _release_cd_plus_dvd())
 
 
-def test_tag_album_counts_everything_when_video_media_is_unknown(album_with_tracks):
-    """`video_media=None` is "not asked yet", not "none are video" (#206). An
-    album that has never been through that lookup must behave exactly as it did
-    before this existed, rather than quietly assuming its second medium is a
-    DVD."""
-    album_dir = album_with_tracks(2)
-    _with_video_media(album_dir, None)
+@pytest.mark.parametrize("recorded", [None, ()])
+def test_tag_album_asks_the_release_not_the_sidecar_about_video(album_with_tracks, recorded):
+    """#237: the sidecar's `video_media` doesn't get a vote here.
 
-    with pytest.raises(TagMismatchError, match="2 audio files but MB release has 5 tracks"):
-        tagger.tag_album(album_dir, _release_cd_plus_dvd())
+    It is written only for albums that already LOOK like they are missing a
+    medium (`reconcile.needs_video_media`), which an album whose tags predate
+    the release gaining discs does not — TISM's *The White Albun* restored from
+    backup says "disc 1 of 1, all present", so nothing was absent, nothing was
+    asked, and the guard went back to counting videos as missing audio.
+
+    `None` is that album ("not asked"), and `()` is the staler version of the
+    same thing ("asked, before the DVDs existed"). The release in hand carries
+    the per-track video flag either way, so neither blocks the re-tag.
+    """
+    album_dir = album_with_tracks(2)
+    _with_video_media(album_dir, recorded)
+
+    assert tagger.tag_album(album_dir, _release_cd_plus_dvd()) == 2


### PR DESCRIPTION
#235 stopped the count guard from treating a bonus DVD's videos as missing audio files, by reading `sidecar.video_media`. That field is written only for albums that already *look* like they're missing a medium — `reconcile.needs_video_media` is gated on `album.absent_media` — and an album whose tags predate the release gaining discs does not look like that.

Restore *TISM — The White Albun* from a backup taken before MusicBrainz added its two DVDs and the files say "disc 1 of 1, 16 tracks, all present". Nothing absent, so nothing asked, so the field stays `None`, which #235 correctly reads as "not asked" rather than "none are video" — and the guard goes back to counting 69:

```
Re-tag failed — album 'The White Albun': 16 audio files but MB release has 69 tracks
```

Permanent, with hand-editing `.harmonist.json` the only way out. The same dead end as #235, reached by a second route.

## The fix

`fetch_release` already asks for `recordings`, so the per-track `video` flag is on every release the album page and the tagger hold:

```
medium 1 (DVD-Video, 22 tracks): recording.video = {'true'}
medium 2 (CD, 16 tracks):        recording.video = {None}
medium 3 (DVD-Video, 31 tracks): recording.video = {'true'}
```

`mb_lookup.video_media_of` is now that computation as a pure function over a release, with `fetch_video_media` calling it after its request. The guard uses it directly: **no MusicBrainz request**, and no dependency on a field a restore can roll back. The sidecar's copy stays where it earns its keep — the scanner, which has no MusicBrainz and genuinely cannot derive it.

## The attempt that didn't survive, and why

I first tried dropping the `video_media` dependency altogether: guard on the **assignment** — refuse when a medium that *has* files isn't filled by them, and treat a medium with no files as absent rather than short. It fixes this album, and #197's control test caught what it costs: a multi-folder album tagged without its explicit file list fills its primary folder's medium exactly, leaves the other empty, and would have been tagged half-done **silently** — the precise bug that test exists to prevent.

The tagger cannot tell "absent because video" from "absent because the caller forgot the rest of the album" without being told which media are video. So it is told, from the release it already has.

## Verified

On the real album, copied out in exactly the state the restore left it (`video_media: None`, derives `complete`):

```
re-tag wrote 16 files
  01 Everyone Else Has Had More Sex Th   1-1 -> 2-1
  …
  16 TISM Are Shit.m4a                   1-16 -> 2-16
```

Titles, ids and everything else untouched. `make check` green (1228 passed). The `video_media` test is now parametrised over `None` ("not asked") and `()` ("asked, before the DVDs existed") — neither blocks the re-tag, because neither gets a vote.

Fixes #237
