### PR TITLE
Name the missing disc, and label the acceptance with what it does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ versions follow [semantic versioning](https://semver.org).
   tracks on disk", under the MusicBrainz and Bandcamp badges — instead of
   leaving that to the Library tile you just came from (#227). When the shortfall
   is a whole disc it names it: "Disc 2 of 2 is missing" (#245).
-- **No more tracks to get** is now a checkbox beside that badge rather than a
-  button in the action row, so it shows whether the album is accepted instead of
-  making you read it backwards off the button's label. Ticking it turns the
-  badge from amber to grey; the album still says how short it is (#227).
+- Accepting an incomplete album is now a checkbox beside that badge — **Don't
+  warn me about this** — rather than a button in the action row, so it shows
+  whether the album is accepted instead of making you read it backwards off the
+  button's label. Ticking it turns the badge from amber to grey; the album still
+  says how short it is (#227, #245).
 
 ## [1.10.2] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ versions follow [semantic versioning](https://semver.org).
 
 - An album's own page now states how much of the release is on disk — "10 of 11
   tracks on disk", under the MusicBrainz and Bandcamp badges — instead of
-  leaving that to the Library tile you just came from (#227).
+  leaving that to the Library tile you just came from (#227). When the shortfall
+  is a whole disc it names it: "Disc 2 of 2 is missing" (#245).
 - **No more tracks to get** is now a checkbox beside that badge rather than a
   button in the action row, so it shows whether the album is accepted instead of
   making you read it backwards off the button's label. Ticking it turns the

--- a/docs/design.md
+++ b/docs/design.md
@@ -580,10 +580,22 @@ File: `<album_dir>/.harmonist.json`. UTF-8, two-space indent, written atomically
   there is nothing to act on. A Blu-ray where only the stereo mixes were ripped;
   a hidden CD track never ripped from a disc since thrown away.
 
-  The claim is about the **source** — "there are no more tracks to get" — not
-  about the UI. That is what keeps it from becoming a general "ignore this
-  album", and it is why a Bandcamp album whose artist has since added tracks is
-  the wrong candidate: those can genuinely be fetched (#132).
+  The control is labelled with what it **does** — *Don't warn me about this* —
+  because that is the whole of its effect: the badge is demoted and the album
+  leaves the Incomplete filter. It was originally phrased as a claim about the
+  source ("there are no more tracks to get"), on the reasoning that a checkable
+  claim keeps the field from becoming a general "ignore this album". Two things
+  were wrong with that. The claim isn't checkable by the person making it —
+  whether a hidden track can still be got *somewhere* is not a fact about their
+  own shelf — and it names tracks, under a badge that may be reporting a missing
+  disc (#245).
+
+  The cost of the change is recorded here rather than lost: the data no longer
+  distinguishes "as complete as this album can be" from "the user muted a
+  shortfall that is genuinely fixable" — a Bandcamp album whose artist has since
+  added tracks, which *can* be fetched (#132). Nothing reads that distinction
+  today; a future gardener pass that offers to fetch newly-available tracks
+  (#32) would want it, and would need to ask rather than infer.
 
   It does **not** change state. The album really is short, `INCOMPLETE` says so
   truthfully, and both the tile and the album page still report the count — in

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -186,10 +186,11 @@ done but still wrong, each with its count:
 
   Some albums are incomplete on purpose and always will be — you ripped only the
   stereo mixes off a Blu-ray, or the hidden track was never ripped and the CD is
-  long gone. Tick **No more tracks to get**, beside that badge, and the album
+  long gone. Tick **Don't warn me about this**, beside that badge, and the album
   drops out of this list. It stays marked "N of M" — the album really is short,
-  and that goes on being true — but the badge turns from amber to grey: a
-  statement rather than something to fix. Untick it if you change your mind.
+  and that goes on being true — but the badge turns from amber to grey, here and
+  on the tile: a statement rather than something to fix. Untick it if you change
+  your mind.
 - **Partially tagged** — some files carry the MusicBrainz Album Id and some don't.
   A half-finished tagging run, or Picard applied to part of a folder, leaves this.
 - **No artwork** — correctly tagged, fully linked, and still a grey square in

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -179,9 +179,10 @@ done but still wrong, each with its count:
   lists the discs that aren't on disk, so nothing is hidden. A DVD you ripped
   only part of does still count as incomplete.
 
-  The album's own page says the same thing in words — *"10 of 11 tracks on
-  disk"*, under the MusicBrainz and Bandcamp badges — so you don't have to work
-  it out from the tracklist below it.
+  The album's own page says the same thing in words, under the MusicBrainz and
+  Bandcamp badges, so you don't have to work it out from the tracklist below it:
+  *"10 of 11 tracks on disk"*, or — where the tile could only manage
+  *Incomplete* — the disc you're missing, *"Disc 2 of 2 is missing"*.
 
   Some albums are incomplete on purpose and always will be — you ripped only the
   stereo mixes off a Blu-ray, or the hidden track was never ripped and the CD is

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -520,6 +520,7 @@ def create_app(
     templates.env.globals["display_path"] = _display_path
     templates.env.globals["rel_path"] = _rel_path
     templates.env.globals["ago"] = _ago
+    templates.env.globals["missing_discs"] = _missing_discs
     templates.env.globals["AUDIT_DETAIL_LIMIT"] = AUDIT_DETAIL_LIMIT
     # The tracklist table's headings. A global rather than a per-route context
     # value because it must stay in lockstep with the field order the model
@@ -829,6 +830,33 @@ def _merge_unscoped_audit(events: list[activity.Event], since: datetime) -> list
     if not unscoped:
         return events
     return sorted([*events, *unscoped], key=lambda e: e.ts, reverse=True)
+
+
+def _missing_discs(absent: frozenset[int], disc_total: int | None) -> str:
+    """The completeness badge's text — "Disc 2 of 2 is missing" — for an album
+    whose shortfall is a whole medium with no files at all (#245).
+
+    Names the disc because it can: `absent_media` is scanner-derived from the
+    files' own `disk` tags, so this costs no MusicBrainz call. What it cannot
+    name is the disc's TITLE — MusicBrainz has that, the files don't, and the
+    badge renders before the release is fetched. The number is what's free.
+
+    "of N" only in the singular. "Discs 2 and 3 of 4 are missing" parses as a
+    fraction of a fraction; the plural drops it and stays readable.
+
+    Deliberately says nothing about "disk". The badge's other branch already ends
+    "tracks on disk", and this one used to read "a disc of this release has no
+    tracks on disk" — two load-bearing near-homophones four words apart, which is
+    a pun to parse before the fact arrives (#245).
+    """
+    discs = sorted(absent)
+    if not discs:
+        return ""  # caller's branch guards this; nothing sensible to say
+    if len(discs) == 1:
+        of_total = f" of {disc_total}" if disc_total else ""
+        return f"Disc {discs[0]}{of_total} is missing"
+    listed = f"{', '.join(str(d) for d in discs[:-1])} and {discs[-1]}"
+    return f"Discs {listed} are missing"
 
 
 def _ago(when: datetime | None) -> str:

--- a/templates/partials/_completeness.html
+++ b/templates/partials/_completeness.html
@@ -54,11 +54,17 @@
        posts accept=true, an unticked one posts nothing and the endpoint's default
        reads that as taking the acceptance back.
 
-       Phrased as a claim about the SOURCE — there are no more tracks to get —
-       because that is checkable, where "ignore this" is not. #}
+       Labelled with what ticking it DOES, because that is all it does: the flag
+       demotes this badge and drops the album from the Incomplete filter, and
+       touches no state, tag or file. It read "No more tracks to get" until #245
+       — a claim about the source, which had two problems. It changed unit under
+       a badge that now says "Disc 2 of 2 is missing"; and it asked the reader to
+       assert something they generally cannot know, since whether a hidden track
+       is obtainable *somewhere* is not a fact about their own shelf. "Stop
+       flagging this" is entirely within what they know. #}
     <label class="inline-flex items-center gap-1.5 cursor-pointer select-none
                   text-2xs uppercase tracking-widest font-bold text-muted hover:text-ink transition"
-           title="{% if _accepted %}Untick to put this album back in the Library's Incomplete list.{% else %}The missing tracks aren't available, so stop listing this album as incomplete. It stays marked above — only the Incomplete filter ignores it.{% endif %}">
+           title="{% if _accepted %}Untick to have the Library list this album as incomplete again.{% else %}Stop listing this album as incomplete — for when what's missing isn't coming. The shortfall stays stated above, in grey rather than amber; only the Incomplete filter ignores it.{% endif %}">
         <input type="checkbox" name="accept" value="true" class="cursor-pointer"
                {% if _accepted %}checked{% endif %}
                hx-post="/library/{{ album.id }}/tracks-unavailable"
@@ -68,7 +74,7 @@
                   nothing, which would leave the box showing a setting that was
                   never persisted — so put it back. #}
                hx-on::after-request="if (!event.detail.successful) this.checked = !this.checked">
-        No more tracks to get
+        Don't warn me about this
     </label>
 </div>
 {% endif %}

--- a/templates/partials/_completeness.html
+++ b/templates/partials/_completeness.html
@@ -18,8 +18,14 @@
 <div id="album-completeness-{{ album.id }}"{% if oob %} hx-swap-oob="true"{% endif %}
      class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
     {# The denominator comes from the files' own tags (#195) and is absent when a
-       whole disc is missing — nothing on disk records how long it was. Say so
-       rather than inventing one.
+       whole disc is missing — nothing on disk records how long it was. Name the
+       disc then rather than inventing a total (#245); `absent_media` is derived
+       from the same tags, so it costs nothing to say WHICH.
+
+       Three branches, and the third is not decoration: an INCOMPLETE album with
+       no total always has absent media today (the no-totals case derives
+       COMPLETE, so it never reaches here), but the badge should state less
+       rather than guess if that ever stops being true.
 
        Amber says "this needs attention". An album accepted as finished (#196) is
        still short and still says so, but it is no longer work — so the badge is
@@ -27,11 +33,13 @@
        fact about the album to make the page tidier. #}
     <span class="inline-flex items-center px-2.5 py-1 rounded-md text-2xs font-bold
                  {{ 'bg-surface text-muted border border-line' if _accepted else 'bg-amber-50 text-amber-700 border border-amber-300' }}"
-          title="{% if album.expected_track_count %}The total comes from the files' own tags, written from MusicBrainz.{% else %}A medium of this release has no files on disk at all, so nothing records how many tracks it had.{% endif %}{% if _accepted %} You've accepted this album as complete, so the Library's Incomplete filter skips it.{% endif %}">
+          title="{% if album.expected_track_count %}The total comes from the files' own tags, written from MusicBrainz.{% elif album.absent_media %}That disc has no files at all, so nothing on disk records how many tracks it held — the Tracks section lists what MusicBrainz says is on it.{% else %}Fewer tracks on disk than this release has.{% endif %}{% if _accepted %} You've accepted this album as complete, so the Library's Incomplete filter skips it.{% endif %}">
         {% if album.expected_track_count %}
         {{ album.track_count }} of {{ album.expected_track_count }} tracks on disk
+        {% elif album.absent_media %}
+        {{ missing_discs(album.absent_media, album.disc_total) }}
         {% else %}
-        Incomplete &mdash; a disc of this release has no tracks on disk
+        Incomplete
         {% endif %}
     </span>
 

--- a/templates/partials/library_detail.html
+++ b/templates/partials/library_detail.html
@@ -235,8 +235,8 @@
                         class="px-3 py-1.5 bg-surface hover:bg-line text-ink border border-line rounded text-xs font-bold uppercase tracking-widest transition">
                     Forget
                 </button>
-                {# "No more tracks to get" used to sit here, as a button reading
-                   "Mark incomplete again" once accepted. It moved up to the
+                {# The acceptance used to sit here, as a button reading "No more
+                   tracks to get" / "Mark incomplete again". It moved up to the
                    completeness badge as a checkbox (#227): it acts on that badge
                    rather than on the album generally, and a button could only
                    show the ACTION, leaving you to infer the state backwards from

--- a/templates/partials/library_tile.html
+++ b/templates/partials/library_tile.html
@@ -40,7 +40,7 @@
            because hiding it would lose a true fact about the album. #}
         {% set _accepted = sc and sc.tracks_unavailable %}
         <span class="absolute bottom-1.5 left-1.5 px-1.5 py-0.5 text-2xs font-bold rounded {{ 'bg-surface text-muted border border-line' if _accepted else 'bg-amber-50 text-amber-700 border border-amber-300' }}"
-              title="{% if album.expected_track_count %}{{ album.track_count }} of {{ album.expected_track_count }} tracks on disk{% else %}A disc of this release has no tracks on disk{% endif %}{% if _accepted %} — accepted as complete; the rest aren't available{% endif %}">
+              title="{% if album.expected_track_count %}{{ album.track_count }} of {{ album.expected_track_count }} tracks on disk{% elif album.absent_media %}{{ missing_discs(album.absent_media, album.disc_total) }}{% else %}Fewer tracks on disk than this release has{% endif %}{% if _accepted %} — accepted as complete; the rest aren't available{% endif %}">
             {% if album.expected_track_count %}{{ album.track_count }} of {{ album.expected_track_count }}{% else %}Incomplete{% endif %}
         </span>
         {% endif %}

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6393,9 +6393,36 @@ def test_a_complete_album_gets_no_completeness_badge(client, cfg):
     assert "album-completeness" not in page
 
 
-def test_an_album_missing_a_whole_disc_gets_no_invented_denominator(client, cfg):
+@pytest.mark.parametrize(
+    "absent,disc_total,expected",
+    [
+        ({2}, 2, "Disc 2 of 2 is missing"),
+        ({2}, None, "Disc 2 is missing"),  # the files don't agree on a disc count
+        ({2, 3}, 3, "Discs 2 and 3 are missing"),  # no "of 3": a fraction of a fraction
+        # Disc numbers whose SET iteration order isn't ascending — {9, 2} yields
+        # 9 first — so this fails if the sort is dropped. {2, 3, 4} would not:
+        # small ints hash to themselves, so that set already iterates in order
+        # and would pass either way.
+        ({9, 2, 5}, 10, "Discs 2, 5 and 9 are missing"),
+    ],
+)
+def test_the_missing_disc_phrase(absent, disc_total, expected):
+    """The badge's text for an album short by whole media (#245). Unit-tested
+    because the plural forms are fiddly and each would otherwise need its own
+    multi-disc fixture to reach through a page."""
+    from harmonist.web.main import _missing_discs
+
+    assert _missing_discs(frozenset(absent), disc_total) == expected
+
+
+def test_an_album_missing_a_whole_disc_names_the_disc(client, cfg):
     """`expected_track_count` is None when a medium has no files at all — nothing
-    on disk records how long it was. The badge says so instead of guessing."""
+    on disk records how long it was — so the badge can't count. It says which
+    disc is missing instead, which is the question "a disc of this release" left
+    the reader to take to the tracklist (#245).
+
+    Also the only spelling of the shortfall that avoids putting "disc" and "on
+    disk" in one sentence, four words apart."""
     from test.helpers import write_track_totals
 
     d = _make_tagged_album(cfg, "Boxed", mbid="rel-boxed", tagged_at=datetime.now(UTC))
@@ -6403,8 +6430,8 @@ def test_an_album_missing_a_whole_disc_gets_no_invented_denominator(client, cfg)
 
     page = client.get(f"/album/{_id_for(cfg, d)}").text
 
-    assert "no tracks on disk" in page
-    assert "of 1 tracks on disk" not in page
+    assert "Disc 2 of 2 is missing" in page
+    assert "of 1 tracks on disk" not in page, "no denominator invented from the disc that IS here"
 
 
 def test_accepting_demotes_the_badge_instead_of_removing_it(client, cfg):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6349,10 +6349,10 @@ def test_the_album_page_offers_the_acceptance_only_when_incomplete(client, cfg):
     whole = _make_tagged_album(cfg, "Whole", mbid="rel-whole", tagged_at=datetime.now(UTC))
 
     page = client.get(f"/album/{_id_for(cfg, incomplete)}").text
-    assert "No more tracks to get" in page
+    assert "Don't warn me about this" in page
     assert not _is_checked(page, "tracks-unavailable"), "not accepted yet"
 
-    assert "No more tracks to get" not in client.get(f"/album/{_id_for(cfg, whole)}").text
+    assert "warn me about this" not in client.get(f"/album/{_id_for(cfg, whole)}").text
 
 
 def test_the_album_page_offers_the_way_back_once_accepted(client, cfg):


### PR DESCRIPTION
Two wording changes to the completeness blob on an album's page, one of which turned out to need the other.

## The badge names the disc

An album short by a whole medium read **"Incomplete — a disc of this release has no tracks on disk"**. "disc" and "on disk" are both load-bearing in this UI and mean different things — a medium of the release, and the user's own folders — so four words apart, as near-homophones, they make the reader parse a pun before the fact arrives. The tooltip then introduced a third word, "medium", which is MusicBrainz's term and appears nowhere else in the interface.

It now says **"Disc 2 of 2 is missing"**, which costs nothing: `absent_media` is derived from the same `disk` tags the track count comes from, so naming the disc needs no MusicBrainz call. Plural when several are absent, and the "of N" is dropped there because "Discs 2 and 3 of 4 are missing" reads as a fraction of a fraction. The disc's *title* stays out of it — MusicBrainz has that, the files don't, and the badge renders before the release is fetched.

The tile keeps its bare "Incomplete" (no room on an image), but its tooltip now uses the same sentence, so hovering the tile and opening the album say the same thing in the same words.

A third template branch appears, for INCOMPLETE with neither a total nor absent media. It cannot happen today — the no-totals case derives COMPLETE, so the only route to a missing total is an absent medium — and it renders a bare "Incomplete" rather than a confident sentence about a disc that might not be the reason.

## The checkbox says what it does

Naming the disc made **"No more tracks to get"** change unit mid-thought: tracks, under a badge reporting a disc. Looking at it properly, the label had a deeper problem — it asked the reader to assert something they generally cannot know. Whether a hidden track can still be got *somewhere* is not a fact about their own shelf.

It now reads **"Don't warn me about this"**, which is the whole of what ticking it does: demote the badge from amber to grey, and drop the album from the Library's Incomplete filter. No state, tag or file changes either way, and the shortfall stays stated — greyed, not hidden.

`docs/design.md` records what the old framing bought, rather than quietly dropping it: the data no longer distinguishes "as complete as this album can be" from "the user muted a shortfall that is genuinely fixable" (#132). Nothing reads that distinction today; a gardener pass offering to fetch newly-available tracks (#32) would want it and will have to ask rather than infer.

The sidecar field stays `tracks_unavailable` — it is on users' disks with no migration runner, and renaming it would buy tidiness at the price the `sidecar` skill exists to prevent.

## Verification

`make check` green. The badge test went red first, on its assertion, before the helper existed. Both states exercised in a browser against a real disc-1-of-2 album, ticking and unticking without a reload.

The unit test for the plural forms was mutation-checked and **failed the check**: its first case (`{4, 2, 3}`) passed with `sorted()` removed, because small ints hash to themselves and that set already iterates in order. Replaced with `{9, 2, 5}`, which iterates `9, 2, 5` — that case now fails without the sort, and passes with it.

Fixes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016emoJJZvLEb5dw83voQcEW