### PR TITLE
Re-download an album from Bandcamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ versions follow [semantic versioning](https://semver.org).
   purchase. Your current files are zipped to the top of your music folder first,
   as `Artist — Album (archived 2026-08-24).zip`, and only removed once the zip
   has been checked; unzip it there to put the album back. The inbox shows the
-  album as re-downloading until the replacement lands.
+  album as re-downloading until the replacement lands, which is then tagged as
+  the same MusicBrainz release the old copy had — re-downloading says the files
+  are wrong, not the match — so the album keeps its history and normally goes
+  straight back to the Library. An album that was already incomplete may come
+  back just as short if the tracks still aren't there; it keeps its tags and its
+  count rather than landing in the inbox.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- **Re-download an album from Bandcamp** (#132) — for upgrading MP3s to FLAC, or
+  picking up tracks the artist has added to a release since you bought it. The
+  button is on the album's own page, for any album linked to a Bandcamp
+  purchase. Your current files are zipped to the top of your music folder first,
+  as `Artist — Album (archived 2026-08-24).zip`, and only removed once the zip
+  has been checked; unzip it there to put the album back. The inbox shows the
+  album as re-downloading until the replacement lands.
+
 ### Changed
 
 - An album's own page now states how much of the release is on disk — "10 of 11

--- a/docs/design.md
+++ b/docs/design.md
@@ -127,27 +127,72 @@ album has no directory, so it is in no state at all — it is held in
 derivation* when `library_index` sees the purchase again (so any route home
 clears it, including the user restoring the zip by hand).
 
-**The replacement is tagged by the ordinary path**, `_resolve_by_store_url` off
-the sync's `post_download_callback` — the same one every first-time download
-takes. So it can land untagged, in exactly the three ways any download can: the
-store URL resolves to no MB release, it resolves but the match is only
-*approximate* (a live release the artist has since grown is precisely this — the
-new file count won't match a stale MB tracklist), or the lookup errors. All three
-leave a sidecar with a `store_url` and no release, i.e. **NEEDS_MBID** — in the
-inbox with Recheck and the assign tools, not silently absent and not silently
-wrong. Worth stating plainly because it is a real cost of the operation: the
-album was COMPLETE before, and the user can get back a copy that needs a click.
-The archive is what makes that recoverable rather than a loss.
+**The release is carried through the round trip.** Re-downloading says the
+*files* are wrong, not the match — the user is looking at an album they already
+accepted as this release and replacing its audio. So the archived album's
+`mb_release_id` is held in `redownloads` and the replacement is tagged as that
+same release (`_tag_as_redownloaded`, off the sync's `post_download_callback`),
+rather than re-resolving the store URL and re-opening a question nobody asked.
+Re-resolution can land on a different release, or on none, turning a finished
+album into inbox work.
 
-**Album history spans the round trip only when the release is unchanged.** The
-archive and delete are recorded under the album's `mb_release_id`; the fresh
-download starts under a path-derived `temp_uid`; tagging it back to the *same*
-release records the `temp_uid → MBID` alias, and `album_history` unions over the
-alias chain — so the album's page shows what happened to it, not just what has
-happened since. If MusicBrainz resolves the store URL to a **different** release,
-nothing joins the two ids and the archive stays on the old album's history:
-findable in the Activity feed, absent from the new album's page. Both halves are
-pinned by tests; the alias is what carries it, so removing it fails them.
+This is **Confirm's semantics, not a guess** — an explicit user decision to tag
+an album as a named release — so the match-confidence assessment is skipped
+exactly as Confirm skips it. What is *not* skipped is the tagger's own count
+guard: whether a tagging is representable is not something a user's assertion can
+make true.
+
+**Whether the copy was INCOMPLETE is carried too**, and this is not a separate
+judgement — it is part of the match the user accepted. An album short of its
+release, re-downloaded to go and get the rest, may well come back just as short
+(the artist hasn't added them after all, or Bandcamp hasn't caught up). That is
+the state it was already in, so it is tagged in the tagger's incomplete mode and
+stays INCOMPLETE. Refusing would charge the user their tags for a shortfall that
+predates the button.
+
+The reverse does **not** get the same treatment: an album that was COMPLETE
+coming back short is a bad download, and gets the strict guard. Both directions
+are pinned by tests, because the rule is wrong if either half is dropped — and
+the first version of this shipped without it, which the demo library caught by
+turning its own INCOMPLETE fixture into inbox work.
+
+**Every case it can't settle falls through to `_resolve_by_store_url`**, i.e. to
+what a first-time download does, so the fallback is never worse than the ordinary
+path:
+
+- The replacement **outgrew** the release (`file_count > track_count`, an error in
+  both tagger modes, §13.3) — MusicBrainz may not have caught up with a release
+  the artist has added to.
+- A previously **COMPLETE** album arrived short (above).
+- The carried release has been **deleted from MusicBrainz** since the archive
+  (#194), or MB is unreachable.
+- The carried match was **lost to a restart** (it is in-memory, like everything
+  else here).
+
+All four leave a sidecar with a `store_url` and no release — **NEEDS_MBID**, in
+the inbox with the side-by-side and Confirm / Confirm as Incomplete on it. Worth
+stating plainly, because it remains a real cost of the operation: an album that
+was COMPLETE can come back needing a click. The archive is what makes that
+recoverable rather than a loss.
+
+**Two lifetimes, two dicts.** The inbox card clears the moment the files are back
+(`prune`, on `library_index.item_ids()`); the carried release must outlive it,
+because the download writes its sidecar — and so populates that index — *before*
+the tagging runs, and the inbox polls every couple of seconds during a sync.
+Holding both in one dict meant a poll landing in that gap silently discarded the
+match. The carried one is instead consumed by `take_match` at the tagging, which
+is also the only thing that clears it on the happy path.
+
+**Album history spans the round trip.** The archive and delete are recorded under
+the album's `mb_release_id`; the fresh download starts under a path-derived
+`temp_uid`; tagging it back to that same release records the `temp_uid → MBID`
+alias, and `album_history` unions over the alias chain — so the album's page
+shows what happened to it, not just what has happened since. Carrying the release
+is what makes this the normal outcome rather than a coincidence. Where it can't
+be carried, nothing joins the two ids and the archive stays on the old album's
+history: findable in the Activity feed, absent from the new album's page. Both
+halves are pinned by tests; the alias is what carries it, so removing it fails
+them.
 
 **Known limitation.** That store and the download approval are both in-memory. A
 restart in the seconds between the archive and its sync loses them, and on a

--- a/docs/design.md
+++ b/docs/design.md
@@ -127,6 +127,28 @@ album has no directory, so it is in no state at all — it is held in
 derivation* when `library_index` sees the purchase again (so any route home
 clears it, including the user restoring the zip by hand).
 
+**The replacement is tagged by the ordinary path**, `_resolve_by_store_url` off
+the sync's `post_download_callback` — the same one every first-time download
+takes. So it can land untagged, in exactly the three ways any download can: the
+store URL resolves to no MB release, it resolves but the match is only
+*approximate* (a live release the artist has since grown is precisely this — the
+new file count won't match a stale MB tracklist), or the lookup errors. All three
+leave a sidecar with a `store_url` and no release, i.e. **NEEDS_MBID** — in the
+inbox with Recheck and the assign tools, not silently absent and not silently
+wrong. Worth stating plainly because it is a real cost of the operation: the
+album was COMPLETE before, and the user can get back a copy that needs a click.
+The archive is what makes that recoverable rather than a loss.
+
+**Album history spans the round trip only when the release is unchanged.** The
+archive and delete are recorded under the album's `mb_release_id`; the fresh
+download starts under a path-derived `temp_uid`; tagging it back to the *same*
+release records the `temp_uid → MBID` alias, and `album_history` unions over the
+alias chain — so the album's page shows what happened to it, not just what has
+happened since. If MusicBrainz resolves the store URL to a **different** release,
+nothing joins the two ids and the archive stays on the old album's history:
+findable in the Activity feed, absent from the new album's page. Both halves are
+pinned by tests; the alias is what carries it, so removing it fails them.
+
 **Known limitation.** That store and the download approval are both in-memory. A
 restart in the seconds between the archive and its sync loses them, and on a
 library with unlinked albums the next sync then runs link-only and surfaces the

--- a/docs/design.md
+++ b/docs/design.md
@@ -75,6 +75,71 @@ the whole reason the `NEEDS_SYNC` state exists.
 2. User clicks **Re-tag from MB** on a Library album's page.
 3. Harmonist re-fetches the MB release and rewrites the file tags. Per-track embedded artwork is preserved unless the user forces **Replace artwork**.
 
+### 2.4.1 Re-download from Bandcamp (#132)
+
+A re-tag rewrites tags; sometimes the **files themselves** are the problem — MP3s
+the user would rather have as FLAC, or a release the artist has added tracks to
+since the purchase (the live@heartlandgathering case, which derives INCOMPLETE
+against MusicBrainz with a live store URL sitting right there). The fix is to let
+the sync fetch a purchase it already has.
+
+**Why the files have to go.** Three independent mechanisms stop a re-fetch, and
+each of them keys off the album being on disk:
+
+1. `sync_items` unions `library_index.item_ids()` into bandcampsync's ignore set,
+   so a sidecar'd `item_id` blocks the download even with a lost `ignores.txt`.
+2. `sync_item` short-circuits on a `store_url` it finds in that index (exact, then
+   slug, then `slug_copies` as a backstop).
+3. `LocalMedia.is_locally_downloaded` reads the `bandcamp_item_id.txt` the
+   original download left in the directory.
+
+There is no variant of this that keeps the files where they are, so the flow is:
+
+1. **Archive** every directory of the album (§13.5 — one release, one zip) into
+   `<music_root>/<Artist> — <Album> (archived YYYY-MM-DD).zip`, stored not
+   deflated, colliding names suffixed rather than overwritten.
+2. **Verify** — reopen, CRC-check, and compare the manifest and every member's
+   size against what went in. Only then is anything deleted. A failure at any
+   point leaves the album untouched and removes the partial zip.
+3. **Delete** the directories, and any parent they just emptied.
+4. **Un-ignore** the purchase, *including* bandcampsync's auto-managed region —
+   the one `_remove_user_ignore` refuses to touch, because there it would mean
+   duplicating an album that is still on disk. Here there is no copy left.
+5. **Approve** the download (`pending_downloads.approve`), the existing flag that
+   gets an item past link-only mode and the per-sync cap, and **clear the
+   collection checkpoint**, or an incremental sync starts past an old purchase.
+6. **Start a sync.**
+
+**Ordering is the safety argument.** The zip is proved good before a byte is
+deleted, and the un-ignore happens between syncs rather than during one —
+bandcampsync snapshots `ignores.txt` at startup and rewrites it wholesale, so a
+concurrent edit is silently discarded. A re-download is therefore refused while a
+sync is in flight.
+
+**The archive is the escape hatch** out of the interim state, and the only one
+offered: unzipping it at the music root restores the album exactly, sidecar and
+all, so it comes back matched rather than as a NEW album to re-reconcile. Nothing
+prunes archives; they are the user's.
+
+**No new state, no sidecar field.** Between the archive and the download the
+album has no directory, so it is in no state at all — it is held in
+`redownloads`, an in-memory store rendered as an inbox card, cleared *by
+derivation* when `library_index` sees the purchase again (so any route home
+clears it, including the user restoring the zip by hand).
+
+**Known limitation.** That store and the download approval are both in-memory. A
+restart in the seconds between the archive and its sync loses them, and on a
+library with unlinked albums the next sync then runs link-only and surfaces the
+purchase as an ordinary *potential download* — one click to fetch, but beside a
+"Don't download" that would strand it. Accepted rather than persisted, for the
+reasons `pending_downloads` gives for refusing a JSON of its own: the decision
+already persists in the two places that matter (the id is out of `ignores.txt`,
+the directory is off disk), which is what makes any later sync fetch it.
+
+**Not offered** without a single `bandcamp.item_id` — a manual/CD-rip album has no
+purchase, and one carrying only `candidate_item_ids` has several it might be.
+Fetching a guess is the no-guessing invariant in reverse.
+
 ### 2.5 Per-album reconciliation
 
 Instead of a "bootstrap" event, reconciliation is **continuous and per-album**. Whenever the scanner encounters an album that has MBID-tagged files but no `.harmonist.json` sidecar, the reconciler runs once for that album to derive the right sidecar.
@@ -480,6 +545,8 @@ stateDiagram-v2
     NEEDS_SYNC --> NEEDS_MBID: Surrender<br/>(full sync, no purchase)
     NEEDS_SYNC --> NEEDS_SYNC: Update URL<br/>(retry on next sync)
 
+    COMPLETE --> [*]: Re-download<br/>(archived to a zip,<br/>files off disk — §2.4.1)
+    INCOMPLETE --> [*]: Re-download<br/>(archived to a zip,<br/>files off disk — §2.4.1)
     COMPLETE --> NEW: Forget<br/>(sidecar deleted)
     COMPLETE --> NEEDS_MBID: Wrong match<br/>(pencil — tags left on disk)
     COMPLETE --> NEEDS_MBID: Undo the linking<br/>tagging (#157/#158)
@@ -500,6 +567,11 @@ Notes:
   flag in the sidecar; state is sufficient.
 - `TAGGING` is omitted: it's a transient state visible only while the
   tagger is mid-write (typically <1s).
+- **A re-download leaves the state machine entirely** (§2.4.1). Every other
+  state is derived from something on disk; an archived album has no directory,
+  so it derives nothing. It is held in the in-memory `redownloads` store —
+  rendered as an inbox card naming its zip — and re-enters at `[*]` when the
+  sync writes the replacement, exactly as a first-time download does.
 - `INCONSISTENT` is purely derived from on-disk file tags; user resolves
   via Picard (§13.2). No sidecar action needed.
 - Forget adds the path to an in-memory exemption set so auto-reconcile
@@ -809,6 +881,8 @@ src/harmonist/
   url_recovery.py       Recover an embedded Bandcamp URL from ©cmt (precise or artist-root; no scraping)
   bandcamp_hook.py      bandcampsync Syncer subclass: download cap, sidecar capture, purchase↔album linking
   pending_downloads.py  In-memory "potential downloads" (unmatched purchases awaiting a decision)
+  redownloads.py        In-memory "archived, awaiting its replacement download" (#132)
+  archive.py            Zip an album's dirs into the music root, verify, then delete them (#132)
   mb_lookup.py          MB by-id / by-url fetch (1 req/sec budget)
   mb_search.py          MB free-text search (manual-ingest path)
   match.py              Disk-vs-MB comparison (assess_match): confidence + per-track deltas
@@ -898,7 +972,7 @@ authoritative list; the shape is:
 - **Per-album actions** (keyed by album id): `/confirm/{id}`, `/reject/{id}`,
   `/recheck/{id}`, `/manual/{id}/…` (search / candidates / assign),
   `/retag/{id}`, `/forget/{id}`, `/surrender/{id}/keep` (Move to Library),
-  `/library/{id}/…` (detail / unlink).
+  `/library/{id}/…` (detail / unlink / redownload).
 - **Potential downloads** (keyed by purchase item_id): `/pending/{id}/…`
   (match / download / skip).
 - **Cover art**: `GET /cover/{id}`; other static assets under `/static/`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -262,6 +262,13 @@ Nothing ever deletes the archive — it's yours to keep or bin once the new
 download looks right. The format is whichever one you've set in Settings, and the
 confirmation says which before you commit.
 
+**The new copy is tagged the same way any download is**, so it can arrive needing
+attention rather than going straight to the Library — if MusicBrainz has no
+release for the album, or has one that no longer matches what you've just
+downloaded. It then waits in the Inbox under **Needs MBID** with the usual
+Recheck and search tools. That's worth knowing before you start: an album that
+was finished can come back needing a click. It's also why the archive exists.
+
 You can't start a re-download while a sync is running; wait for it to finish.
 
 ## Undoing a tagging

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -237,6 +237,33 @@ MBID to re-pick, leaving your files' current tags alone until you re-tag), and
 **Forget**, which deletes the sidecar and returns the album to New without
 touching a single audio file.
 
+### Re-downloading an album
+
+**Re-download** fetches the album from Bandcamp again. Two reasons to want it:
+you bought MP3s years ago and would rather have FLAC, or the artist has added
+tracks to the release since you bought it and your copy is short. It appears on
+any album Harmonist has linked to a single Bandcamp purchase — not on a CD rip,
+and not on one of the rare albums whose store URL matches several purchases,
+where Harmonist can't tell which one to fetch.
+
+It is the one action here that removes files, so it works like this:
+
+1. **Your current files are zipped into the top of your music folder**, named
+   `Artist — Album (archived 2026-08-24).zip`. Everything goes in — audio,
+   artwork, and Harmonist's own sidecar — so unzipping it *there* puts the album
+   back exactly as it was, still matched to its release.
+2. **The zip is checked before anything is deleted.** If it can't be written, or
+   comes back short, nothing is removed and you're told why.
+3. The album is taken off disk, its purchase is taken out of your Bandcamp
+   ignores, and a sync starts. The album shows in the Inbox as *Re-downloading*,
+   naming its archive, until the new copy lands and it returns to your Library.
+
+Nothing ever deletes the archive — it's yours to keep or bin once the new
+download looks right. The format is whichever one you've set in Settings, and the
+confirmation says which before you commit.
+
+You can't start a re-download while a sync is running; wait for it to finish.
+
 ## Undoing a tagging
 
 Every tagging is recorded field by field — the value before and the value after,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -262,12 +262,25 @@ Nothing ever deletes the archive — it's yours to keep or bin once the new
 download looks right. The format is whichever one you've set in Settings, and the
 confirmation says which before you commit.
 
-**The new copy is tagged the same way any download is**, so it can arrive needing
-attention rather than going straight to the Library — if MusicBrainz has no
-release for the album, or has one that no longer matches what you've just
-downloaded. It then waits in the Inbox under **Needs MBID** with the usual
-Recheck and search tools. That's worth knowing before you start: an album that
-was finished can come back needing a click. It's also why the archive exists.
+**The new copy keeps the release you'd already matched.** Re-downloading says the
+files are wrong, not the match — so Harmonist tags the replacement as the same
+MusicBrainz release the old copy had, rather than looking the album up afresh and
+possibly landing somewhere else. The album keeps its history across the round
+trip, and normally goes straight back to the Library.
+
+If the album was already incomplete, it's allowed to come back incomplete — you
+re-downloaded to *try* for the missing tracks, and if they still aren't there
+that's the same album you had, not a new problem. It keeps its tags and its "2 of
+4 tracks on disk" badge.
+
+It can still come back needing attention, when the new files genuinely don't fit
+that release: more tracks than MusicBrainz lists (the artist added them and
+MusicBrainz hasn't caught up), fewer than it lists on an album that was
+previously complete (a bad download — Harmonist won't quietly accept that), or
+the release has since been deleted from MusicBrainz. Then it waits in the Inbox
+under **Needs MBID** with the side-by-side and the usual Confirm and search
+tools. Worth knowing before you start: an album that was finished can come back
+needing a click. It's also why the archive exists.
 
 You can't start a re-download while a sync is running; wait for it to finish.
 

--- a/src/harmonist/archive.py
+++ b/src/harmonist/archive.py
@@ -1,0 +1,303 @@
+"""Zip an album up and take it off disk, so it can be downloaded again (#132).
+
+Re-downloading an album — to upgrade MP3s to FLAC, or to pick up tracks the
+artist added to the release after the purchase — means letting the sync fetch a
+purchase it already has. Three separate mechanisms stop that, and all three key
+off the album still being on disk: `library_index.item_ids()` is unioned into
+bandcampsync's ignore set at sync start, `sync_item` short-circuits on a
+`store_url` it finds in that index, and `LocalMedia.is_locally_downloaded` reads
+the `bandcamp_item_id.txt` the download left in the directory. So the directory
+has to go. There is no version of this that keeps the files where they are.
+
+Deleting a user's music outright is not something Harmonist does, so the files
+are zipped into the music root first, under a name that says what they are and
+when they were put there. The user can unzip it back, or delete it once the
+replacement looks right; nothing in Harmonist expects the archive to still be
+there, and nothing prunes it either. It is theirs.
+
+**The zip is verified before anything is deleted.** `archive_and_remove` writes
+the archive, reopens it, CRC-checks every member and compares the manifest
+against the files that went in — and only then removes a single byte. A failure
+anywhere in that sequence leaves the album exactly where it was. This ordering is
+the whole safety argument for the feature, which is why the archive and the
+delete are one function rather than two a caller sequences.
+
+**Stored, not deflated.** FLAC, ALAC and MP3 are already compressed; deflating a
+500 MB album buys a fraction of a percent and costs minutes of CPU on the NAS
+this runs on. The sidecar and the cover are small enough not to argue about.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import zipfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from . import audit
+
+log = logging.getLogger(__name__)
+
+#: Headroom demanded on top of the album's own size before archiving starts.
+#: The zip and the album coexist until the delete, so the operation transiently
+#: needs both — and a NAS that fills up mid-write leaves a truncated archive
+#: beside an album we then must not delete. Cheaper to refuse.
+_FREE_SPACE_MARGIN = 64 * 1024 * 1024
+
+#: Filesystem limit on a single name is 255 bytes nearly everywhere; leave room
+#: for the " (archived YYYY-MM-DD) (12).zip" tail this appends.
+_MAX_STEM = 180
+
+#: Characters that can't go in a filename on the platforms Harmonist runs on
+#: (Linux under Docker, macOS, and Windows via a SMB share onto either).
+_UNSAFE = '/\\:*?"<>|\0'
+
+
+class ArchiveError(Exception):
+    """Archiving failed, and the album is still on disk. Always raised before
+    anything is deleted — a caller that sees this has lost nothing."""
+
+
+class InsufficientSpaceError(ArchiveError):
+    """Not enough free space to hold the archive alongside the album."""
+
+
+@dataclass(frozen=True)
+class ArchiveResult:
+    """What `archive_and_remove` wrote and what it then took away."""
+
+    path: Path
+    file_count: int
+    total_bytes: int
+    removed: tuple[Path, ...]
+
+
+def archive_and_remove(
+    dirs: Sequence[Path],
+    *,
+    music_root: Path,
+    label: str,
+    album_id: str | None = None,
+    now: datetime | None = None,
+) -> ArchiveResult:
+    """Zip every directory in `dirs`, verify the zip, then delete them.
+
+    `dirs` is an album's directories — usually one, but a release split across
+    per-disc folders (§13.5) has several and they belong in one archive, because
+    they are one album and get restored together.
+
+    Members are stored under their path relative to `music_root`, so unzipping at
+    the music root puts everything back exactly where it was. Every directory
+    must therefore lie under `music_root`; one that doesn't is a bug in the
+    caller, not a user error, and raises.
+
+    Raises `ArchiveError` (or its `InsufficientSpaceError` subclass) with the
+    album untouched. Once this returns, the directories are gone and the archive
+    has been checked.
+    """
+    if not dirs:
+        raise ArchiveError("no directories to archive")
+
+    members = _collect(dirs, music_root)
+    if not members:
+        raise ArchiveError(f"nothing to archive under {', '.join(str(d) for d in dirs)}")
+
+    total = sum(size for _, _, size in members)
+    _check_space(music_root, total)
+
+    zip_path = _unique_path(music_root, label, now or datetime.now(UTC))
+    # Recorded BEFORE the write, per event-recording rule 6: if the process dies
+    # mid-archive there is a line saying what it was attempting, rather than
+    # silence next to a half-written zip.
+    audit.record(
+        "redownload.archive",
+        album_id=album_id,
+        archive=zip_path,
+        files=len(members),
+        bytes=total,
+        dirs=len(dirs),
+    )
+    try:
+        _write(zip_path, members)
+        _verify(zip_path, members)
+    except (OSError, zipfile.BadZipFile, ArchiveError) as e:
+        # The album is still on disk and stays that way. Clean up the partial
+        # archive so a later attempt doesn't collide with a broken file, and so
+        # the user isn't left a zip that would restore an incomplete album.
+        zip_path.unlink(missing_ok=True)
+        log.exception("archiving %s to %s failed — the album has NOT been removed", label, zip_path)
+        raise ArchiveError(f"could not write {zip_path.name}: {e}") from e
+
+    removed = _remove(dirs, music_root, album_id=album_id)
+    return ArchiveResult(path=zip_path, file_count=len(members), total_bytes=total, removed=removed)
+
+
+def _collect(dirs: Sequence[Path], music_root: Path) -> list[tuple[Path, str, int]]:
+    """`(source, arcname, size)` for every file under `dirs`, deepest last.
+
+    Everything is taken — audio, cover art, the `.harmonist.json` sidecar and
+    bandcampsync's `bandcamp_item_id.txt`. An archive missing the bookkeeping
+    would restore as a NEW album needing re-reconciliation, which is not what
+    "you can recover this" should mean.
+    """
+    out: list[tuple[Path, str, int]] = []
+    seen: set[str] = set()
+    for d in dirs:
+        try:
+            rel_root = d.resolve().relative_to(music_root.resolve())
+        except ValueError as e:
+            raise ArchiveError(f"{d} is not inside the music folder {music_root}") from e
+        if not d.is_dir():
+            raise ArchiveError(f"{d} is not a directory")
+        for path in sorted(d.rglob("*")):
+            if not path.is_file() or path.is_symlink():
+                continue  # a symlink's target may live outside the library
+            arcname = str(rel_root / path.relative_to(d))
+            if arcname in seen:
+                continue  # nested album dirs listed twice by the caller
+            seen.add(arcname)
+            out.append((path, arcname, path.stat().st_size))
+    return out
+
+
+def _check_space(music_root: Path, total: int) -> None:
+    try:
+        free = shutil.disk_usage(music_root).free
+    except OSError:
+        # Can't tell. Don't refuse on that basis — the write below reports a real
+        # ENOSPC perfectly well, and refusing here would block the feature on a
+        # filesystem statvfs doesn't answer for. Loud, because a NAS that can't
+        # answer this is worth knowing about.
+        log.exception("could not read free space at %s — archiving anyway", music_root)
+        return
+    needed = total + _FREE_SPACE_MARGIN
+    if free < needed:
+        raise InsufficientSpaceError(
+            f"{_mb(needed)} MB needed to archive this album, {_mb(free)} MB free"
+        )
+
+
+def _write(zip_path: Path, members: list[tuple[Path, str, int]]) -> None:
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
+        for source, arcname, _ in members:
+            zf.write(source, arcname)
+
+
+def _verify(zip_path: Path, members: list[tuple[Path, str, int]]) -> None:
+    """Re-open the archive and prove it holds what went into it.
+
+    Three checks, because they fail differently: `testzip` catches corrupted
+    bytes, the manifest comparison catches a member that never got written, and
+    the size comparison catches one truncated to a valid-looking short entry.
+    Only the first is what `zipfile` would tell you on its own.
+    """
+    expected = {arcname: size for _, arcname, size in members}
+    with zipfile.ZipFile(zip_path) as zf:
+        bad = zf.testzip()
+        if bad is not None:
+            raise ArchiveError(f"failed its CRC check on {bad}")
+        got = {info.filename: info.file_size for info in zf.infolist()}
+    if missing := sorted(set(expected) - set(got)):
+        raise ArchiveError(f"{len(missing)} file(s) missing from the archive, e.g. {missing[0]}")
+    if short := sorted(name for name, size in expected.items() if got[name] != size):
+        raise ArchiveError(f"{len(short)} file(s) stored at the wrong size, e.g. {short[0]}")
+
+
+def _remove(dirs: Sequence[Path], music_root: Path, *, album_id: str | None) -> tuple[Path, ...]:
+    """Delete each archived directory, then any parent it just emptied.
+
+    Pruning empty parents is not the directory reshuffling §1 forbids — nothing
+    is renamed or moved, and the only directories touched are ones this call
+    emptied itself. Left behind, an emptied `Artist/` shows up in Plex as an
+    artist with no music; bandcampsync recreates the whole path on the way back
+    in. A parent holding anything at all — another album, a stray `.DS_Store` —
+    is left alone.
+    """
+    removed: list[Path] = []
+    for d in dirs:
+        try:
+            shutil.rmtree(d)
+        except OSError:
+            # Partial removal is the one genuinely bad outcome here: the archive
+            # is good, so nothing is lost, but the album is now half on disk and
+            # will scan as a mangled remnant. Say so and stop — carrying on to
+            # the next directory would widen the mess.
+            log.exception("could not remove %s after archiving it", d)
+            audit.record("redownload.delete_failed", album_id=album_id, dir=d)
+            raise ArchiveError(
+                f"the archive was written, but {d.name} could not be removed — "
+                "the album is now partly deleted; check the folder by hand"
+            ) from None
+        audit.record("redownload.delete", album_id=album_id, dir=d)
+        removed.append(d)
+    for parent in _prunable_parents(dirs, music_root):
+        try:
+            parent.rmdir()
+        except OSError:
+            # Raced, or not actually empty. Nothing is lost by leaving it, so
+            # this is genuinely moot — the album is already archived and gone.
+            log.info("left %s in place — not empty", parent)
+        else:
+            audit.record("redownload.prune", album_id=album_id, dir=parent)
+    return tuple(removed)
+
+
+def _prunable_parents(dirs: Sequence[Path], music_root: Path) -> list[Path]:
+    """Parents of `dirs` that are now empty, deepest first and never the root.
+
+    Built by re-joining the relative parts onto `music_root` AS GIVEN rather than
+    by walking the resolved path, so the paths handed to `audit.record` are the
+    same shape as everything else in the log. `audit._rel` relativises against
+    the configured music dir literally, and on macOS that is `/var/folders/…`
+    while `resolve()` returns `/private/var/folders/…` — a symlink apart, enough
+    for the relativisation to give up and print an absolute path nobody wants to
+    read (#98).
+    """
+    root = music_root.resolve()
+    candidates: list[Path] = []
+    for d in dirs:
+        try:
+            rel = d.resolve().relative_to(root)
+        except ValueError:
+            continue  # not under the root; _collect already refused it
+        for parent_rel in rel.parents:
+            if parent_rel == Path("."):
+                break  # the music root itself is never pruned
+            candidates.append(music_root / parent_rel)
+    # Deepest first, so emptying `Artist/Album/Disc 1` lets `Artist/Album` go
+    # before `Artist` is considered.
+    return sorted(set(candidates), key=lambda p: len(p.parts), reverse=True)
+
+
+def _unique_path(music_root: Path, label: str, when: datetime) -> Path:
+    """`<music_root>/<label> (archived YYYY-MM-DD).zip`, never an existing file.
+
+    Re-downloading the same album twice — or two albums that clean down to the
+    same name — must not overwrite the earlier archive, which may be the only
+    copy of those files left. Suffix instead.
+    """
+    stem = f"{_clean(label)} (archived {when.strftime('%Y-%m-%d')})"
+    candidate = music_root / f"{stem}.zip"
+    n = 2
+    while candidate.exists():
+        candidate = music_root / f"{stem} ({n}).zip"
+        n += 1
+    return candidate
+
+
+def _clean(label: str) -> str:
+    """`label` reduced to something every filesystem here will accept.
+
+    A leading dot would hide the archive — the opposite of the point — and a
+    trailing dot or space is rejected outright over SMB from Windows.
+    """
+    out = "".join(" " if c in _UNSAFE else c for c in label)
+    out = " ".join(out.split())[:_MAX_STEM].strip(". ")
+    return out or "album"
+
+
+def _mb(n: int) -> int:
+    return n // (1024 * 1024)

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -32,7 +32,7 @@ from typing import Any
 
 from mutagen.mp4 import MP4
 
-from . import activity, activity_store, audit, id_registry, pending_downloads
+from . import activity, activity_store, audit, id_registry, pending_downloads, redownloads
 from . import sidecar as sidecar_mod
 from .formats.m4a import (
     ATOM_ALBUM,
@@ -696,6 +696,10 @@ def seed(music_dir: Path) -> None:
         f"Harmonist demo data — safe to delete.\nversion: {data_version()}\n"
     )
     pending_downloads.replace_all([])
+    # A re-download awaited against the OLD library refers to an album this
+    # re-seed has just recreated from scratch (#132) — leaving the card up would
+    # have the inbox waiting forever for something already there.
+    redownloads.reset()
 
 
 def reset(music_dir: Path) -> None:

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -746,6 +746,7 @@ def run_demo_sync(
     link_only: bool = False,
     ignores_file: Path | None = None,
     progress_callback: Callable[[str], None] | None = None,
+    post_download_callback: Callable[[Path], None] | None = None,
 ) -> Any:
     """Mirror the real syncer's adoption behaviour:
       1. Link every already-on-disk album whose Bandcamp store_url matches a
@@ -755,8 +756,18 @@ def run_demo_sync(
          are the residue. In **link-only** mode they surface as POTENTIAL
          DOWNLOADS for review (download nothing); any the user already approved
          (clicked Download) are fetched. In a **full** sync they all download.
+      3. Bring back any LIBRARY album archived off disk by a re-download (#132):
+         an approved purchase that is one of the seeded albums rather than one of
+         the pending ones. Like the real path, an approval bypasses link-only.
     Returns a stub matching the attributes the sync runner introspects — including
     `unmatched_purchases()`, which the post-sync mis-tag detection reads.
+
+    `post_download_callback` is invoked for **re-downloads only**. The pending
+    purchases' fixtures already carry their release, so they land tagged with no
+    resolution needed; a re-download must go through the real callback because
+    that is the thing being demonstrated — it is what tags the replacement as the
+    release the archived copy had, and a demo that skipped it would show the right
+    outcome while proving nothing about the code that produces it.
     """
 
     class _Result:
@@ -809,7 +820,44 @@ def run_demo_sync(
             _download(music_dir, p, progress_callback)
             result.new_items_downloaded = True
         pending_downloads.replace_all([])
+
+    for spec in _archived_redownloads(on_disk):
+        _download(music_dir, _as_fresh_download(spec), progress_callback)
+        result.new_items_downloaded = True
+        if post_download_callback:
+            album_dir = music_dir / _safe(spec["artist"]) / _safe(spec["album"])
+            with contextlib.suppress(Exception):
+                post_download_callback(album_dir)
     return result
+
+
+def _archived_redownloads(on_disk: set[int]) -> list[dict[str, Any]]:
+    """Seeded albums the user re-downloaded: approved, and no longer on disk
+    because the re-download archived them away (#132)."""
+    out = []
+    for spec in LIBRARY:
+        sc_spec = spec.get("sidecar") or {}
+        iid = sc_spec.get("bandcamp_item_id")
+        if iid and iid not in on_disk and pending_downloads.is_approved(int(iid)):
+            out.append(spec)
+    return out
+
+
+def _as_fresh_download(spec: dict[str, Any]) -> dict[str, Any]:
+    """The same album as it arrives from Bandcamp: audio and a purchase link, no
+    MusicBrainz anything.
+
+    The seeded spec describes the album in its *settled* state — tagged, with a
+    release on the sidecar and an MBID atom on the files. A download has none of
+    that yet; the tagging happens afterwards, in the app. Handing the settled
+    spec back would leave nothing for the re-download's tagging to do, and the
+    demo would show a working feature whatever the code did."""
+    sidecar = {
+        k: v
+        for k, v in (spec.get("sidecar") or {}).items()
+        if k not in ("mb_release_id", "tagged", "mb_match_candidate")
+    }
+    return {**spec, "sidecar": sidecar, "file_mbid": None, "file_mbid_tracks": None}
 
 
 def _purchase_label(url: str) -> str:

--- a/src/harmonist/redownloads.py
+++ b/src/harmonist/redownloads.py
@@ -1,0 +1,97 @@
+"""In-memory record of albums archived and waiting to come back (#132).
+
+Between the archive and the sync that re-fetches it, a re-downloaded album is
+nowhere: its directory is gone, so the scanner cannot see it and it is in no
+state, no count and no filter. Without this it would simply vanish from the UI
+for the length of a sync, which is not an acceptable thing to do to someone who
+just clicked a button that deleted their files.
+
+**Not persisted**, for the same reasons as `pending_downloads` — a
+`redownloads.json` buys a schema and a migration for something re-derivable, and
+the *decision* already persists through mechanisms that exist: the item_id is out
+of `ignores.txt` and the directory is off disk, which is exactly what makes the
+next sync fetch it, restart or no restart.
+
+What a restart does lose is the in-memory download approval alongside this card.
+On a library with unlinked albums the next sync then runs link-only, and the
+purchase surfaces as an ordinary *potential download* instead — one click to
+fetch, but sitting next to a "Don't download" that would strand it. The window is
+the few seconds between the archive and the sync it kicks, and the recovery
+(Restore in Settings, then unzip) exists, so this is accepted rather than
+engineered around.
+
+**Cleared by derivation, not by lifecycle.** Nothing here is told when a download
+lands; `prune` is handed the item_ids the library currently holds and drops
+whatever has come back. So a re-download that arrives by any route — the sync we
+kicked, a later one, the user restoring the zip by hand — clears the card, and
+there is no completion callback to forget to call.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class PendingRedownload:
+    """An album archived and awaiting its replacement download."""
+
+    item_id: int
+    artist: str
+    title: str
+    #: Bandcamp URL of the purchase, so the card can link out to it.
+    url: str
+    #: Filename of the archive holding the old files, so the card can say where
+    #: they went without the user hunting for it.
+    archive_name: str
+    requested_at: datetime
+
+    @property
+    def label(self) -> str:
+        return f"{self.artist} — {self.title}".strip(" —")
+
+
+_lock = threading.Lock()
+_pending: dict[int, PendingRedownload] = {}
+
+
+def add(entry: PendingRedownload) -> None:
+    """Record an archived album as awaiting re-download."""
+    with _lock:
+        _pending[entry.item_id] = entry
+
+
+def remove(item_id: int) -> None:
+    with _lock:
+        _pending.pop(item_id, None)
+
+
+def prune(present_item_ids: set[int]) -> None:
+    """Drop every entry whose purchase is back on disk.
+
+    `present_item_ids` is `library_index.item_ids()` — the purchases the current
+    scan can see. An entry in both is an album that has returned.
+    """
+    with _lock:
+        for item_id in present_item_ids & set(_pending):
+            del _pending[item_id]
+
+
+def all_pending() -> list[PendingRedownload]:
+    """Awaited re-downloads, oldest request first — the order they were asked for
+    is the order they will arrive in."""
+    with _lock:
+        return sorted(_pending.values(), key=lambda r: r.requested_at)
+
+
+def count() -> int:
+    with _lock:
+        return len(_pending)
+
+
+def reset() -> None:
+    """Clear all state. For demo re-seed and test isolation."""
+    with _lock:
+        _pending.clear()

--- a/src/harmonist/redownloads.py
+++ b/src/harmonist/redownloads.py
@@ -57,15 +57,68 @@ _lock = threading.Lock()
 _pending: dict[int, PendingRedownload] = {}
 
 
-def add(entry: PendingRedownload) -> None:
-    """Record an archived album as awaiting re-download."""
+@dataclass(frozen=True)
+class CarriedMatch:
+    """What an archived album knew about itself, for its replacement to inherit."""
+
+    mb_release_id: str
+    #: The archived copy was INCOMPLETE — short of the release's tracklist, and
+    #: tagged that way regardless. Carried because it is part of the match the
+    #: user accepted, not a separate judgement: a replacement that arrives just
+    #: as short is the status quo, and refusing to tag it would turn a tagged
+    #: album into inbox work for a shortfall it already had. The reverse case is
+    #: the one that must NOT be waved through — an album that was complete coming
+    #: back short is a bad download, so it does not get this.
+    incomplete: bool = False
+
+
+# item_id → what the archived album was, for the replacement to be tagged as too
+# (#132).
+#
+# **Deliberately not the same lifetime as the card above**, which is why it is a
+# second dict rather than a field on `PendingRedownload`. The card clears the
+# moment the files are back on disk; this must survive until the *tagging*, which
+# happens afterwards — and the inbox polls every couple of seconds during a sync,
+# so the gap between the two is not theoretical. Sharing one dict meant a poll
+# landing in that window silently threw the release away and the replacement
+# re-resolved from scratch: the exact thing carrying it is meant to prevent.
+#
+# Consumed by `take_release`, so an entry has a definite end. One that is never
+# consumed — the download never arrives — leaks a single string until restart,
+# which is the same bound as everything else in this module.
+_carried: dict[int, CarriedMatch] = {}
+
+
+def add(entry: PendingRedownload, *, match: CarriedMatch | None = None) -> None:
+    """Record an archived album as awaiting re-download.
+
+    `match` is what the archived copy was. Re-downloading says the *files* are
+    wrong, not the match — so the replacement is tagged as that same release
+    rather than being re-resolved from its store URL, which could land on a
+    different one (or on none).
+    """
     with _lock:
         _pending[entry.item_id] = entry
+        if match:
+            _carried[entry.item_id] = match
+
+
+def take_match(item_id: int) -> CarriedMatch | None:
+    """What a re-download should be tagged as, removing it as it answers.
+
+    Take-once: the tagging either succeeds, or falls back to resolving the store
+    URL and must not then be re-attempted against the same release on a later
+    sync — by which point the user has seen the album in their inbox and may have
+    assigned it something else themselves.
+    """
+    with _lock:
+        return _carried.pop(item_id, None)
 
 
 def remove(item_id: int) -> None:
     with _lock:
         _pending.pop(item_id, None)
+        _carried.pop(item_id, None)
 
 
 def prune(present_item_ids: set[int]) -> None:
@@ -73,6 +126,10 @@ def prune(present_item_ids: set[int]) -> None:
 
     `present_item_ids` is `library_index.item_ids()` — the purchases the current
     scan can see. An entry in both is an album that has returned.
+
+    Clears the CARD only. The carried release outlives it on purpose: the album
+    is on disk here but not yet tagged, and that is precisely when the release is
+    still needed (see `_carried`).
     """
     with _lock:
         for item_id in present_item_ids & set(_pending):
@@ -95,3 +152,4 @@ def reset() -> None:
     """Clear all state. For demo re-seed and test isolation."""
     with _lock:
         _pending.clear()
+        _carried.clear()

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -18,7 +18,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 from urllib.parse import quote
 
 from fastapi import FastAPI, File, Form, HTTPException, Request, Response, UploadFile, status
@@ -32,18 +32,21 @@ from harmonist import (
     activity,
     activity_store,
     album_files,
+    archive,
     artwork_store,
     audit,
     compare,
     cover_art,
     formats,
     id_registry,
+    library_index,
     live_counts,
     match,
     mb_lookup,
     mb_search,
     pending_downloads,
     reconcile,
+    redownloads,
     scanner,
     tag_history,
 )
@@ -407,7 +410,9 @@ def create_app(
             sync_runner.link_only_override = None
             link_only = override if override is not None else pending_links > 0
             if link_only and pending_links == 0:
-                _clear_bandcampsync_checkpoint(cfg.paths.music_dir)
+                _clear_bandcampsync_checkpoint(
+                    cfg.paths.music_dir, reason="link-only sync forced from the popover"
+                )
             # The ONE sync-start entry, written here because this is where the
             # mode is decided — the runner's generic "started" line fired before
             # this point and so could never name it (#101).
@@ -1255,13 +1260,19 @@ def _ctx(request: Request, **extra: Any) -> dict[str, Any]:
 _BANDCAMPSYNC_STATE_FILE = ".bandcampsync-state.json"
 
 
-def _clear_bandcampsync_checkpoint(music_dir: Path) -> bool:
+def _clear_bandcampsync_checkpoint(music_dir: Path, *, reason: str) -> bool:
     """Remove bandcampsync's collection-checkpoint file if present. Returns
-    True if a file was removed. Never raises — best-effort."""
+    True if a file was removed. Never raises — best-effort.
+
+    `reason` goes in the audit line. There are two callers now and they clear it
+    for genuinely different reasons — unlinked albums whose purchase an
+    incremental sync wouldn't re-page, and a re-download whose purchase is
+    older still (#132) — so the reason can't be a constant here without the log
+    confidently misattributing half of them."""
     state_file = music_dir / _BANDCAMPSYNC_STATE_FILE
     try:
         if state_file.is_file():
-            audit.record("checkpoint.clear", path=state_file, reason="pending Needs-Sync links")
+            audit.record("checkpoint.clear", path=state_file, reason=reason)
             state_file.unlink()
             return True
     except OSError as e:
@@ -1289,7 +1300,9 @@ def _force_full_sync_if_pending_links(cfg: config_mod.Config, scan_runner: ScanR
             scan_runner.albums() if scan_runner.is_engaged() else scanner.scan(cfg.paths.music_dir)
         )
         pending = sum(1 for a in albums if a.state == AlbumState.NEEDS_SYNC)
-        if pending and _clear_bandcampsync_checkpoint(cfg.paths.music_dir):
+        if pending and _clear_bandcampsync_checkpoint(
+            cfg.paths.music_dir, reason="pending Needs-Sync links"
+        ):
             log.info(
                 "Forcing a full Bandcamp sync: %d album(s) await a purchase link",
                 pending,
@@ -2262,6 +2275,53 @@ def _remove_user_ignore(ignores_file: Path, item_id: int) -> bool:
     return True
 
 
+def _remove_ignore_anywhere(
+    ignores_file: Path, item_id: int
+) -> Literal["removed", "absent", "failed"]:
+    """Drop one id from BOTH regions so the next sync downloads it again (#132).
+
+    The sibling above refuses to touch the auto-managed region, on the grounds
+    that removing an already-downloaded id there would re-download the album.
+    That is precisely the intent here: the album has just been archived off disk,
+    so there is no copy to duplicate and the ignore is now the only thing
+    standing between the user and the files they asked for.
+
+    Rewriting bandcampsync's region is safe *between* syncs and only then — it
+    reads the file once at startup and rewrites it wholesale from that snapshot,
+    so an edit made while a sync runs is silently discarded. The caller refuses
+    to archive anything while a sync is in flight, which is what makes this hold.
+
+    Three outcomes, not two, because "the id wasn't in the file" and "I couldn't
+    rewrite the file" want opposite responses and a bool would conflate them. An
+    adopted album was never downloaded by bandcampsync, so it has no auto-region
+    line and `absent` is the *ordinary* result — warning about it would cry wolf
+    on the common case. `failed` is the one worth interrupting the user for: the
+    ignore stands, so the replacement they were promised will never arrive.
+    """
+    try:
+        text = ignores_file.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return "absent"  # nothing ignored yet — genuinely nothing to remove
+    except OSError:
+        log.exception("could not read ignores %s — %s stays ignored", ignores_file, item_id)
+        return "failed"
+
+    def keep(line: str) -> bool:
+        return (line.partition("#")[0].strip() or None) != str(item_id)
+
+    user, auto = _ignores_split(text)
+    kept_user, kept_auto = [ln for ln in user if keep(ln)], [ln for ln in auto if keep(ln)]
+    if len(kept_user) + len(kept_auto) == len(user) + len(auto):
+        return "absent"
+    try:
+        ignores_file.write_text("".join(kept_user + kept_auto), encoding="utf-8")
+    except OSError:
+        log.exception("could not rewrite ignores %s — %s stays ignored", ignores_file, item_id)
+        return "failed"
+    audit.record("ignores.remove", item_id=item_id, file=ignores_file, reason="re-download")
+    return "removed"
+
+
 def _search_albums(request: Request, q: str, *, limit: int = 25) -> list[dict[str, str]]:
     """On-disk albums whose artist/title/folder matches `q` — the Match picker's
     candidates, each carrying its display path for disambiguation."""
@@ -2703,6 +2763,10 @@ def _register_routes(app: FastAPI) -> None:
         ):
             request.app.state.reconcile_runner.start()
         pending = pending_downloads.all_pending()
+        # Awaited re-downloads clear by derivation (#132): anything whose purchase
+        # the library can see again has come back, whether the sync we kicked
+        # fetched it, a later one did, or the user unzipped the archive by hand.
+        redownloads.prune(library_index.item_ids())
         pending_suggestions, surrender_suggestions = _reconcile_suggestions(
             albums, pending, request.app.state.cfg.paths.music_dir
         )
@@ -2711,6 +2775,7 @@ def _register_routes(app: FastAPI) -> None:
             albums=_inbox_albums(albums),
             total_albums=len(albums),
             pending=pending,
+            redownloading=redownloads.all_pending(),
             pending_suggestions=pending_suggestions,
             surrender_suggestions=surrender_suggestions,
             scan=request.app.state.scan_runner.status(),
@@ -2928,7 +2993,9 @@ def _register_routes(app: FastAPI) -> None:
         # next sync re-pages the whole Bandcamp collection rather than stopping
         # at bandcampsync's saved checkpoint. ignores.txt is deliberately left
         # alone — clearing it would re-download audio, which nuke is not about.
-        state_cleared = _clear_bandcampsync_checkpoint(cfg.paths.music_dir)
+        state_cleared = _clear_bandcampsync_checkpoint(
+            cfg.paths.music_dir, reason="sidecars erased — start fresh"
+        )
         suffix = " · sync checkpoint reset" if state_cleared else ""
         # Drop the now-stale snapshot + counts and kick a fresh scan, so the inbox
         # shows the "Scanning…" screen (then the rebuilt inbox) when the user
@@ -3590,6 +3657,137 @@ def _register_routes(app: FastAPI) -> None:
             "Tags put back",
             _revert_detail(outcome, unlinked=unlinked),
             extra_triggers={"album-retagged": True},
+            album=album,
+        )
+
+    @app.post("/library/{album_id}/redownload", response_class=HTMLResponse)
+    def redownload(request: Request, album_id: str) -> Response:
+        """Archive the album's files off disk and let the next sync fetch it again
+        (#132) — a format upgrade, or a release the artist has since added to.
+
+        Four things have to be undone for a sync to re-fetch a purchase it has
+        already got, and the order matters:
+
+        1. **Archive and delete the directories** (`archive.archive_and_remove`,
+           which verifies the zip before removing anything). This is what clears
+           `library_index`, the `bandcamp_item_id.txt` marker and the on-disk
+           `store_url` — the three things `sync_item` short-circuits on.
+        2. **Un-ignore the purchase**, including bandcampsync's auto-managed
+           region. Done here rather than during the sync because bandcampsync
+           snapshots the file at startup and discards concurrent edits.
+        3. **Approve the download**, which is the existing flag that gets an item
+           past both link-only mode and the per-sync cap.
+        4. **Clear the collection checkpoint**, or an incremental sync starts past
+           an old purchase and never re-pages it.
+
+        Then start the sync. A sync already in flight is refused outright: step 2
+        would be thrown away by the run that is already going.
+        """
+        cfg: config_mod.Config = request.app.state.cfg
+        album = _find_album(request, album_id)
+        sc = album.sidecar
+        item_id = sc.bandcamp.item_id if sc and sc.bandcamp else None
+        if item_id is None:
+            # No purchase id, no re-download: an album linked only by
+            # `candidate_item_ids` has several purchases it could be and we would
+            # be guessing which to fetch (review-gate item 2).
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "This album isn't linked to a single Bandcamp purchase, so there's "
+                "nothing to re-download.",
+            )
+        if request.app.state.sync_runner.is_running:
+            return _flash_response(
+                "Can't re-download now",
+                "a sync is already running — wait for it to finish and try again",
+                level=Level.WARNING,
+                tasks_changed=False,
+                status_code=409,
+                album=album,
+            )
+
+        # Captured BEFORE the mutation, unlike everywhere else (event-recording
+        # rule 2), because the mutation *destroys* the sidecar this id would be
+        # re-read from. It is the right id regardless: a re-downloadable album is
+        # matched, so `Album.id` is its `mb_release_id`, which the replacement
+        # will be tagged with in turn — so the archive, the delete and the
+        # re-tagging all land on one album history.
+        aid = album.id
+        label = f"{album.artist} — {album.title}".strip(" —")
+        # One scope, so the audit rows beneath the archive attach to the activity
+        # entry as its "what changed" (#97).
+        with activity_store.action():
+            try:
+                result = archive.archive_and_remove(
+                    album.folders,
+                    music_root=cfg.paths.music_dir,
+                    label=label,
+                    album_id=aid,
+                )
+            except archive.ArchiveError as e:
+                # Nothing was deleted (or, in the one partial-removal case, the
+                # message says so) and no ignore was touched — the album is where
+                # it was and the user can try again.
+                return _flash_response(
+                    "Couldn't archive this album",
+                    str(e),
+                    level=Level.ERROR,
+                    tasks_changed=False,
+                    status_code=500,
+                    album=album,
+                )
+            # Drop it from the in-memory index NOW rather than waiting for the
+            # rescan: `sync_items` seeds bandcampsync's ignore set from
+            # `library_index.item_ids()`, and the sync starts below.
+            for d in album.folders:
+                library_index.remove(d)
+            unignore = _remove_ignore_anywhere(cfg.ignores_file, item_id)
+            pending_downloads.approve(item_id)
+            _clear_bandcampsync_checkpoint(
+                cfg.paths.music_dir, reason=f"re-download of purchase {item_id}"
+            )
+            redownloads.add(
+                redownloads.PendingRedownload(
+                    item_id=item_id,
+                    artist=album.artist,
+                    title=album.title,
+                    url=sc.store_url or "" if sc else "",
+                    archive_name=result.path.name,
+                    requested_at=datetime.now(UTC),
+                )
+            )
+            # The album has left every state — it isn't on disk any more. The
+            # next scan's reset_from would correct this anyway; doing it here
+            # keeps the Library count honest in the same render (#11).
+            live_counts.move(album.state, None)
+            activity.record(
+                f"Archived to {result.path.name} ({result.file_count} files) — "
+                "re-downloading from Bandcamp",
+                album_id=aid,
+                album_label=label,
+            )
+        if unignore == "failed":
+            # The album is already gone, so this is not fatal — but bandcampsync
+            # will skip the purchase and the replacement never arrives. Say so
+            # where the user will see it rather than only in the log. ("absent"
+            # is not this: an adopted album was never in the ignores file, and
+            # nothing was blocking the download in the first place.)
+            activity.warning(
+                f"{label}: couldn't take Bandcamp purchase {item_id} out of your ignores "
+                "file, so the sync may skip it. Restore it from Settings → Ignored, or "
+                "unzip the archive to put the album back.",
+                album_id=aid,
+            )
+        try:
+            request.app.state.sync_runner.start()
+        except AlreadyRunningError:
+            # Raced with a sync started between the check above and here. The
+            # archive stands and the purchase is un-ignored, so the *next* sync
+            # fetches it; the card stays up meanwhile saying exactly that.
+            log.info("a sync started while archiving %s — the next one will fetch it", label)
+        return _flash_response(
+            "Re-downloading",
+            f"old files archived to {result.path.name} in your music folder",
             album=album,
         )
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -343,6 +343,13 @@ def create_app(
         demo.install()
         demo.ensure_seeded(cfg.paths.music_dir)
 
+        def demo_resolve_after_download(album_dir: Path) -> None:
+            # The demo twin of `resolve_after_download` below. MB is monkey-patched
+            # by demo.install(), so this reaches the mocked catalogue rather than
+            # the network — but it is otherwise the same code, which is the point:
+            # a re-download's tagging is what the demo is there to show.
+            _resolve_by_store_url(album_dir, cfg, tagger)
+
         def runner_fn() -> Any:
             # Same link-only rule as the real runner: the popover override wins,
             # else auto-detect (any Needs-Link album or pending potential-download).
@@ -360,6 +367,10 @@ def create_app(
                 link_only=link_only,
                 ignores_file=cfg.ignores_file,
                 progress_callback=sync_runner.set_current_item,
+                # Re-downloads (#132) go through the REAL post-download resolve,
+                # so the demo exercises the carry-through rather than staging its
+                # outcome. See run_demo_sync for why only they do.
+                post_download_callback=demo_resolve_after_download,
             )
             # Run the REAL post-sync mis-tag detection (like the non-demo runner),
             # so a mis-tag surfaces AFTER a sync rather than being pre-seeded. Pass
@@ -2623,6 +2634,71 @@ def _tag_with_release(
     _claim_pending_by_store_url(store_url)
 
 
+def _tag_as_redownloaded(
+    album_path: Path, sc: Sidecar, cfg: config_mod.Config, tagger: Tagger
+) -> str | None:
+    """Tag a just-downloaded album as the release its archived copy was (#132).
+
+    Returns a status string if it handled the album, or **None to fall through**
+    to the ordinary store-URL resolution — which is every case this can't settle,
+    so the fallback is always today's behaviour rather than a worse one.
+
+    **Why carry the release at all.** Re-downloading says the *files* are wrong,
+    not the match: the user is looking at an album they already accepted as this
+    release and replacing its audio. Re-resolving the store URL from scratch
+    re-opens a question they did not ask — it can land on a different release, or
+    on none, turning a finished album into inbox work. Carrying it also keeps the
+    album's id stable across the round trip, which is what lets its history span
+    the archive (§2.4.1).
+
+    This is `Confirm`'s semantics, not a guess: an explicit user decision to tag
+    an album as a named release, so the match-confidence assessment is skipped
+    exactly as Confirm skips it. What is NOT skipped is the tagger's own count
+    guard, and that is the right remaining check — it asks whether the tagging is
+    *representable*, which no assertion by the user can make true. Files that
+    don't fit the release fall through, and the user meets the ordinary
+    side-by-side with Confirm / Confirm as Incomplete on it.
+    """
+    item_id = sc.bandcamp.item_id if sc.bandcamp else None
+    if item_id is None:
+        return None
+    carried = redownloads.take_match(item_id)
+    if carried is None:
+        return None  # not a re-download, or its match was already consumed
+    mbid = carried.mb_release_id
+    try:
+        # `incomplete` is carried, not decided here. An album that was already
+        # short keeps being taggable while short — refusing would cost it its
+        # tags over a shortfall it had before the user pressed anything. One that
+        # was COMPLETE gets the strict guard, so a truncated download is caught.
+        _tag_with_release(album_path, mbid, cfg, tagger, incomplete=carried.incomplete)
+    except tagger_mod.TagMismatchError as e:
+        # The replacement doesn't fit the release the old copy was. Genuinely
+        # possible and worth seeing: MusicBrainz may not have caught up with a
+        # release the artist has grown, and extra files on disk are out of scope
+        # for the tagger either way (§13.3). Fall through to the normal path,
+        # which stashes a suggestion and puts it in the inbox with the tools.
+        log.info("re-download of %s doesn't fit release %s: %s", album_path.name, mbid, e)
+        activity.record(
+            "Re-downloaded — the new files don't fit the release it was tagged as, "
+            "so it needs a look",
+            album_id=sidecar_mod.album_id_for(album_path),
+            album_label=album_path.name,
+            level=Level.WARNING,
+        )
+        return None
+    except mb_lookup.MBError:
+        # The release is gone from MusicBrainz, or MB is down. Same answer.
+        log.exception("could not fetch release %s for the re-download of %s", mbid, album_path)
+        return None
+    activity.info(
+        "Re-downloaded and tagged as the same MusicBrainz release",
+        album_id=sidecar_mod.album_id_for(album_path),
+        album_label=album_path.name,
+    )
+    return "tagged"
+
+
 def _resolve_by_store_url(album_path: Path, cfg: config_mod.Config, tagger: Tagger) -> str:
     """Auto-resolve a sidecar's store_url against MusicBrainz.
 
@@ -2632,10 +2708,16 @@ def _resolve_by_store_url(album_path: Path, cfg: config_mod.Config, tagger: Tagg
     match assessment: exact → tag (COMPLETE), approximate → stash candidate
     (NEEDS_MBID with a suggestion shown), no match → NEEDS_MBID. Never raises — returns a
     short status string for logging.
+
+    A **re-download** (#132) short-circuits all of that: the album is tagged as
+    the release its archived copy was, because that match is not what the user
+    asked to revisit. Only if those files won't fit it does this run.
     """
     sc = sidecar_mod.read(album_path)
     if sc is None or not sc.store_url or sc.mb_release_id:
         return "skipped"  # nothing to resolve, or already resolved
+    if (carried := _tag_as_redownloaded(album_path, sc, cfg, tagger)) is not None:
+        return carried
     # The album's name for the feed's album column. No artist/title is available
     # on this path — neither MatchCandidate nor BandcampInfo carries one, and
     # _apply_best_match returns plain strings — so use the directory name, which
@@ -3754,7 +3836,23 @@ def _register_routes(app: FastAPI) -> None:
                     url=sc.store_url or "" if sc else "",
                     archive_name=result.path.name,
                     requested_at=datetime.now(UTC),
-                )
+                ),
+                # Carried through the round trip so the replacement is tagged as
+                # THIS release rather than re-resolved from the store URL (#132).
+                # Re-downloading says the files are wrong, not the match.
+                match=(
+                    redownloads.CarriedMatch(
+                        mb_release_id=sc.mb_release_id,
+                        # Re-downloading an INCOMPLETE album is the issue's own
+                        # case: the artist added tracks. It may well come back
+                        # just as short (they haven't, or Bandcamp hasn't caught
+                        # up), and that is the state it was already in — so it
+                        # stays taggable rather than being demoted to the inbox.
+                        incomplete=album.state == AlbumState.INCOMPLETE,
+                    )
+                    if sc and sc.mb_release_id
+                    else None
+                ),
             )
             # The album has left every state — it isn't on disk any more. The
             # next scan's reset_from would correct this anyway; doing it here

--- a/templates/partials/_redownloading.html
+++ b/templates/partials/_redownloading.html
@@ -1,0 +1,55 @@
+{# Albums archived off disk and waiting for the sync to fetch them again (#132).
+
+   Purely informational — there is nothing to decide here, and no button that
+   would help. Between the archive and the download the album is genuinely
+   nowhere: no directory, so no state, no tile and no history page to link to.
+   Without this card it would just vanish for the length of a sync, moments after
+   the user clicked something that deleted their files.
+
+   So the card's whole job is to name the zip. That archive IS the escape hatch
+   out of this state — if the download never lands, unzipping it at the music
+   root puts the album back exactly as it was, sidecar included. A "Cancel"
+   button could not do better (it would re-ignore the purchase and leave the
+   files in the zip regardless), so it isn't offered; the honest instruction is
+   the filename.
+
+   Cleared by derivation in /tasks — `redownloads.prune` drops anything the
+   library can see again, so nothing has to remember to remove a card. #}
+<section id="redownload-section" class="space-y-3 mb-6">
+    {% if redownloading %}
+    <div class="rounded-md border-l-4 border-mb-purple bg-mb-purple/10 px-3 py-2">
+        <h3 class="text-sm font-bold text-mb-purple">
+            Re-downloading
+            <span class="text-muted font-normal ml-1">· {{ redownloading|length }}</span>
+        </h3>
+        <p class="text-xs text-muted mt-0.5">
+            Archived and being fetched from Bandcamp again. They reappear in your Library
+            when the download finishes.
+            {% if not (sync and sync.state == 'running') %}
+            <span class="font-bold text-mb-purple">Click Sync</span> if one doesn't arrive.
+            {% endif %}
+        </p>
+    </div>
+    <div class="grid grid-cols-1 gap-3">
+        {% for r in redownloading %}
+        <div class="rounded-lg border border-line bg-surface px-4 py-3">
+            <div class="min-w-0">
+                <div class="font-semibold text-ink truncate">{{ r.label }}</div>
+                {% if r.url %}
+                <div class="text-xs text-muted truncate">
+                    <a href="{{ r.url }}" target="_blank" rel="noopener"
+                       class="text-mb-purple hover:underline">{{ r.url }}</a>
+                </div>
+                {% endif %}
+            </div>
+            <p class="text-2xs text-muted mt-1.5">
+                Your old files are in
+                <span class="font-mono text-ink break-all">{{ r.archive_name }}</span>
+                at the top of your music folder. Unzip it there to put the album back;
+                delete it once the new download looks right.
+            </p>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+</section>

--- a/templates/partials/library_detail.html
+++ b/templates/partials/library_detail.html
@@ -235,6 +235,30 @@
                         class="px-3 py-1.5 bg-surface hover:bg-line text-ink border border-line rounded text-xs font-bold uppercase tracking-widest transition">
                     Forget
                 </button>
+                {# Re-download from Bandcamp (#132) — upgrade MP3s to FLAC, or pick
+                   up tracks the artist has added to the release since the purchase.
+                   Only offered where it can actually be done: a single Bandcamp
+                   purchase id. An album linked by `candidate_item_ids` alone has
+                   several purchases it might be, and fetching a guess is exactly
+                   what Harmonist doesn't do.
+
+                   Subtle until hover (web-ui rule 4): this is rare, and it deletes
+                   files. `hx-confirm` names the archive and the format, because
+                   both are things the user cannot see beforehand and would want to
+                   have known — the format especially, since it comes from Settings
+                   rather than from anything on this page. #}
+                {% set bc = album.sidecar.bandcamp if album.sidecar else None %}
+                {% if bc and bc.item_id %}
+                <button hx-post="/library/{{ album.id }}/redownload"
+                        hx-swap="none" hx-disabled-elt="this" hx-indicator="#tagging-{{ album.id }}"
+                        hx-on::after-request="if (event.detail.successful) window.location.href = '/'"
+                        hx-confirm="Re-download this album as {{ cfg.bandcamp.download_format|upper }}? The files you have now are zipped into the top of your music folder first, then removed, and the next sync fetches a fresh copy."
+                        class="px-3 py-1.5 bg-surface hover:bg-line text-muted hover:text-ink border border-line rounded text-xs font-bold uppercase tracking-widest transition"
+                        title="Archive this album to a .zip in your music folder and download it again from Bandcamp, in the format set in Settings ({{ cfg.bandcamp.download_format|upper }}). Use this to upgrade the format, or to pick up tracks added to the release since you bought it."
+                        aria-label="Re-download from Bandcamp — archives the current files to a zip first">
+                    Re-download
+                </button>
+                {% endif %}
                 {# The acceptance used to sit here, as a button reading "No more
                    tracks to get" / "Mark incomplete again". It moved up to the
                    completeness badge as a checkbox (#227): it acts on that badge

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -20,6 +20,11 @@
    decides (Match / Download / Don't download). In-memory, from the last sync. #}
 {% include 'partials/_pending.html' %}
 
+{# Albums archived off disk and awaiting their replacement download (#132). They
+   have no directory, so they are in no state and no group below — this is the
+   only place they appear until the download lands. #}
+{% include 'partials/_redownloading.html' %}
+
 {% if reconciling %}
 {# Reconcile in flight: the inbox is being built. Show the counts climbing as
    each orphan is filed, rather than the churning (and re-polled) card lists.
@@ -43,7 +48,7 @@
     </p>
     <p class="text-2xs text-muted mt-1">Large libraries on a network mount can take a few minutes.</p>
 </div>
-{% elif not albums and not pending %}
+{% elif not albums and not pending and not redownloading|default([]) %}
 <div class="p-10 text-center border border-line rounded-lg">
     <p class="text-muted italic">
         {% if total_albums %}
@@ -54,7 +59,8 @@
     </p>
 </div>
 {% elif not albums %}
-{# Only potential downloads remain — the section above shows them. #}
+{# Only potential downloads and/or re-downloads remain — the sections above
+   show them. #}
 {% else %}
 
 {# Render albums grouped by state with a header + instruction per group.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -84,3 +84,15 @@ def album_with_tracks(tmp_path):
         return album_dir
 
     return _build
+
+
+@pytest.fixture(autouse=True)
+def reset_redownloads():
+    """Albums awaiting a re-download (#132) are process-level in-memory state, so
+    a test that archives one would otherwise leave its card rendering in every
+    later `/tasks` assertion — and tests run in random order, so that surfaces as
+    an unrelated test failing intermittently."""
+    from harmonist import redownloads
+
+    yield
+    redownloads.reset()

--- a/test/e2e/test_redownload.py
+++ b/test/e2e/test_redownload.py
@@ -1,0 +1,92 @@
+"""The Re-download button actually issues its request (#132).
+
+This is the #40 bug class, and the Python suite structurally cannot see it: it
+renders the album page and asserts the button's markup is right, which it was in
+#40 too. What it can't see is whether a click reaches htmx — and this button
+carries the exact combination that ate #40's, an `hx-confirm` gating the request
+plus an `hx-on::after-request` that navigates away the moment it lands.
+
+`make template-lint` covers the mechanical half (no `onclick` beside `hx-*`).
+The half left over is the confirm dialog: htmx uses `window.confirm`, which
+Playwright auto-dismisses unless a handler accepts it, and a dismissed confirm
+looks identical from the server's side to a button that never fired. So the
+assertion is on the request itself, not on the aftermath.
+
+Drives a browser via `sync_playwright()` opened per test, like every other module
+here — see test_release_gone.py for why mixing in the pytest-playwright `page`
+fixture kills the rest of the session.
+
+Runs LAST-ish by filename and in its own module so the module-scoped
+`demo_server` is its own process: this test genuinely deletes an album from the
+demo library, which is not a thing to hand to a neighbouring test.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1", reason="e2e disabled (set RUN_E2E=1)"
+)
+playwright_sync = pytest.importorskip("playwright.sync_api")
+
+# INCOMPLETE, linked to Bandcamp purchase 1005 — the issue's own case: an album
+# that is short and whose store link means the missing tracks can still be got.
+ALBUM_ID = "demo-rel-electric-mayhem"
+
+# A SECOND linked album (COMPLETE, purchase 1003) for the dismiss test, because
+# the confirm test really does delete the one above and `demo_server` is
+# module-scoped. Two albums keeps the pair order-independent, which matters:
+# tests here run in random order.
+UNTOUCHED_ALBUM_ID = "demo-rel-rural-juror"
+
+
+def test_confirming_the_dialog_posts_the_redownload(demo_server: str) -> None:
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        # Accept htmx's confirm. Without this Playwright dismisses it, no request
+        # is made, and every assertion about the aftermath would fail for a
+        # reason that has nothing to do with the button.
+        page.on("dialog", lambda d: d.accept())
+
+        page.goto(f"{demo_server}/album/{ALBUM_ID}")
+        page.wait_for_load_state("networkidle")
+
+        button = page.get_by_role("button", name="Re-download")
+        assert button.is_visible(), "the album is linked to a purchase, so it's offered"
+
+        with page.expect_request(f"**/library/{ALBUM_ID}/redownload") as request:
+            button.click()
+        assert request.value.method == "POST"
+
+        # The album has left the Library, so the page describing it must not be
+        # where the user is left standing.
+        page.wait_for_url(f"{demo_server}/", timeout=10_000)
+        browser.close()
+
+
+def test_dismissing_the_dialog_posts_nothing(demo_server: str) -> None:
+    """The control: `hx-confirm` has to be able to stop the request, or the
+    confirmation is decoration on an operation that deletes files."""
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        page.on("dialog", lambda d: d.dismiss())
+
+        posts: list[str] = []
+        page.on(
+            "request",
+            lambda r: posts.append(r.url) if r.method == "POST" else None,
+        )
+
+        page.goto(f"{demo_server}/album/{UNTOUCHED_ALBUM_ID}")
+        page.wait_for_load_state("networkidle")
+        page.get_by_role("button", name="Re-download").click()
+        page.wait_for_timeout(500)
+
+        assert not [u for u in posts if "redownload" in u]
+        assert page.url.endswith(f"/album/{UNTOUCHED_ALBUM_ID}"), "still on the album page"
+        browser.close()

--- a/test/test_archive.py
+++ b/test/test_archive.py
@@ -1,0 +1,253 @@
+"""Tests for archiving an album off disk ahead of a re-download (#132).
+
+The whole safety argument for #132 is an ordering claim — the zip is written and
+proved good BEFORE a byte is deleted — so most of what is worth testing here is
+what the module does when something goes wrong partway. The web rung can't see
+any of it: it would need the same failures injected, and would then be asserting
+on this module's behaviour through two extra layers.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from harmonist import archive
+
+WHEN = datetime(2026, 8, 24, tzinfo=UTC)
+
+
+def _album(root: Path, artist: str = "Artist", album: str = "Album", *, tracks: int = 3) -> Path:
+    d = root / artist / album
+    d.mkdir(parents=True)
+    for i in range(1, tracks + 1):
+        (d / f"{i:02d} Track.m4a").write_bytes(b"audio" * (100 * i))
+    (d / "cover.jpg").write_bytes(b"jpeg")
+    (d / ".harmonist.json").write_text('{"schema_version": 1}')
+    (d / "bandcamp_item_id.txt").write_text("4242")
+    return d
+
+
+def test_archives_everything_and_removes_the_album(tmp_path):
+    d = _album(tmp_path)
+    result = archive.archive_and_remove([d], music_root=tmp_path, label="Artist — Album", now=WHEN)
+
+    assert result.path == tmp_path / "Artist — Album (archived 2026-08-24).zip"
+    assert not d.exists()
+    with zipfile.ZipFile(result.path) as zf:
+        names = set(zf.namelist())
+    # The bookkeeping goes in too: an archive that restores as an unreconciled
+    # NEW album is not the recovery the button promises.
+    assert names == {
+        "Artist/Album/01 Track.m4a",
+        "Artist/Album/02 Track.m4a",
+        "Artist/Album/03 Track.m4a",
+        "Artist/Album/cover.jpg",
+        "Artist/Album/.harmonist.json",
+        "Artist/Album/bandcamp_item_id.txt",
+    }
+    assert result.file_count == 6
+
+
+def test_archive_restores_the_album_byte_for_byte(tmp_path):
+    d = _album(tmp_path)
+    before = {p.relative_to(tmp_path).as_posix(): p.read_bytes() for p in d.rglob("*")}
+
+    result = archive.archive_and_remove([d], music_root=tmp_path, label="A — B", now=WHEN)
+
+    # Unzipping at the music root is the escape hatch the UI tells the user
+    # about, so it has to actually put the album back where it was.
+    with zipfile.ZipFile(result.path) as zf:
+        zf.extractall(tmp_path)
+    after = {p.relative_to(tmp_path).as_posix(): p.read_bytes() for p in d.rglob("*")}
+    assert after == before
+
+
+def test_multi_directory_album_lands_in_one_archive(tmp_path):
+    """A release split across per-disc folders (§13.5) is one album, so it gets
+    one zip — restoring half of it would be worse than not offering the button."""
+    disc1 = _album(tmp_path, album="Album/Disc 1", tracks=1)
+    disc2 = _album(tmp_path, album="Album/Disc 2", tracks=1)
+
+    result = archive.archive_and_remove(
+        [disc1, disc2], music_root=tmp_path, label="A — B", now=WHEN
+    )
+
+    with zipfile.ZipFile(result.path) as zf:
+        names = set(zf.namelist())
+    assert "Artist/Album/Disc 1/01 Track.m4a" in names
+    assert "Artist/Album/Disc 2/01 Track.m4a" in names
+    assert not disc1.exists() and not disc2.exists()
+    # Both discs and the folder that held them are gone, so nothing is left for
+    # Plex to show as an artist with no music.
+    assert not (tmp_path / "Artist").exists()
+
+
+def test_empties_parent_directories_it_emptied_but_not_ones_holding_music(tmp_path):
+    d = _album(tmp_path)
+    sibling = _album(tmp_path, album="Other Album")
+
+    archive.archive_and_remove([d], music_root=tmp_path, label="A — B", now=WHEN)
+
+    # The artist still has an album, so the artist folder stays.
+    assert sibling.exists()
+    assert (tmp_path / "Artist").is_dir()
+
+
+def test_leaves_a_parent_that_still_holds_a_stray_file(tmp_path):
+    d = _album(tmp_path)
+    (tmp_path / "Artist" / ".DS_Store").write_bytes(b"junk")
+
+    archive.archive_and_remove([d], music_root=tmp_path, label="A — B", now=WHEN)
+
+    assert (tmp_path / "Artist" / ".DS_Store").exists()
+
+
+def test_a_second_archive_of_the_same_album_does_not_overwrite_the_first(tmp_path):
+    first = _album(tmp_path)
+    r1 = archive.archive_and_remove([first], music_root=tmp_path, label="A — B", now=WHEN)
+    again = _album(tmp_path)
+    r2 = archive.archive_and_remove([again], music_root=tmp_path, label="A — B", now=WHEN)
+
+    # The first archive may be the only copy of those files in existence.
+    assert r1.path != r2.path
+    assert r1.path.exists() and r2.path.exists()
+    assert r2.path.name == "A — B (archived 2026-08-24) (2).zip"
+
+
+def test_refuses_when_there_is_not_enough_free_space_and_keeps_the_album(monkeypatch, tmp_path):
+    import shutil as shutil_mod
+
+    d = _album(tmp_path)
+    monkeypatch.setattr(
+        archive.shutil, "disk_usage", lambda _p: shutil_mod._ntuple_diskusage(1, 1, 0)
+    )
+
+    with pytest.raises(archive.InsufficientSpaceError):
+        archive.archive_and_remove([d], music_root=tmp_path, label="A — B", now=WHEN)
+
+    assert d.exists()
+    assert list(d.glob("*.m4a"))
+    assert not list(tmp_path.glob("*.zip"))
+
+
+def test_a_zip_that_fails_verification_leaves_the_album_alone(monkeypatch, tmp_path):
+    """The ordering claim, tested where it can actually break: if the archive is
+    bad for any reason, nothing is deleted and no half-written zip is left."""
+    d = _album(tmp_path)
+    before = sorted(p.name for p in d.iterdir())
+
+    def _truncating_write(zip_path, members):
+        # Write every member but one — the failure `testzip` alone would miss,
+        # since what it produces is a perfectly valid, incomplete archive.
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for source, arcname, _ in members[:-1]:
+                zf.write(source, arcname)
+
+    monkeypatch.setattr(archive, "_write", _truncating_write)
+
+    with pytest.raises(archive.ArchiveError, match="missing from the archive"):
+        archive.archive_and_remove([d], music_root=tmp_path, label="A — B", now=WHEN)
+
+    assert sorted(p.name for p in d.iterdir()) == before
+    assert not list(tmp_path.glob("*.zip"))
+
+
+def test_a_member_stored_at_the_wrong_size_is_caught(monkeypatch, tmp_path):
+    d = _album(tmp_path)
+
+    def _short_write(zip_path, members):
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for _, arcname, _ in members:
+                zf.writestr(arcname, b"")  # right name, no bytes
+
+    monkeypatch.setattr(archive, "_write", _short_write)
+
+    with pytest.raises(archive.ArchiveError, match="wrong size"):
+        archive.archive_and_remove([d], music_root=tmp_path, label="A — B", now=WHEN)
+    assert d.exists()
+
+
+def test_refuses_a_directory_outside_the_music_folder(tmp_path):
+    """The arcnames are relative to the music root, so a directory outside it has
+    no representable place in the archive — and would restore somewhere else."""
+    outside = tmp_path / "elsewhere" / "Album"
+    outside.mkdir(parents=True)
+    (outside / "t.m4a").write_bytes(b"x")
+    music = tmp_path / "music"
+    music.mkdir()
+
+    with pytest.raises(archive.ArchiveError, match="not inside the music folder"):
+        archive.archive_and_remove([outside], music_root=music, label="A — B", now=WHEN)
+    assert outside.exists()
+
+
+def test_refuses_an_empty_album_rather_than_writing_an_empty_zip(tmp_path):
+    d = tmp_path / "Artist" / "Album"
+    d.mkdir(parents=True)
+
+    with pytest.raises(archive.ArchiveError, match="nothing to archive"):
+        archive.archive_and_remove([d], music_root=tmp_path, label="A — B", now=WHEN)
+    assert not list(tmp_path.glob("*.zip"))
+
+
+def test_a_symlink_is_not_followed_out_of_the_library(tmp_path):
+    """Following one would copy someone's whole home directory into the music
+    folder, and deleting the album would then look like it lost the target."""
+    d = _album(tmp_path, tracks=1)
+    target = tmp_path / "outside.txt"
+    target.write_text("not mine to archive")
+    (d / "link.txt").symlink_to(target)
+
+    result = archive.archive_and_remove([d], music_root=tmp_path, label="A — B", now=WHEN)
+
+    with zipfile.ZipFile(result.path) as zf:
+        assert "Artist/Album/link.txt" not in zf.namelist()
+    assert target.read_text() == "not mine to archive"
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("Artist / Band — Album", "Artist Band — Album (archived 2026-08-24).zip"),
+        ("...hidden", "hidden (archived 2026-08-24).zip"),
+        ("  spaced   out  ", "spaced out (archived 2026-08-24).zip"),
+        ("/:*?", "album (archived 2026-08-24).zip"),
+        ("x" * 400, "x" * 180 + " (archived 2026-08-24).zip"),
+    ],
+)
+def test_archive_names_are_safe_filenames(tmp_path, label, expected):
+    """A slash would make a directory, a leading dot would hide the file the user
+    is being told to look for, and 400 characters exceeds every filesystem here."""
+    d = _album(tmp_path, tracks=1)
+    result = archive.archive_and_remove([d], music_root=tmp_path, label=label, now=WHEN)
+    assert result.path.name == expected
+    assert result.path.parent == tmp_path
+
+
+def test_pruned_parents_are_named_the_way_the_caller_names_them(tmp_path, monkeypatch):
+    """The audit log records paths relative to the configured music dir, and it
+    relativises literally. A music dir reached through a symlink — every macOS
+    $TMPDIR, and any bind mount — resolves to a different prefix, so a pruned
+    parent built from `resolve()` relativises against nothing and prints an
+    absolute path instead of the album's name (#98).
+    """
+    from harmonist import audit
+
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "music"  # what the user configured
+    link.symlink_to(real, target_is_directory=True)
+    _album(link, tracks=1)
+    monkeypatch.setattr(audit, "_library_root", link)
+    recorded: list[str] = []
+    monkeypatch.setattr(audit.log, "info", lambda _fmt, line: recorded.append(line))
+
+    archive.archive_and_remove(
+        [link / "Artist" / "Album"], music_root=link, label="A — B", now=WHEN
+    )
+
+    assert "redownload.prune dir=Artist" in recorded

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6900,7 +6900,7 @@ def test_redownload_of_an_adopted_album_does_not_cry_wolf_about_the_ignores(
 
 
 def test_redownload_warns_when_the_ignore_could_not_be_removed(
-    client, cfg, quiet_sync, monkeypatch
+    client, cfg, quiet_sync, no_cover_fetch, monkeypatch
 ):
     """The opposite case, and the one worth interrupting for: the id is still
     ignored, so bandcampsync skips the purchase and the replacement the user was
@@ -6979,7 +6979,9 @@ def test_redownloading_twice_archives_once(client, cfg, quiet_sync):
     assert len(list(cfg.paths.music_dir.glob("*.zip"))) == 1
 
 
-def _replay_the_download(cfg, name: str, *, item_id: int, mbid: str | None) -> Path:
+def _replay_the_download(
+    cfg, name: str, *, item_id: int, mbid: str | None, tracks: int = 1
+) -> Path:
     """What the sync does when the replacement lands: recreate the album dir and
     write a sidecar for the purchase (no MBID — a fresh download isn't tagged
     yet), then, if MusicBrainz resolved it, tag it. Both go through
@@ -6987,6 +6989,8 @@ def _replay_the_download(cfg, name: str, *, item_id: int, mbid: str | None) -> P
     from harmonist.bandcamp_hook import write_sidecar_for_item
 
     d = _make_album(cfg, name)
+    for i in range(2, tracks + 1):  # _make_album writes track 1
+        shutil.copy(SINE_M4A, d / f"{i:02d} Track.m4a")
     slug = name.lower().replace(" ", "-")
     item = mock.Mock(
         item_id=item_id,
@@ -7026,11 +7030,16 @@ def test_history_survives_the_round_trip_when_the_replacement_tags_the_same_rele
 
 
 def test_history_splits_when_the_replacement_tags_a_different_release(client, cfg, quiet_sync):
-    """The limit of the above, stated rather than discovered. If MusicBrainz
-    resolves the store URL to a DIFFERENT release, the replacement's id is not
-    the archived album's id and no alias joins them — the archive stays on the
-    old id's history, reachable from the Activity feed but not from the new
-    album's page."""
+    """The limit of the above, stated rather than discovered. If the replacement
+    ends up on a DIFFERENT release, its id is not the archived album's id and no
+    alias joins them — the archive stays on the old id's history, reachable from
+    the Activity feed but not from the new album's page.
+
+    Carrying the release through the round trip is what makes this rare rather
+    than routine: it is now only reachable when the carried release was lost (a
+    restart) or refused (the files don't fit it), and in the second case the user
+    is looking at the suggestion card when it happens. So this pins a residual
+    case, not the common path — which is the test above."""
     d = _make_tagged_album(
         cfg, "Split", mbid="rel-split-old", tagged_at=datetime.now(UTC), item_id=7002
     )
@@ -7067,3 +7076,247 @@ def test_a_replacement_musicbrainz_cannot_match_lands_in_the_inbox_not_the_libra
 
     states = {a.path: a.state for a in scanner.scan(cfg.paths.music_dir)}
     assert states[back] == AlbumState.NEEDS_MBID
+
+
+@pytest.fixture
+def no_cover_fetch(monkeypatch):
+    """Tagging embeds cover art, which would otherwise reach the real Cover Art
+    Archive over the network for every release id these tests invent."""
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+
+
+def _resolve_the_download(cfg, album_dir: Path) -> str:
+    """Run the post-download hook the sync runs, against a just-landed album."""
+    from harmonist.tagger import PicardCompatibleTagger
+    from harmonist.web.main import _resolve_by_store_url
+
+    return _resolve_by_store_url(album_dir, cfg, PicardCompatibleTagger())
+
+
+def test_the_replacement_is_tagged_as_the_release_it_was_archived_as(
+    client, cfg, quiet_sync, no_cover_fetch, monkeypatch
+):
+    """Re-downloading says the FILES are wrong, not the match — so the release
+    the user already accepted is carried through rather than re-resolved from the
+    store URL, which is a question they didn't ask."""
+    d = _make_tagged_album(
+        cfg, "Carried", mbid="rel-carry", tagged_at=datetime.now(UTC), item_id=8001
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda m: _release_with_rg(m, "rg-carry", n_tracks=1)
+    )
+    # The store URL now resolves somewhere ELSE — a re-match would take it, and
+    # carrying the release is exactly what stops that.
+    monkeypatch.setattr(mb_lookup, "lookup_by_bandcamp_url", lambda _u: ["rel-something-else"])
+    back = _replay_the_download(cfg, "Carried", item_id=8001, mbid=None)
+
+    assert _resolve_the_download(cfg, back) == "tagged"
+    assert sc.read(back).mb_release_id == "rel-carry"
+
+
+def test_carrying_the_release_keeps_the_album_out_of_the_inbox(
+    client, cfg, quiet_sync, no_cover_fetch, monkeypatch
+):
+    """The point of it, in the terms the user sees: an album that was in the
+    Library before the re-download is in the Library after it."""
+    from harmonist import scanner
+    from harmonist.models import AlbumState
+
+    d = _make_tagged_album(
+        cfg, "Stays Done", mbid="rel-stays", tagged_at=datetime.now(UTC), item_id=8002
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda m: _release_with_rg(m, "rg-stays", n_tracks=1)
+    )
+    back = _replay_the_download(cfg, "Stays Done", item_id=8002, mbid=None)
+    _resolve_the_download(cfg, back)
+
+    states = {a.path: a.state for a in scanner.scan(cfg.paths.music_dir)}
+    assert states[back] == AlbumState.COMPLETE
+
+
+def test_a_replacement_that_does_not_fit_the_release_falls_back_to_a_suggestion(
+    client, cfg, quiet_sync, no_cover_fetch, monkeypatch
+):
+    """The tagger's count guard is not skipped, and must not be: whether a
+    tagging is representable is not something the user's assertion can settle.
+    MusicBrainz may not have caught up with a release the artist has grown, so
+    the new files can outnumber its tracklist — which is an error in both tagger
+    modes (§13.3). The user meets the ordinary side-by-side instead."""
+    d = _make_tagged_album(
+        cfg, "Outgrown", mbid="rel-outgrown", tagged_at=datetime.now(UTC), item_id=8003
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    # MB still lists one track; the replacement arrives with three.
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda m: _release_with_rg(m, "rg-out", n_tracks=1)
+    )
+    monkeypatch.setattr(mb_lookup, "lookup_by_bandcamp_url", lambda _u: ["rel-outgrown"])
+    back = _replay_the_download(cfg, "Outgrown", item_id=8003, mbid=None, tracks=3)
+
+    assert _resolve_the_download(cfg, back) != "tagged"
+    after = sc.read(back)
+    assert after.mb_release_id is None  # not tagged behind the user's back
+    assert after.mb_match_candidate is not None  # ...but the suggestion is there
+
+
+def test_a_release_deleted_from_musicbrainz_falls_back_rather_than_failing(
+    client, cfg, quiet_sync, no_cover_fetch, monkeypatch
+):
+    """The carried release can go away between the archive and the download —
+    #194's case. Falling through to the store-URL path is how the album still
+    gets a chance at a release that exists."""
+    d = _make_tagged_album(
+        cfg, "Vanished", mbid="rel-vanished", tagged_at=datetime.now(UTC), item_id=8004
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    monkeypatch.setattr(mb_lookup, "fetch_release", _gone)
+    monkeypatch.setattr(mb_lookup, "lookup_by_bandcamp_url", lambda _u: [])
+    back = _replay_the_download(cfg, "Vanished", item_id=8004, mbid=None)
+
+    assert _resolve_the_download(cfg, back) == "no_match"
+    assert sc.read(back).mb_release_id is None
+
+
+def test_the_carried_release_survives_an_inbox_poll_between_download_and_tagging(
+    client, cfg, quiet_sync, no_cover_fetch, monkeypatch
+):
+    """The inbox polls every couple of seconds during a sync, and the download
+    writes the sidecar — putting the item_id into library_index — BEFORE the
+    tagging runs. A poll landing in that gap must not take the carried release
+    away with the card."""
+    from harmonist import redownloads
+
+    d = _make_tagged_album(
+        cfg, "Polled", mbid="rel-polled", tagged_at=datetime.now(UTC), item_id=8005
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda m: _release_with_rg(m, "rg-polled", n_tracks=1)
+    )
+    monkeypatch.setattr(mb_lookup, "lookup_by_bandcamp_url", lambda _u: ["rel-elsewhere"])
+    back = _replay_the_download(cfg, "Polled", item_id=8005, mbid=None)
+
+    client.get("/tasks")  # the poll: the album is back, so the card goes
+    assert redownloads.count() == 0
+    _resolve_the_download(cfg, back)
+
+    assert sc.read(back).mb_release_id == "rel-polled"
+
+
+def test_a_replacement_that_arrives_short_is_not_quietly_tagged_incomplete(
+    client, cfg, quiet_sync, no_cover_fetch, monkeypatch
+):
+    """The other side of the count guard. A download that arrives SHORT could be
+    forced through in the tagger's incomplete mode, and that would be the wrong
+    favour: the album was complete before, so a short replacement is a bad
+    download, not a newly-incomplete album. Carrying the release must not turn
+    into carrying an excuse for it."""
+    d = _make_tagged_album(
+        cfg, "Short", mbid="rel-short", tagged_at=datetime.now(UTC), item_id=8006
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    # MB says three tracks; only one file comes back.
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda m: _release_with_rg(m, "rg-short", n_tracks=3)
+    )
+    monkeypatch.setattr(mb_lookup, "lookup_by_bandcamp_url", lambda _u: ["rel-short"])
+    back = _replay_the_download(cfg, "Short", item_id=8006, mbid=None, tracks=1)
+
+    assert _resolve_the_download(cfg, back) != "tagged"
+    assert sc.read(back).mb_release_id is None
+
+
+def test_the_carried_release_is_let_go_of_once_it_has_been_used(
+    client, cfg, quiet_sync, no_cover_fetch, monkeypatch
+):
+    """`prune` deliberately leaves the carried release alone, so consuming it at
+    the tagging is the ONLY thing that clears it on the happy path. Without that
+    every successful re-download would leak one until restart."""
+    from harmonist import redownloads
+
+    d = _make_tagged_album(
+        cfg, "Let Go", mbid="rel-letgo", tagged_at=datetime.now(UTC), item_id=8007
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda m: _release_with_rg(m, "rg-letgo", n_tracks=1)
+    )
+    back = _replay_the_download(cfg, "Let Go", item_id=8007, mbid=None)
+    assert redownloads.take_match(8007) is not None  # still held before the tagging
+    redownloads.add(
+        redownloads.PendingRedownload(
+            item_id=8007,
+            artist="Artist",
+            title="Let Go",
+            url="",
+            archive_name="x.zip",
+            requested_at=datetime.now(UTC),
+        ),
+        match=redownloads.CarriedMatch(mb_release_id="rel-letgo"),
+    )
+
+    _resolve_the_download(cfg, back)
+
+    assert redownloads.take_match(8007) is None
+
+
+def test_an_incomplete_album_that_comes_back_just_as_short_keeps_its_tags(
+    client, cfg, quiet_sync, no_cover_fetch, monkeypatch
+):
+    """The issue's own case: an album short of its release because the artist
+    added tracks after the purchase, re-downloaded to go and get them. Bandcamp
+    may not have them either — and then the replacement arrives just as short.
+
+    Being short is the state it was ALREADY in, and the user accepted this
+    release knowing that, so it stays tagged and INCOMPLETE. Refusing here would
+    charge them their tags for a shortfall that predates the button, which is
+    what the demo library did before the incompleteness was carried too."""
+    from harmonist import scanner
+    from harmonist.models import AlbumState
+    from test.helpers import write_track_totals
+
+    d = _make_incomplete_album(
+        cfg, "Still Short", mbid="rel-short-still", tagged_at=datetime.now(UTC), expected=4
+    )
+    tagged = sc.read(d)
+    assert tagged is not None
+    sc.write(
+        d,
+        replace(
+            tagged,
+            bandcamp=BandcampInfo(item_id=8008),
+            store_url="https://x.bandcamp.com/album/still-short",
+        ),
+    )
+    assert _state_of(cfg, d) == AlbumState.INCOMPLETE
+
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda m: _release_with_rg(m, "rg-still", n_tracks=4)
+    )
+    back = _replay_the_download(cfg, "Still Short", item_id=8008, mbid=None, tracks=1)
+
+    assert _resolve_the_download(cfg, back) == "tagged"
+    assert sc.read(back).mb_release_id == "rel-short-still"
+    write_track_totals(back, track_total=4)
+    states = {a.path: a.state for a in scanner.scan(cfg.paths.music_dir)}
+    assert states[back] == AlbumState.INCOMPLETE  # short, and honest about it

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import zipfile
 from collections.abc import Sequence
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest import mock
@@ -19,7 +20,7 @@ import pytest
 from fastapi.testclient import TestClient
 from mutagen.mp4 import MP4
 
-from harmonist import mb_lookup
+from harmonist import activity, activity_store, mb_lookup
 from harmonist import sidecar as sc
 from harmonist.activity_store import Level
 from harmonist.config import BandcampConfig, Config, PathsConfig, ServerConfig, TestConfig
@@ -6976,3 +6977,93 @@ def test_redownloading_twice_archives_once(client, cfg, quiet_sync):
     assert first.status_code == 200
     assert second.status_code == 404
     assert len(list(cfg.paths.music_dir.glob("*.zip"))) == 1
+
+
+def _replay_the_download(cfg, name: str, *, item_id: int, mbid: str | None) -> Path:
+    """What the sync does when the replacement lands: recreate the album dir and
+    write a sidecar for the purchase (no MBID — a fresh download isn't tagged
+    yet), then, if MusicBrainz resolved it, tag it. Both go through
+    `sidecar.write`, which is what records the identity alias."""
+    from harmonist.bandcamp_hook import write_sidecar_for_item
+
+    d = _make_album(cfg, name)
+    slug = name.lower().replace(" ", "-")
+    item = mock.Mock(
+        item_id=item_id,
+        band_name="Artist",
+        item_title=name,
+        _data={"band_id": 1, "item_url": f"https://x.bandcamp.com/album/{slug}"},
+    )
+    write_sidecar_for_item(item, d)
+    activity.record("Downloaded", album_id=sc.album_id_for(d), album_label=name)
+    if mbid:
+        existing = sc.read(d)
+        assert existing is not None
+        sc.write(d, replace(existing, mb_release_id=mbid, tagged_at=datetime.now(UTC)))
+        activity.record("Auto-tagged from MusicBrainz after sync", album_id=sc.album_id_for(d))
+    return d
+
+
+def test_history_survives_the_round_trip_when_the_replacement_tags_the_same_release(
+    client, cfg, quiet_sync
+):
+    """The claim the audit trail rests on: the archive is recorded under the
+    album's MBID, the fresh download starts life under a path-derived temp_uid,
+    and tagging it back to the same release aliases the two — so the album's page
+    shows what happened to it, not just what happened since."""
+    d = _make_tagged_album(
+        cfg, "Round Trip", mbid="rel-rt-1", tagged_at=datetime.now(UTC), item_id=7001
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    _replay_the_download(cfg, "Round Trip", item_id=7001, mbid="rel-rt-1")
+
+    messages = [e.message for e in activity_store.album_history("rel-rt-1")]
+    assert any(m.startswith("redownload.archive") for m in messages)  # before
+    assert "Downloaded" in messages  # during, under the temp_uid
+    assert "Auto-tagged from MusicBrainz after sync" in messages  # after
+
+
+def test_history_splits_when_the_replacement_tags_a_different_release(client, cfg, quiet_sync):
+    """The limit of the above, stated rather than discovered. If MusicBrainz
+    resolves the store URL to a DIFFERENT release, the replacement's id is not
+    the archived album's id and no alias joins them — the archive stays on the
+    old id's history, reachable from the Activity feed but not from the new
+    album's page."""
+    d = _make_tagged_album(
+        cfg, "Split", mbid="rel-split-old", tagged_at=datetime.now(UTC), item_id=7002
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    _replay_the_download(cfg, "Split", item_id=7002, mbid="rel-split-new")
+
+    new_side = [e.message for e in activity_store.album_history("rel-split-new")]
+    assert "Downloaded" in new_side
+    assert not any(m.startswith("redownload.archive") for m in new_side)
+    # The record is not lost, just filed under the album it was made about.
+    old_side = [e.message for e in activity_store.album_history("rel-split-old")]
+    assert any(m.startswith("redownload.archive") for m in old_side)
+
+
+def test_a_replacement_musicbrainz_cannot_match_lands_in_the_inbox_not_the_library(
+    client, cfg, quiet_sync
+):
+    """A re-download can end up UNTAGGED. The album was COMPLETE before; if the
+    store URL no longer resolves, the replacement has a sidecar and a store_url
+    but no release, which is NEEDS_MBID — in the inbox with the usual tools, not
+    silently absent and not silently wrong."""
+    from harmonist import scanner
+    from harmonist.models import AlbumState
+
+    d = _make_tagged_album(
+        cfg, "Unmatched", mbid="rel-um-1", tagged_at=datetime.now(UTC), item_id=7003
+    )
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+    shutil.rmtree(d, ignore_errors=True)
+
+    back = _replay_the_download(cfg, "Unmatched", item_id=7003, mbid=None)
+
+    states = {a.path: a.state for a in scanner.scan(cfg.paths.music_dir)}
+    assert states[back] == AlbumState.NEEDS_MBID

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import re
 import shutil
+import zipfile
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest import mock
@@ -6716,3 +6718,261 @@ def test_a_deleted_release_leaves_the_album_alone(client, cfg, monkeypatch):
     client.post(f"/retag/{_id_for(cfg, d)}")
 
     assert sc.read(d) == before
+
+
+# ---------- Re-download from Bandcamp (#132) ----------
+
+
+@pytest.fixture
+def quiet_sync(client):
+    """Make the sync a no-op that still moves the runner through its states, so a
+    re-download can start one without reaching the network (or the missing
+    cookies file). Returns the runner for assertions about whether it ran."""
+    runner = client.app.state.sync_runner
+    runner._runner_fn = lambda: None
+    return runner
+
+
+def _ignores_with(cfg, *, user: Sequence[int] = (), auto: Sequence[int] = ()) -> Path:
+    """An ignores.txt with ids in each of its two regions. bandcampsync appends
+    a downloaded album's id BELOW the separator, which is the half the ordinary
+    Restore refuses to touch — so a re-download has to reach into it."""
+    cfg.paths.config_dir.mkdir(parents=True, exist_ok=True)
+    lines = [f"{i}  # declined\n" for i in user]
+    lines.append("# ==========================================================\n")
+    lines += [f"{i}  # downloaded\n" for i in auto]
+    cfg.ignores_file.write_text("".join(lines), encoding="utf-8")
+    return cfg.ignores_file
+
+
+def test_redownload_archives_the_album_and_takes_it_off_disk(client, cfg, quiet_sync):
+    d = _make_tagged_album(
+        cfg, "Upgrade Me", mbid="rel-rd-1", tagged_at=datetime.now(UTC), item_id=5150
+    )
+    album_id = _id_for(cfg, d)
+
+    r = client.post(f"/library/{album_id}/redownload")
+
+    assert r.status_code == 200
+    assert not d.exists()
+    zips = list(cfg.paths.music_dir.glob("*.zip"))
+    assert len(zips) == 1
+    with zipfile.ZipFile(zips[0]) as zf:
+        assert any(n.endswith("01 Track.m4a") for n in zf.namelist())
+        assert any(n.endswith(".harmonist.json") for n in zf.namelist())
+
+
+def test_redownload_unignores_the_purchase_in_bandcampsyncs_own_region(client, cfg, quiet_sync):
+    """The one thing that actually makes the next sync re-fetch it. The id sits
+    below the separator because bandcampsync put it there on the first download,
+    and `_remove_user_ignore` deliberately won't go there."""
+    d = _make_tagged_album(cfg, "Reget", mbid="rel-rd-2", tagged_at=datetime.now(UTC), item_id=777)
+    ign = _ignores_with(cfg, user=[111], auto=[777, 888])
+
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+
+    remaining = ign.read_text()
+    assert "777" not in remaining
+    assert "888" in remaining  # somebody else's download, left alone
+    assert "111" in remaining  # a genuine "don't download", left alone
+
+
+def test_redownload_approves_the_download_so_a_link_only_sync_still_fetches_it(
+    client, cfg, quiet_sync
+):
+    """While any album is Needs Link the sync runs link-only and downloads
+    nothing — except items the user explicitly asked for, which is this."""
+    from harmonist import pending_downloads
+
+    d = _make_tagged_album(
+        cfg, "Approved", mbid="rel-rd-3", tagged_at=datetime.now(UTC), item_id=4242
+    )
+    try:
+        client.post(f"/library/{_id_for(cfg, d)}/redownload")
+        assert pending_downloads.is_approved(4242)
+    finally:
+        pending_downloads.reset()
+
+
+def test_redownload_clears_the_collection_checkpoint(client, cfg, quiet_sync):
+    """An incremental sync starts at the checkpoint, so an old purchase would
+    never be re-paged and the replacement would never arrive."""
+    d = _make_tagged_album(
+        cfg, "Old Purchase", mbid="rel-rd-4", tagged_at=datetime.now(UTC), item_id=99
+    )
+    state_file = cfg.paths.music_dir / ".bandcampsync-state.json"
+    state_file.write_text('{"token": "2020-01-01"}')
+
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+
+    assert not state_file.exists()
+
+
+def test_redownload_starts_a_sync(client, cfg, quiet_sync):
+    started = []
+    quiet_sync._runner_fn = lambda: started.append(True)
+    d = _make_tagged_album(
+        cfg, "Fetch Me", mbid="rel-rd-5", tagged_at=datetime.now(UTC), item_id=31337
+    )
+
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+
+    quiet_sync._thread.join(timeout=5)
+    assert started == [True]
+
+
+def test_redownload_refuses_while_a_sync_is_running_and_keeps_the_album(client, cfg):
+    """bandcampsync snapshots ignores.txt at startup and rewrites it wholesale,
+    so an edit made mid-sync is silently discarded — the album would be deleted
+    and then skipped."""
+    d = _make_tagged_album(cfg, "Busy", mbid="rel-rd-6", tagged_at=datetime.now(UTC), item_id=606)
+    client.app.state.sync_runner._status.state = "running"
+
+    r = client.post(f"/library/{_id_for(cfg, d)}/redownload")
+
+    assert r.status_code == 409
+    assert d.exists()
+    assert not list(cfg.paths.music_dir.glob("*.zip"))
+
+
+def test_redownload_refuses_an_album_with_no_single_purchase_id(client, cfg, quiet_sync):
+    """`candidate_item_ids` means several purchases share this store URL and a
+    tiebreak couldn't pin one. Fetching a guess is exactly what Harmonist
+    doesn't do — so the album is not deleted either."""
+    d = _make_tagged_album(cfg, "Ambiguous", mbid="rel-rd-7", tagged_at=datetime.now(UTC))
+    sc.write(
+        d,
+        Sidecar(
+            store_url="https://x.bandcamp.com/album/ambiguous",
+            bandcamp=BandcampInfo(item_id=None, candidate_item_ids=[1, 2]),
+            mb_release_id="rel-rd-7",
+            tagged_at=datetime.now(UTC),
+        ),
+    )
+
+    r = client.post(f"/library/{_id_for(cfg, d)}/redownload")
+
+    assert r.status_code == 400
+    assert d.exists()
+
+
+def test_redownload_records_the_archive_against_the_albums_history(client, cfg, quiet_sync):
+    """The album's id is its MBID, and the replacement gets tagged with the same
+    one — so the archive, the delete and the eventual re-tag all land on one
+    history, which is the point of auditing this at all."""
+    from harmonist import activity_store
+
+    d = _make_tagged_album(
+        cfg, "Traceable", mbid="rel-rd-8", tagged_at=datetime.now(UTC), item_id=8080
+    )
+
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+
+    messages = [e.message for e in activity_store.album_history("rel-rd-8")]
+    assert any(m.startswith("redownload.archive") for m in messages)
+    assert any(m.startswith("redownload.delete") for m in messages)
+    assert any("Archived to" in m for m in messages)
+    # Recorded relative to the library root (#98), so the log names the album
+    # rather than repeating a container path on every line. The pruned parent is
+    # the one that can get this wrong — see test_archive.py, where a symlinked
+    # root can actually tell the two apart.
+    prune = next(m for m in messages if m.startswith("redownload.prune"))
+    assert prune == "redownload.prune dir=Artist"
+
+
+def test_redownload_of_an_adopted_album_does_not_cry_wolf_about_the_ignores(
+    client, cfg, quiet_sync
+):
+    """An album adopted from an existing library was never downloaded by
+    bandcampsync, so it has no line in ignores.txt and nothing was blocking the
+    re-download. Reporting that as a problem would fire on the common case."""
+    from harmonist import activity
+
+    d = _make_tagged_album(
+        cfg, "Adopted", mbid="rel-rd-12", tagged_at=datetime.now(UTC), item_id=1212
+    )
+    assert not cfg.ignores_file.exists()
+
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+
+    assert not [e for e in activity.recent() if e.level == Level.WARNING]
+
+
+def test_redownload_warns_when_the_ignore_could_not_be_removed(
+    client, cfg, quiet_sync, monkeypatch
+):
+    """The opposite case, and the one worth interrupting for: the id is still
+    ignored, so bandcampsync skips the purchase and the replacement the user was
+    promised never arrives."""
+    from harmonist import activity
+
+    d = _make_tagged_album(
+        cfg, "Stuck", mbid="rel-rd-13", tagged_at=datetime.now(UTC), item_id=1313
+    )
+    _ignores_with(cfg, auto=[1313])
+    monkeypatch.setattr(Path, "write_text", mock.Mock(side_effect=OSError("read-only filesystem")))
+
+    client.post(f"/library/{_id_for(cfg, d)}/redownload")
+
+    warnings = [e.message for e in activity.recent() if e.level == Level.WARNING]
+    assert any("ignores" in m for m in warnings)
+
+
+def test_an_awaited_redownload_is_shown_in_the_inbox_until_it_lands(client, cfg, quiet_sync):
+    """Between the archive and the download the album has no directory, so it is
+    in no state and no group — without this card it just vanishes moments after
+    the user clicked something that deleted their files."""
+    from harmonist import library_index, redownloads
+
+    d = _make_tagged_album(
+        cfg, "Interim", mbid="rel-rd-9", tagged_at=datetime.now(UTC), item_id=9090
+    )
+    try:
+        client.post(f"/library/{_id_for(cfg, d)}/redownload")
+
+        r = client.get("/tasks")
+        assert "Re-downloading" in r.text
+        assert "Interim" in r.text
+        # The zip is the escape hatch out of this state, so the card has to name it.
+        assert "(archived " in r.text
+
+        # ...and it clears by derivation once the purchase is back on disk — no
+        # completion callback anything could forget to fire.
+        library_index.upsert(
+            cfg.paths.music_dir / "Artist" / "Interim",
+            Sidecar(mb_release_id="rel-rd-9", bandcamp=BandcampInfo(item_id=9090)),
+        )
+        assert "Interim" not in client.get("/tasks").text
+    finally:
+        redownloads.reset()
+        library_index.clear()
+
+
+def test_album_page_offers_redownload_only_for_a_linked_bandcamp_purchase(client, cfg):
+    linked = _make_tagged_album(
+        cfg, "Linked", mbid="rel-rd-10", tagged_at=datetime.now(UTC), item_id=1010
+    )
+    manual = _make_tagged_album(cfg, "Manual", mbid="rel-rd-11", tagged_at=datetime.now(UTC))
+
+    assert "/redownload" in client.get(f"/album/{_id_for(cfg, linked)}").text
+    # A CD rip has no purchase to re-download, so the control isn't offered —
+    # the same string IS present on the album above, under different conditions.
+    assert "/redownload" not in client.get(f"/album/{_id_for(cfg, manual)}").text
+
+
+def test_redownloading_twice_archives_once(client, cfg, quiet_sync):
+    """Transitions are idempotent (§3). The album is off disk after the first
+    call, so the second finds nothing to act on rather than writing a second
+    archive of an album that no longer exists — which would be an empty zip and
+    a second sync for a purchase already queued."""
+    d = _make_tagged_album(
+        cfg, "Twice", mbid="rel-rd-14", tagged_at=datetime.now(UTC), item_id=1414
+    )
+    album_id = _id_for(cfg, d)
+
+    first = client.post(f"/library/{album_id}/redownload")
+    second = client.post(f"/library/{album_id}/redownload")
+
+    assert first.status_code == 200
+    assert second.status_code == 404
+    assert len(list(cfg.paths.music_dir.glob("*.zip"))) == 1


### PR DESCRIPTION
Adds a **Re-download** button to an album's page, for the two reasons the issue names — upgrading MP3s bought years ago to FLAC, and picking up tracks the artist has added to a release since the purchase — plus the third from the issue's comment: a release that grew after you bought it, which Harmonist can already see as INCOMPLETE with a live store link.

## The files have to go, and that shapes everything

Three independent mechanisms stop a sync re-fetching a purchase it already has, and each keys off the album being on disk: `sync_items` unions `library_index.item_ids()` into bandcampsync's ignore set, `sync_item` short-circuits on a `store_url` it finds in that index, and `LocalMedia.is_locally_downloaded` reads the `bandcamp_item_id.txt` the original download left behind. There is no variant that leaves the music where it is.

So a new `archive.py` zips the album into the top of the music folder — audio, artwork and the sidecar, stored not deflated, colliding names suffixed rather than overwritten — then **reopens it, CRC-checks it, and compares the manifest and every member's size against what went in.** Only then is anything deleted. A failure at any point leaves the album exactly where it was and removes the partial zip. That ordering is the whole safety argument, which is why the archive and the delete are one function rather than two a caller sequences.

Un-ignoring reaches into bandcampsync's auto-managed region — the half `_remove_user_ignore` deliberately refuses, because there it would mean duplicating an album still on disk. Here there is no copy left. It happens between syncs and only then: bandcampsync snapshots `ignores.txt` at startup and rewrites it wholesale, so a concurrent edit is silently discarded and a re-download is refused outright while a sync runs.

## The release is carried through

Re-downloading says the *files* are wrong, not the match — so the archived album's `mb_release_id` is carried and the replacement is tagged as that same release, rather than re-resolving the store URL and re-opening a question nobody asked. That is Confirm's semantics, not a guess; the confidence assessment is skipped exactly as Confirm skips it. The tagger's count guard is **not** skipped, and everything it can't settle falls through to the ordinary post-download path, so the fallback is never worse than a first-time download.

Whether the copy was INCOMPLETE is carried too — it is part of the match the user accepted. An album short because the artist added tracks may come back just as short, and that is the state it was already in; it stays tagged rather than becoming inbox work over a shortfall that predates the button. A previously-COMPLETE album coming back short still gets the strict guard, because that is a bad download.

Carrying the release also keeps the album's id stable, so the archive, the download and the re-tag land on **one history page** under the album's original URL.

## Interim state and the escape hatch

Between the archive and the download the album has no directory, so it is in no state at all. It is held in `redownloads`, in-memory beside `pending_downloads` and for the same stated reasons, rendered as an inbox card that names its zip. That archive is the escape hatch and the only one offered: unzipping at the music root restores the album matched, sidecar and all, which no Cancel button could better.

Two lifetimes, two dicts. The card clears when the files are back; the carried match must outlive it, because the download writes its sidecar — populating the index `prune` reads — *before* the tagging runs, and the inbox polls every couple of seconds during a sync.

## Not offered

Without a single `bandcamp.item_id`: a CD rip has no purchase, and an album carrying only `candidate_item_ids` has several it might be. Fetching a guess is the no-guessing invariant in reverse.

## Testing

`make check` green (1280 tests), `make e2e` green (22). Every test written after its code was mutation-checked red — across the archive ordering, the collision suffix, the symlink guard, the auto-region un-ignore, the sync guard, the placeholder card, the audit path shape, the carried release, the poll race, the incompleteness rule in **both** directions, and both browser tests.

Two findings worth calling out, because both came from tests rather than from reading:

- An audit-path assertion I first wrote at the web rung **could not fail** — pytest's `tmp_path` is already resolved, so `resolve()` and the configured path are identical there. Moved to a unit test with a symlinked music root, where the difference is real.
- **Demo mode caught a real bug.** Its INCOMPLETE fixture is the issue's own case; the first version of the carry-through turned it into untagged inbox work. Demo mode now models a re-download rather than swallowing it, and runs the real post-download callback — staging the outcome would have shown a working feature whatever the code did.

Verified end to end in demo: archived, deleted, re-fetched, tagged `mode=incomplete`, back at its original `/album/...` URL with the whole history on one page above a "2 of 4 tracks on disk" badge.

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016emoJJZvLEb5dw83voQcEW