### PR TITLE
Mark a video track with a camera, not a play button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ versions follow [semantic versioning](https://semver.org).
   whether the album is accepted instead of making you read it backwards off the
   button's label. Ticking it turns the badge from amber to grey; the album still
   says how short it is (#227, #245).
+- Video tracks are now marked with a video-camera icon instead of a play
+  triangle, which looked like a button you could press. Same icon MusicBrainz
+  uses (#249).
 - The Library no longer repeats itself above the grid: the `LIBRARY · N done`
   heading is gone, since the tab directly above already names the Library and
   counts it — and "done" quietly disagreed with the Incomplete filter sitting

--- a/templates/partials/_track_list.html
+++ b/templates/partials/_track_list.html
@@ -122,12 +122,18 @@
                         row a re-tag will never touch, and a track that silently
                         never changes and never compares is worse than one that
                         says why. One mark per row, beside the number, so a disc
-                        of them reads as a column rather than as 26 notices. -#}
+                        of them reads as a column rather than as 26 notices.
+
+                        A camera rather than a play triangle (#249): the triangle
+                        read as a control you could press, and a column of them
+                        down a DVD medium looked like play buttons that do
+                        nothing. MusicBrainz marks its video tracks the same way,
+                        so the glyph is one the user has already been taught. -#}
                     {%- if loop.first and t.video -%}
                     <span class="track-diff__video" role="img" aria-label="Video file"
                           title="A video file — Harmonist reads its tags but never writes them"><svg
-                        viewBox="0 0 24 24" width="9" height="9" fill="currentColor" aria-hidden="true"
-                        ><path d="M5 3L21 12L5 21Z"/></svg></span>
+                        viewBox="0 0 24 24" width="12" height="12" fill="currentColor" aria-hidden="true"
+                        ><path d="M17 10.5V7a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-3.5l4 4v-11l-4 4z"/></svg></span>
                     {%- endif -%}
                     {%- if f.disk -%}
                     {%- with runs = f.disk_runs, value = f.disk %}{% include 'partials/_diff_runs.html' %}{% endwith -%}


### PR DESCRIPTION
The marker beside a video track's number was a play triangle, which reads as a control — on a DVD medium it drew a column of things that look pressable and aren't. A video camera says what the row *is* rather than offering an action, and it's the glyph MusicBrainz puts on its own video tracks, so it arrives already learnt.

12px rather than 9: the camera has interior detail where the triangle had none, and at 9px the lens wedge closed up into a blob. Placement, tooltip, `aria-label` and colour are unchanged.

Verified by rendering the real `/compare` route with the committed stylesheet — demo mode's seeded catalogue has no video tracks, so it can't show this one. No new test: the change is a glyph, and `test_video_tracks.py` already asserts one `track-diff__video` mark per video track. `make css` produced no drift (no class names changed).

Fixes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016emoJJZvLEb5dw83voQcEW