### PR TITLE
Call an AAC file AAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- AAC files now say **AAC** in an album's Format row instead of **MP4** (#254),
+  so the row tells you at a glance whether an `.m4a` album is the lossless
+  download or the lossy one. **MP4** now means only what it should: a file
+  whose codec Harmonist couldn't identify.
 - Your files are now paired with MusicBrainz tracks by the per-track id they
   carry, so an album stays on its own tracks after MusicBrainz renumbers or
   reorders the release's discs (#232).

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -181,10 +181,24 @@ def read_duration_ms(path: Path) -> int | None:
 
 
 def _codec_label(audio: MP4) -> str:
+    """The short label for what's inside the MP4 container.
+
+    `MP4Info.codec` is an RFC 6381 string — mutagen documents it as
+    `'mp4a[.*][.*]'` or `'alac'` — so AAC arrives as "mp4a.40.2" and an
+    equality test against the bare "mp4a" matched nothing (#254). `alac` really
+    is bare, which is why only half of this was ever wrong.
+
+    Matched on `.40` rather than on "mp4a" alone: the suffix is
+    `"%X" % objectTypeIndication`, and 0x40 is MPEG-4 Audio — the AAC family.
+    Other object types in an `mp4a` box genuinely aren't AAC (`mp4a.69` and
+    `mp4a.6B` are MP3 in an MP4 container), and a bare "mp4a" means no ESDS
+    descriptor could be parsed at all. Both keep falling through to "MP4",
+    which is the honest answer for a container whose codec we can't name.
+    """
     codec = getattr(audio.info, "codec", "")
     if codec == "alac":
         return "ALAC"
-    if codec == "mp4a":
+    if codec.startswith("mp4a.40"):
         return "AAC"
     return "MP4"
 

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -475,6 +475,25 @@ def test_describe_label(tmp_path, ext, fixture, expected):
     assert formats.describe(f) == expected
 
 
+def test_describe_names_aac_rather_than_its_container(tmp_path):
+    """#254: `MP4Info.codec` is an RFC 6381 string — "mp4a.40.2", not "mp4a" —
+    so an equality test against the bare four-character code never matched and
+    every AAC file read as "MP4".
+
+    The point of the label is to separate lossless ALAC from lossy AAC, and
+    "MP4" is the answer that should be reserved for a container whose codec
+    can't be pinned down.
+    """
+    from mutagen.mp4 import MP4
+
+    dst = tmp_path / "01 track.m4a"
+    shutil.copy(FIXTURES_DIR / "sine-aac.m4a", dst)
+    assert MP4(dst).info.codec == "mp4a.40.2"  # what the label has to cope with
+
+    assert formats.describe(dst) == "AAC"
+    assert formats.read_scan_fields(dst).codec == "AAC"
+
+
 def test_describe_none_for_unknown(tmp_path):
     assert formats.describe(tmp_path / "cover.jpg") is None
 


### PR DESCRIPTION
An AAC-encoded `.m4a` showed `MP4` in the album page's Format row — so the one row meant to separate lossless ALAC from lossy AAC declined to name the lossy one, and did so using the label that should mean "we couldn't identify this".

## Root cause

`MP4Info.codec` is an RFC 6381 string, not a bare four-character code. mutagen documents it as `'mp4a[.*][.*]'` or `'alac'` (`mutagen/mp4/_as_entry.py:31`) and builds the suffix from the ESDS object type indication, so AAC arrives as `mp4a.40.2` and the `== "mp4a"` branch matched nothing.

Only half of this was ever wrong: `alac` really is a bare string, so lossless was labelled correctly throughout.

```
sine.m4a      codec: 'alac'       -> ALAC   (correct all along)
sine-aac.m4a  codec: 'mp4a.40.2'  -> MP4    (should be AAC)
```

## Why `.40` and not `mp4a`

`codec_param` is `"%X" % objectTypeIndication`, and `0x40` is MPEG-4 Audio — the AAC family. Matching on `mp4a` alone would sweep in things that genuinely aren't AAC: `mp4a.69` and `mp4a.6B` are MP3 in an MP4 container, and a bare `mp4a` means no ESDS descriptor could be parsed at all. Both keep falling through to `MP4`, which is the honest answer for a container whose codec can't be named.

## Blast radius

None beyond the label. `ScanFields.codec`'s only reader is the Format row's codec rollup (`scanner.py:604`), so this cannot reach state derivation, matching or tagging. `#130`'s `lossless` flag is still keyed on `ALAC` alone, so AAC was already being read as lossy and its quality detail is unchanged.

## Testing

Red-first — the test failed with `assert 'MP4' == 'AAC'` before the one-line change. It asserts mutagen's `mp4a.40.2` directly first, so it documents what the label has to cope with rather than just what Harmonist now returns.

`test/fixtures/sine-aac.m4a` already existed (added by #130, where this bug surfaced).

`make check` green: 1299 passed, 24 skipped.

Fixes #254