### PR TITLE
Update the sidecar on re-tag instead of rebuilding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ versions follow [semantic versioning](https://semver.org).
 - An album whose only missing discs are video can be re-tagged again. It used
   to refuse — "16 audio files but MB release has 69 tracks" — counting a bonus
   DVD's videos as audio files you were missing (#235, #237).
+- Re-tagging no longer resets parts of an album's record: a surrendered album
+  stays surrendered, an accepted-as-incomplete one stays accepted, and an album
+  with a bonus DVD no longer flips to Incomplete until the next reconcile
+  (#239).
+- The History panel's per-track lines now number tracks from 1, matching the
+  files and the tracklist above them, instead of from 0 (#240).
 - An album page now lists the video files on disk instead of reporting a
   part-ripped DVD as a disc you don't have at all. They're marked as video and
   not compared against MusicBrainz — Harmonist reads their tags, never writes

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -241,7 +241,11 @@ def tag_album(
             "tag.track",
             album_id=album_id,
             file=album_files.rel_name(album_dir, file_path),
-            track=track_pos_in_medium,
+            # +1 because `_flatten_tracks` enumerates from zero and MusicBrainz,
+            # the files and the album page all count from one (#240). A record
+            # off by one is worse than none: it is exactly what someone auditing
+            # a re-tag would read as the tagger having assigned the wrong track.
+            track=track_pos_in_medium + 1,
             title=_track_title(track),
         )
         if event_id is not None:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -2497,15 +2497,26 @@ def _tag_with_release(
             )
         except Exception:
             log.exception("store_url derivation during tagging failed")
-    new = Sidecar(
+    # `replace`, not a fresh `Sidecar(...)` — anything not named here carries
+    # through BY CONSTRUCTION (#239). Listing the fields to keep meant every
+    # field left off the list was silently reset to its default on every
+    # re-tag: `video_media` (so an album with a bonus DVD went Incomplete until
+    # a later pass spent a MusicBrainz request re-learning it), and the
+    # `purchase_unavailable` / `tracks_unavailable` surrenders, whose whole
+    # purpose is to be permanent. A field added to the model later would have
+    # joined them, silently, with no test to notice.
+    base = sc or Sidecar()
+    new = replace(
+        base,
         store_url=store_url,
-        bandcamp=sc.bandcamp if sc else None,
-        downloaded_at=sc.downloaded_at if sc else None,
-        added_at=(sc.added_at if sc else None) or datetime.now(UTC),
+        added_at=base.added_at or datetime.now(UTC),
         mb_release_id=mbid,
-        mb_match_candidate=None,  # cleared on tag
+        mb_match_candidate=None,  # cleared on tag — a suggestion, now acted on
         tagged_at=datetime.now(UTC),
-        notes=sc.notes if sc else None,
+        # Read off the release this tagging used, so the one fact the files
+        # cannot carry (#206) is recorded at the moment it is known rather than
+        # left for a reconcile pass to fetch again. Pure — no request (#237).
+        video_media=mb_lookup.video_media_of(release),
     )
     sidecar_mod.write(album_path, new)
     _claim_pending_by_store_url(store_url)

--- a/test/test_retag_sidecar.py
+++ b/test/test_retag_sidecar.py
@@ -1,0 +1,232 @@
+"""What a re-tag does to the sidecar beside the files (#239, #240).
+
+`_tag_with_release` used to build a **new** `Sidecar(...)` field by field, which
+meant every field it did not name was reset to its default — silently, and with
+nothing in the suite to notice. Three of them mattered:
+
+* `video_media` (#206), so an album with a bonus DVD went Incomplete after every
+  re-tag and stayed there until a reconcile pass spent a MusicBrainz request
+  re-learning what Harmonist had already written down;
+* `purchase_unavailable` and `tracks_unavailable`, the surrender and
+  accept-as-done flags, whose entire purpose is to be permanent.
+
+The shape is the bug, not the three fields: a field added to the model later
+would have joined them. So the test below asserts the WHOLE record, not the
+fields that were wrong this time.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from mutagen.mp4 import MP4
+
+from harmonist import activity_store, mb_lookup
+from harmonist import sidecar as sidecar_mod
+from harmonist.config import BandcampConfig, Config, PathsConfig, ServerConfig, TestConfig
+from harmonist.models import BandcampInfo, MatchCandidate, Sidecar
+from harmonist.web.main import create_app
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+SINE_M4A = FIXTURES_DIR / "sine.m4a"
+MBID = "33333333-4444-5555-6666-777777777777"
+TAGGED_AT = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    return Config(
+        paths=PathsConfig(config_dir=tmp_path / "config", music_dir=tmp_path / "music"),
+        bandcamp=BandcampConfig(),
+        server=ServerConfig(),
+        test=TestConfig(mode="fixture"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def no_cover_fetch(monkeypatch):
+    """No cover-art requests: this module is about the sidecar, and CAA is off-box."""
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+
+
+@pytest.fixture
+def client(cfg):
+    cfg.paths.music_dir.mkdir(parents=True, exist_ok=True)
+    cfg.paths.config_dir.mkdir(parents=True, exist_ok=True)
+    # HX-Request: the CSRF middleware requires it on every state-changing call.
+    return TestClient(create_app(cfg), headers={"HX-Request": "true"})
+
+
+def _release(*, video_disc: bool) -> dict:
+    """A 2-track CD, optionally followed by a 2-track DVD of videos."""
+    release = {
+        "id": MBID,
+        "title": "Test Album",
+        "status": "Official",
+        "artist-credit": [{"artist": {"id": "art-1", "name": "Artist"}, "name": "Artist"}],
+        "release-group": {"id": "rg-1", "primary-type": "Album"},
+        "medium-list": [
+            {
+                "position": "1",
+                "format": "CD",
+                "track-list": [
+                    {
+                        "id": f"rt-{i}",
+                        "position": str(i),
+                        "title": f"Track {i}",
+                        "recording": {"id": f"rec-{i}", "title": f"Track {i}", "length": "1000"},
+                    }
+                    for i in range(1, 3)
+                ],
+            }
+        ],
+    }
+    if video_disc:
+        release["medium-list"].append(
+            {
+                "position": "2",
+                "format": "DVD-Video",
+                "track-list": [
+                    {
+                        "id": f"rt-v{i}",
+                        "position": str(i),
+                        "title": f"Video {i}",
+                        "recording": {
+                            "id": f"rec-v{i}",
+                            "title": f"Video {i}",
+                            "length": "300000",
+                            "video": "true",
+                        },
+                    }
+                    for i in range(1, 3)
+                ],
+            }
+        )
+    return release
+
+
+def _album(cfg, sidecar: Sidecar) -> Path:
+    """A 2-track album carrying `sidecar`, tagged and sitting in the Library."""
+    d = cfg.paths.music_dir / "Artist" / "Album"
+    d.mkdir(parents=True)
+    for i in (1, 2):
+        f = d / f"0{i} Track {i}.m4a"
+        shutil.copy(SINE_M4A, f)
+        a = MP4(f)
+        a["\xa9alb"] = ["Test Album"]
+        a["\xa9ART"] = ["Artist"]
+        a["trkn"] = [(i, 2)]
+        a["----:com.apple.iTunes:MusicBrainz Album Id"] = [MBID.encode()]
+        a.save()
+    sidecar_mod.write(d, sidecar)
+    return d
+
+
+def _album_id(cfg, album_dir: Path) -> str:
+    from harmonist import scanner
+
+    for a in scanner.scan(cfg.paths.music_dir):
+        if a.path == album_dir:
+            return a.id
+    raise AssertionError(f"no album at {album_dir}")
+
+
+def _fully_populated() -> Sidecar:
+    """Every field a sidecar can carry, set to something that is not its default
+    — so anything the re-tag drops shows up as a difference."""
+    return Sidecar(
+        store_url="https://artist.bandcamp.com/album/test-album",
+        bandcamp=BandcampInfo(item_id=4242, band_id=99, is_private=True),
+        downloaded_at=datetime(2025, 6, 1, tzinfo=UTC),
+        added_at=datetime(2025, 5, 1, tzinfo=UTC),
+        mb_release_id=MBID,
+        mb_match_candidate=MatchCandidate(
+            mb_release_id=MBID, confidence="exact", file_count=2, track_count=2
+        ),
+        tagged_at=TAGGED_AT,
+        notes="bought at a gig",
+        purchase_unavailable=True,
+        tracks_unavailable=True,
+    )
+
+
+def test_a_retag_changes_only_what_it_means_to_change(client, cfg, monkeypatch):
+    """The whole record, field by field.
+
+    Deliberately not a list of the three fields that were being lost: the defect
+    was that the sidecar got REBUILT, so the next field added to the model would
+    have been lost too. This fails if that happens again.
+    """
+    d = _album(cfg, _fully_populated())
+    monkeypatch.setattr(mb_lookup, "fetch_release", lambda mbid: _release(video_disc=False))
+
+    r = client.post(f"/retag/{_album_id(cfg, d)}")
+    assert r.status_code == 200
+
+    after = sidecar_mod.read(d)
+    assert after is not None
+    before = dataclasses.asdict(_fully_populated())
+    changed = {k: v for k, v in dataclasses.asdict(after).items() if before[k] != v}
+
+    assert set(changed) == {"mb_match_candidate", "tagged_at", "video_media"}
+    assert changed["mb_match_candidate"] is None, "a suggestion, now acted on"
+    assert after.tagged_at is not None and after.tagged_at > TAGGED_AT
+    assert changed["video_media"] == (), "asked, and this release has no video media"
+
+
+def test_a_retag_keeps_a_surrender(client, cfg, monkeypatch):
+    """`purchase_unavailable` is the user's decision that an album with no
+    findable purchase is finished. A re-tag changes nothing about Bandcamp, and
+    dropping it would send the album back round the sync-and-surrender loop."""
+    d = _album(cfg, _fully_populated())
+    monkeypatch.setattr(mb_lookup, "fetch_release", lambda mbid: _release(video_disc=False))
+
+    client.post(f"/retag/{_album_id(cfg, d)}")
+
+    after = sidecar_mod.read(d)
+    assert after is not None
+    assert after.purchase_unavailable is True
+    assert after.tracks_unavailable is True
+
+
+def test_a_retag_records_which_media_are_video(client, cfg, monkeypatch):
+    """The release is in hand and carries the per-track video flag, so the fact
+    is written at the moment it is known (#237) — rather than the album going
+    Incomplete and a later reconcile pass spending a request to find it out."""
+    d = _album(cfg, Sidecar(mb_release_id=MBID, tagged_at=TAGGED_AT))
+    monkeypatch.setattr(mb_lookup, "fetch_release", lambda mbid: _release(video_disc=True))
+
+    def _boom(mbid):
+        raise AssertionError("the release already says which media are video")
+
+    monkeypatch.setattr(mb_lookup, "fetch_video_media", _boom)
+
+    client.post(f"/retag/{_album_id(cfg, d)}")
+
+    after = sidecar_mod.read(d)
+    assert after is not None
+    assert after.video_media == (2,)
+
+
+def test_the_audit_line_numbers_tracks_from_one(client, cfg, monkeypatch):
+    """#240: `tag.track` recorded `_flatten_tracks`'s 0-based index, so every
+    line in a production log was off by one against the file it named — and
+    against the tracklist on the page right above it."""
+    d = _album(cfg, Sidecar(mb_release_id=MBID, tagged_at=TAGGED_AT))
+    monkeypatch.setattr(mb_lookup, "fetch_release", lambda mbid: _release(video_disc=False))
+
+    client.post(f"/retag/{_album_id(cfg, d)}")
+
+    rows = [
+        e.message
+        for e in activity_store.recent(50, source=activity_store.Source.AUDIT)
+        if e.message.startswith("tag.track")
+    ]
+    assert any('file="01 Track 1.m4a" track=1' in m for m in rows), rows
+    assert any('file="02 Track 2.m4a" track=2' in m for m in rows), rows
+    assert not any("track=0" in m for m in rows)


### PR DESCRIPTION
`_tag_with_release` constructed a fresh `Sidecar(...)` field by field, so every field it did not name was reset to its default on every re-tag:

```
KEPT     store_url, bandcamp, downloaded_at, added_at,
         mb_release_id, mb_match_candidate, tagged_at, notes
DROPPED  video_media, purchase_unavailable, tracks_unavailable, temp_uid, schema_version
```

- **`video_media`** (#206) — an album with a bonus DVD went Incomplete straight after a *successful* re-tag and stayed there until a reconcile pass spent a rate-limited MusicBrainz request re-learning what Harmonist had already written down. On a settled library nothing kicks that pass except a sync or a restart. This is what *TISM — The White Albun* did on the NAS the moment #237 let it re-tag at last.
- **`purchase_unavailable`** and **`tracks_unavailable`** — the surrender and accept-as-done flags, whose entire purpose is to be permanent; their own docstring says the album otherwise re-classifies NEEDS_SYNC and re-surrenders on the next full sync.
- `temp_uid` and `schema_version` were dropped harmlessly — `write()` normalises identity, and the default is the current version.

## The fix

`replace(sc, …)`, so anything not explicitly changed carries through **by construction**. The shape was the bug, not those three fields: the next field added to `Sidecar` would have joined them, silently, with nothing in the suite to notice. The main test therefore asserts the *whole* record — a fully populated sidecar in, and exactly three fields allowed to differ — rather than the fields that happened to be wrong this time.

While tagging, `video_media` is now also recorded from the release already in hand: `video_media_of` is pure since #237 and `fetch_release` asks for recordings, so the one fact the files cannot carry is written at the moment it is known. No request, and no spell of wrong state waiting on a pass that might not run for hours.

Per the `sidecar` skill: no new field, `CURRENT_SCHEMA_VERSION` untouched, and `_to_dict` already handles `video_media`'s `[]`-vs-absent distinction. `video_media` is on the audited load-bearing list, so the first re-tag of an album records one `sidecar.update` row — a one-time correction, silent thereafter.

## Also here: #240

`tag.track` recorded `_flatten_tracks`'s 0-based index, so every audit line was off by one against the file it named *and* against the tracklist on the page above it. Straight from the production log:

```
tag.track file="01 Everyone Else Has Had More Sex Than Me.m4a" track=0
tag.track file="16 TISM Are Shit.m4a"                          track=15
```

These rows are permanent and rendered in History, and a track number one off is exactly what someone auditing a re-tag would read as the tagger having assigned the wrong track — the failure #232 was about. Rows already written keep the old value.

`make check` green (1232 passed). All three changes are mutation-checked: reverting the carry-through, the video-media record, or the `+ 1` each reddens the tests that cover them.

Fixes #239
Fixes #240
