### PR TITLE
Tidy the Library header: drop the redundant heading, move the page-size control down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ versions follow [semantic versioning](https://semver.org).
   whether the album is accepted instead of making you read it backwards off the
   button's label. Ticking it turns the badge from amber to grey; the album still
   says how short it is (#227, #245).
+- The Library no longer repeats itself above the grid: the `LIBRARY · N done`
+  heading is gone, since the tab directly above already names the Library and
+  counts it — and "done" quietly disagreed with the Incomplete filter sitting
+  underneath. The **Show N per page** control has moved down beside the pager,
+  where you reach for it after reading a page (#217).
 
 ## [1.10.2] - 2026-08-22
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1137,9 +1137,9 @@ def _library_page_vars(
         reverse=True,
     )
     # How many terminal albums exist, before any filter — the Library's own count,
-    # and the number the header reports. Captured here because `shown` below is a
-    # DIFFERENT number once a filter is on, and the two must not be conflated: the
-    # header says how big the library is, the pager says how much of it is on
+    # and the number `data-total-done` reports. Captured here because `shown` below
+    # is a DIFFERENT number once a filter is on, and the two must not be conflated:
+    # the dataset says how big the library is, the pager says how much of it is on
     # screen (#174).
     total_done = len(done)
     # Search narrows BEFORE the filter, and the filter counts below are taken after
@@ -1192,9 +1192,9 @@ def _library_page_vars(
         # rather than being silently corrected, so the control always shows the
         # truth about what's on screen.
         "page_sizes": _LIBRARY_PAGE_SIZES,
-        # The whole Library, unfiltered — the header's "· N done" and the
-        # `data-total-done` attribute both read this. A filtered grid must not let
-        # it start reporting the rows it happens to be rendering (#140).
+        # The whole Library, unfiltered — the `data-total-done` attribute and the
+        # "search all N" links both read this. A filtered grid must not let it
+        # start reporting the rows it happens to be rendering (#140).
         "total_done": total_done,
         # How many albums the search left, before the filter — what the All chip
         # says, and what the chips beside it are subsets of. Equal to `total_done`

--- a/templates/partials/library_page.html
+++ b/templates/partials/library_page.html
@@ -1,4 +1,4 @@
-{# One page of the Library grid — header, tiles, pager — rendered as a whole.
+{# One page of the Library grid — search, filters, tiles, pager — as a whole.
 
    It used to be an accumulator: the first page opened #library-grid and every
    later page appended tiles plus a fresh Load-more button. That made the grid's
@@ -12,77 +12,28 @@
    link inside would then send its own `?page=2` plus the container's `?page=1`,
    and the last value wins — which silently pinned the grid to page 1. Here there
    is no inherited value to collide with, and a refresh mid-browse (every
-   `tasks-changed`) keeps you on your page. #}
+   `tasks-changed`) keeps you on your page.
+
+   It also carries the dataset that says what this render *is*: which slice is on
+   screen (`data-page`, `data-limit`) and how big the whole Library is
+   (`data-total-done` — unfiltered and unsearched, #140's constraint, since a
+   paginated grid cannot be counted by its rendered rows). The browser tests read
+   it to tell an in-place swap from a page load. It used to hang off a `LIBRARY ·
+   N done` heading here, which repeated the tab label and count directly above it
+   and called every terminal album "done" while the chips below offered to filter
+   the Incomplete ones — so the heading went and the dataset stayed (#217). #}
 {% from 'macros.html' import library_query %}
-<div hx-get="/library?{{ library_query(page, limit, filter, q) }}"
+<div id="library-page" data-total-done="{{ total_done }}" data-page="{{ page }}"
+     data-limit="{{ limit }}"
+     hx-get="/library?{{ library_query(page, limit, filter, q) }}"
      hx-trigger="library-refresh from:body, tasks-changed from:body"
      hx-target="#library-rows" hx-swap="innerHTML">
-<div class="flex justify-between items-baseline mb-3 gap-3">
-    {# data-total-done carries the full terminal-album count (not just this
-       page) so the Library tab badge can show the real total — the grid is
-       paginated, so counting rendered rows would under-report. #}
-    <h2 id="library-total" data-total-done="{{ total_done }}" data-page="{{ page }}"
-        data-limit="{{ limit }}"
-        class="text-sm font-semibold text-muted uppercase tracking-widest">Library
-        <span class="ml-1 font-normal normal-case tracking-normal">· {{ total_done }} done</span>
-    </h2>
-    <div class="flex items-baseline gap-4">
-        {% if rows %}
-        {# Page size (#144). A real <form> so it works without JS — submitting to
-           the index URL is exactly what the hx-get does, one tab-panel wider. The
-           hx-get lives on the FORM, not the <select>, so HTMX serialises the
-           hidden inputs alongside the chosen size; `change` bubbles up from the
-           select, so no click handler is needed (and none is allowed here — an
-           onclick beside hx-* is what `make template-lint` fails on).
-
-           `submit` is in the trigger list on purpose. A form's DEFAULT hx-trigger
-           is `submit`, and naming `change` REPLACES that default rather than
-           adding to it — so with `change` alone any submit event reaching this
-           form escapes HTMX and the browser navigates to `action` instead. Same
-           albums, but a full page load, and the address bar left reading
-           `?anchor=3&limit=40`: the transient hint stranded where the resolved
-           `?page=` belongs, ready to be bookmarked. Committing the select with the
-           keyboard is enough to do it.
-
-           `anchor` is the first row on screen. The server resolves it against the
-           NEW size and corrects the address bar with an HX-Push-Url header, so
-           picking a bigger page keeps the album you were looking at in view
-           instead of throwing you back to page 1. #}
-        <form method="get" action="/" hx-get="/library" hx-trigger="change, submit"
-              hx-target="#library-rows" hx-swap="innerHTML"
-              class="flex items-baseline gap-1.5">
-            <input type="hidden" name="tab" value="library">
-            <input type="hidden" name="anchor" value="{{ first_row }}">
-            {# The filter and the search travel with the size, or picking "40 per
-               page" would quietly answer a different question than the one on
-               screen. #}
-            {% if filter %}<input type="hidden" name="filter" value="{{ filter }}">{% endif %}
-            {% if q %}<input type="hidden" name="q" value="{{ q }}">{% endif %}
-            <label for="library-limit"
-                   class="text-xs text-muted uppercase tracking-widest font-bold">Show</label>
-            <select id="library-limit" name="limit"
-                    class="bg-white border border-line rounded px-1.5 py-0.5 text-xs text-ink focus:border-accent outline-none">
-                {# An off-menu size — hand-typed, or remembered from a build that
-                   offered different ones — is shown rather than silently swapped
-                   for a neighbour, so the control never misreports the page. #}
-                {% if limit not in page_sizes %}<option selected>{{ limit }}</option>{% endif %}
-                {% for size in page_sizes %}
-                <option value="{{ size }}" {{ 'selected' if size == limit }}>{{ size }}</option>
-                {% endfor %}
-            </select>
-            <span class="text-xs text-muted">per page</span>
-            {# Without JS the change event can't submit anything; give that reader
-               a button. HTMX users never see it. #}
-            <noscript><button type="submit"
-                    class="text-xs font-bold text-accent">Apply</button></noscript>
-        </form>
-        {% endif %}
-        <button hx-get="/library?{{ library_query(page, limit, filter, q) }}"
-                hx-target="#library-rows" hx-swap="innerHTML"
-                class="text-xs text-muted hover:text-accent transition uppercase tracking-widest font-bold">
-            Refresh
-        </button>
-    </div>
+<div class="mb-3 flex justify-end">
+    <button hx-get="/library?{{ library_query(page, limit, filter, q) }}"
+            hx-target="#library-rows" hx-swap="innerHTML"
+            class="text-xs text-muted hover:text-accent transition uppercase tracking-widest font-bold">
+        Refresh
+    </button>
 </div>
 
 {# Search (#180). The filters below find albums that are *wrong*; this finds the
@@ -185,8 +136,8 @@
 {% set chip_dead = chip ~ " border-transparent text-muted opacity-40 cursor-default select-none" %}
 {# Every count here is `total_matched`-relative, not library-relative: under a
    search the chips report what they would yield *within it* (#180). All says how
-   many the search left; the rest are subsets of that. The header above is the one
-   number that stays library-wide. #}
+   many the search left; the rest are subsets of that. The container's
+   `data-total-done` is the one number that stays library-wide. #}
 <nav class="mb-3 flex flex-wrap items-center gap-1.5" aria-label="Library filters">
     {% if filter %}
     <a href="/?tab=library&{{ library_query(none, limit, none, q) }}"
@@ -264,6 +215,13 @@
     {% for album in rows %}{% include 'partials/library_tile.html' %}{% endfor %}
 </div>
 
+{# The pager and the page-size control, at the bottom together: both are things
+   you reach for after reading a page, not before, and #217 moved the size down
+   here from above the search box for that reason. The size control survives a
+   single-page library — dropping to 20 is a way to *make* a second page — so it
+   is gated on `rows`, which this branch already establishes, and not on the
+   pager's `total_pages > 1`. #}
+<div class="mt-5">
 {% if total_pages > 1 %}
 {# Pager. Each control is a real <a href> to the index URL for that page AND an
    hx-get that swaps just the grid: with JS it's an in-place swap that pushes the
@@ -272,7 +230,7 @@
    construction, so the address bar always names what's on screen.
    At the ends the control becomes a plain disabled <span> — there is no disabled
    state for an anchor, and a link to a page that doesn't exist is worse. #}
-<nav class="mt-5 flex items-center justify-between gap-4" aria-label="Library pages">
+<nav class="flex items-center justify-between gap-4" aria-label="Library pages">
     {% set nav_class = "px-3 py-1.5 rounded border border-line text-sm font-bold transition" %}
     {% if prev_page %}
     <a href="/?tab=library&{{ library_query(prev_page, limit, filter, q) }}"
@@ -286,8 +244,8 @@
     {% endif %}
 
     {# `total_shown`, not `total_done`: this readout describes the list being paged,
-       which under a filter is a subset. The header keeps reporting the whole
-       library — one number cannot honestly be both (#174). #}
+       which under a filter is a subset. The container's `data-total-done` keeps
+       reporting the whole library — one number cannot honestly be both (#174). #}
     <span class="text-xs text-muted tabular-nums">
         {{ first_row }}–{{ last_row }} of {{ total_shown }}
         <span class="mx-1 opacity-50">·</span>
@@ -306,5 +264,53 @@
     {% endif %}
 </nav>
 {% endif %}
+
+{# Page size (#144). A real <form> so it works without JS — submitting to the
+   index URL is exactly what the hx-get does, one tab-panel wider. The hx-get
+   lives on the FORM, not the <select>, so HTMX serialises the hidden inputs
+   alongside the chosen size; `change` bubbles up from the select, so no click
+   handler is needed (and none is allowed here — an onclick beside hx-* is what
+   `make template-lint` fails on).
+
+   `submit` is in the trigger list on purpose. A form's DEFAULT hx-trigger is
+   `submit`, and naming `change` REPLACES that default rather than adding to it —
+   so with `change` alone any submit event reaching this form escapes HTMX and the
+   browser navigates to `action` instead. Same albums, but a full page load, and
+   the address bar left reading `?anchor=3&limit=40`: the transient hint stranded
+   where the resolved `?page=` belongs, ready to be bookmarked. Committing the
+   select with the keyboard is enough to do it.
+
+   `anchor` is the first row on screen. The server resolves it against the NEW
+   size and corrects the address bar with an HX-Push-Url header, so picking a
+   bigger page keeps the album you were looking at in view instead of throwing you
+   back to page 1. #}
+<form method="get" action="/" hx-get="/library" hx-trigger="change, submit"
+      hx-target="#library-rows" hx-swap="innerHTML"
+      class="mt-3 flex items-baseline justify-end gap-1.5">
+    <input type="hidden" name="tab" value="library">
+    <input type="hidden" name="anchor" value="{{ first_row }}">
+    {# The filter and the search travel with the size, or picking "40 per page"
+       would quietly answer a different question than the one on screen. #}
+    {% if filter %}<input type="hidden" name="filter" value="{{ filter }}">{% endif %}
+    {% if q %}<input type="hidden" name="q" value="{{ q }}">{% endif %}
+    <label for="library-limit"
+           class="text-xs text-muted uppercase tracking-widest font-bold">Show</label>
+    <select id="library-limit" name="limit"
+            class="bg-white border border-line rounded px-1.5 py-0.5 text-xs text-ink focus:border-accent outline-none">
+        {# An off-menu size — hand-typed, or remembered from a build that offered
+           different ones — is shown rather than silently swapped for a neighbour,
+           so the control never misreports the page. #}
+        {% if limit not in page_sizes %}<option selected>{{ limit }}</option>{% endif %}
+        {% for size in page_sizes %}
+        <option value="{{ size }}" {{ 'selected' if size == limit }}>{{ size }}</option>
+        {% endfor %}
+    </select>
+    <span class="text-xs text-muted">per page</span>
+    {# Without JS the change event can't submit anything; give that reader a
+       button. HTMX users never see it. #}
+    <noscript><button type="submit"
+            class="text-xs font-bold text-accent">Apply</button></noscript>
+</form>
+</div>
 {% endif %}
 </div>

--- a/test/e2e/test_library_page_size.py
+++ b/test/e2e/test_library_page_size.py
@@ -56,7 +56,7 @@ def test_choosing_a_size_swaps_in_place_and_names_the_resolved_page(demo_server:
         _open_library_page_two(page, demo_server)
 
         page.select_option("#library-limit", "20")
-        page.wait_for_function("document.querySelector('#library-total')?.dataset.limit === '20'")
+        page.wait_for_function("document.querySelector('#library-page')?.dataset.limit === '20'")
 
         assert page.evaluate("window.__harmonistNoReload === true"), "the grid reloaded"
         # Row 3 — the top of page 2 at size 2 — sits on page 1 at size 20.

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2042,9 +2042,10 @@ def test_library_page_two_holds_the_next_slice(client, cfg):
     assert r.text.count('id="lib-') == 2
     assert "Album2" in r.text and "Album3" in r.text
     assert "Album0" not in r.text
-    # Every page is a whole render now, header included — it replaces the grid
-    # rather than appending to it, so page 2 must stand on its own.
-    assert "<h2" in r.text
+    # Every page is a whole render now, search and filters included — it replaces
+    # the grid rather than appending to it, so page 2 must stand on its own.
+    assert 'id="library-search"' in r.text
+    assert 'aria-label="Library filters"' in r.text
     assert 'data-page="2"' in r.text
 
 
@@ -2116,6 +2117,25 @@ def test_library_page_size_control_offers_the_sizes_and_marks_the_current_one(cl
     # in test/e2e/test_library_page_size.py, which most runs skip — this is the
     # cheap guard against the attribute being tidied by someone who never sees it.
     assert 'hx-trigger="change, submit"' in body
+
+
+def test_library_page_size_control_sits_below_the_grid(client, cfg):
+    """It is a control you reach for after reading a page, so it belongs at the
+    bottom with the pager rather than above the search box, competing for the top
+    of the view (#217). Rendering order is the only handle the server has on that."""
+    _make_library(cfg, 3)
+    body = client.get("/library").text
+    assert body.index('id="library-grid"') < body.index('id="library-limit"')
+    assert body.index('id="library-search"') < body.index('id="library-limit"')
+
+
+def test_library_page_size_control_survives_a_single_page(client, cfg):
+    """The pager disappears when everything fits on one page; the size control must
+    not go with it. Dropping to 20 is how a reader *makes* a second page."""
+    _make_library(cfg, 3)
+    body = client.get("/library?limit=40").text
+    assert 'aria-label="Library pages"' not in body
+    assert 'id="library-limit"' in body
 
 
 def test_library_page_size_control_is_absent_when_there_is_nothing_to_size(client, cfg):
@@ -2291,10 +2311,11 @@ def test_library_filter_counts_come_from_the_whole_library_not_the_page(client, 
     assert re.search(r"Incomplete\s*<span[^>]*>5</span>", body)  # all five, not the two shown
 
 
-def test_library_header_total_ignores_the_filter(client, cfg):
-    """#140's constraint: the header (and the `data-total-done` the tab count
-    reads) reports the whole library. A filtered grid must not let it start
-    reporting the rows it happens to be rendering."""
+def test_library_total_done_ignores_the_filter(client, cfg):
+    """#140's constraint: `data-total-done` reports the whole library, however the
+    grid below it is narrowed. A filtered grid must not let it start reporting the
+    rows it happens to be rendering — the "show all N" ways out read it, and so do
+    the browser tests that wait for a particular render."""
     from datetime import datetime
 
     base = datetime.now(UTC)
@@ -2302,7 +2323,7 @@ def test_library_header_total_ignores_the_filter(client, cfg):
     _make_incomplete_album(cfg, "Short", mbid="rel-short", tagged_at=base)
     body = client.get("/library?filter=incomplete").text
     assert 'data-total-done="2"' in body
-    assert "· 2 done" in body
+    assert body.count('id="lib-') == 1  # one incomplete album on screen, of the two
 
 
 def test_library_filtered_pager_reports_the_filtered_total(client, cfg):
@@ -2570,9 +2591,9 @@ def test_library_search_matching_nothing_names_the_query(client, cfg):
     assert "Clear the search" in body
 
 
-def test_library_header_total_ignores_the_search(client, cfg):
-    """`data-total-done` feeds the Library tab badge, which reports the whole
-    library. A searched grid must not let it start reporting its own rows (#140)."""
+def test_library_total_done_ignores_the_search(client, cfg):
+    """The other narrowing, same rule: `data-total-done` reports the whole library,
+    so a searched grid must not let it start reporting its own rows (#140)."""
     _make_two_albums(cfg)
     body = client.get("/library?q=aphex").text
     assert 'data-total-done="2"' in body
@@ -2791,7 +2812,10 @@ def test_library_page_size_is_bounded(client, cfg):
     assert 'data-limit="200"' in r.text
 
 
-def test_library_empty_still_renders_its_header(client, cfg):
+def test_library_empty_still_describes_itself(client, cfg):
+    """An empty Library is still a render that says what it is: the e2e harness
+    polls `data-total-done` to know when the seeded albums have landed, so the
+    attribute has to be there before there is anything to count."""
     r = client.get("/library")
     assert "No fully-tagged albums yet." in r.text
     assert 'data-total-done="0"' in r.text


### PR DESCRIPTION
The `LIBRARY · 957 done` heading said what the tab an inch above it already said, and said it wrong — "done" means *terminal*, which includes the Incomplete albums the chips directly below offer to pull out. So it goes.

The heading was also carrying the render's dataset — `data-total-done`, `data-page`, `data-limit` — which the browser tests read to tell an in-place swap from a page load. Those move up to the container that survives, now `#library-page`, rather than leaving with the element that happened to hold them. Nothing else consumed them: the Library tab badge comes from `live_counts`, so two comments in `main.py` claiming otherwise are corrected here too.

**Show N per page** moves to the bottom beside the pager, where you reach for it after reading a page. It stays gated on there being rows rather than on the pager's `total_pages > 1` — dropping to 20 is how a reader *makes* a second page. The form moved whole, `hx-trigger="change, submit"` included.

## Verification

- `make check` green; `make css` produced no drift (every class involved is used elsewhere).
- Two new web-rung tests, both mutation-checked red: the placement test fails against the old template, the single-page test fails if the form is moved inside the pager's conditional.
- `make e2e`: both page-size browser tests pass from the form's new home. (Five e2e tests fail on `main` as well, in files this PR doesn't touch — separate problem.)
- Exercised by hand in demo mode, both with and without a pager.

Fixes #217