### PR TITLE
Offer a way through when MusicBrainz has grown a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ versions follow [semantic versioning](https://semver.org).
   comparing durations, which could write another track's title and ids (#232).
 - An album whose only missing discs are video can be re-tagged again, instead
   of refusing with "16 audio files but MB release has 69 tracks" (#235, #237).
+- Re-tagging an album whose MusicBrainz release has since gained tracks no
+  longer fails with a stack trace (#252). It says how many tracks are there and
+  how many you have, and offers **Re-tag as incomplete** — press it and your
+  files take the release's current tags, and the album is listed as incomplete
+  in your Library. Nothing is written unless you do.
 - Re-tagging no longer resets parts of an album's record — a surrendered album
   stays surrendered, and one accepted as incomplete stays accepted (#239).
 - An album page now lists the video files on disk, marked as video, instead of

--- a/docs/design.md
+++ b/docs/design.md
@@ -74,6 +74,21 @@ the whole reason the `NEEDS_SYNC` state exists.
 1. User edits a release in MB (track titles, dates, etc.) — or just wants to refresh tags.
 2. User clicks **Re-tag from MB** on a Library album's page.
 3. Harmonist re-fetches the MB release and rewrites the file tags. Per-track embedded artwork is preserved unless the user forces **Replace artwork**.
+4. If the release now lists **more** tracks than the album has files, the tagger's
+   count guard refuses (§15.3) and the refusal is presented as a decision rather
+   than an error: both counts, plus a **Re-tag as incomplete** control that
+   re-runs the same re-tag in incomplete mode (#252). Nothing is written until
+   that control is pressed; the album then derives `INCOMPLETE` from the totals
+   the re-tag wrote (§13.3) and stays in the Library.
+
+   The guard cannot be keyed off the album's derived state alone. `COMPLETE` vs
+   `INCOMPLETE` says whether the files were short of what MusicBrainz said **at
+   tagging time** (§3, #195); the guard asks what it says **now**. The two
+   diverge on precisely the album a MusicBrainz correction has grown, and no
+   derived fact can settle that — only the user can, so the endpoint asks.
+   `incomplete = file_count < track_count` at the call site is explicitly *not*
+   the answer (#133): it accepts any shortfall silently, which is the one thing
+   the guard exists to prevent.
 
 ### 2.4.1 Re-download from Bandcamp (#132)
 
@@ -617,6 +632,7 @@ stateDiagram-v2
     COMPLETE --> NEW: Forget<br/>(sidecar deleted)
     COMPLETE --> NEEDS_MBID: Wrong match<br/>(pencil — tags left on disk)
     COMPLETE --> NEEDS_MBID: Undo the linking<br/>tagging (#157/#158)
+    COMPLETE --> INCOMPLETE: Re-tag as incomplete<br/>(MB gained tracks — §2.4)
 
     INCOMPLETE --> NEW: Forget
     INCOMPLETE --> NEEDS_MBID: Recheck<br/>(MB tracklist changed → suggestion)
@@ -1403,6 +1419,13 @@ button next to Confirm / Dismiss suggestion:
   tagging writes the release's own track/disc totals into every file it
   touches, so the album's state becomes `INCOMPLETE`, derived at scan time
   from those tags (§3). Nothing about the count is persisted separately.
+
+A Library album that is already tagged reaches the same mode by the same kind of
+decision, offered where the problem appears: **Re-tag as incomplete**, on the
+refusal a re-tag returns when the release has since grown (§2.4 step 4). Same
+tagger mode, same lack of persistence — the only difference is that the album
+already has an MBID, so the answer belongs on its page rather than on a
+suggestion card.
 
 **Tagger incomplete mode:** doesn't raise `TagMismatchError` on
 `file_count < track_count`. Matching the on-disk files to a subset of MB

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -237,6 +237,16 @@ MBID to re-pick, leaving your files' current tags alone until you re-tag), and
 **Forget**, which deletes the sidecar and returns the album to New without
 touching a single audio file.
 
+**When MusicBrainz has gained tracks since you were tagged.** A re-tag won't
+write a release's tags onto fewer files than it lists — that guard is what stops
+a half-finished download being tagged as the whole album. So if an editor has
+added tracks in the meantime, Re-tag stops and tells you both numbers, with a
+**Re-tag as incomplete** button beside them. Press it and your files take the
+release's current tags anyway; the album is then listed as incomplete, saying how
+many tracks it's short, and stays in your Library. Nothing is written until you
+press it. (If your copy is short because the *artist* added tracks, **Re-download**
+below is the fix that gets you the missing audio.)
+
 ### Re-downloading an album
 
 **Re-download** fetches the album from Bandcamp again. Two reasons to want it:

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -389,6 +389,30 @@ LIBRARY: list[dict[str, Any]] = [
             "tagged": True,
         },
     },
+    {
+        # State: COMPLETE — and it will stay COMPLETE, because the album's own
+        # files agree there are two of two. MusicBrainz has since grown the
+        # release to four (an editor merged in the reissue's bonus tracks), so
+        # pressing Re-tag from MB meets the count guard and gets the #252 offer
+        # rather than a stack trace.
+        #
+        # No `release_tracks`: the default writes the FILES' own count into them,
+        # which is exactly the point — the two facts (what MB said at tagging
+        # time, what it says now) have to disagree for this state to exist, and
+        # the disagreement lives between the files and MB_RELEASES below. The
+        # incomplete album above is the other way round and is not this case.
+        "artist": "The Wonders",
+        "album": "Play!",
+        "tracks": ["That Thing You Do!", "Dance With Me Tonight"],
+        "cover": "cover-5.jpg",
+        "file_mbid": "demo-rel-wonders",
+        "sidecar": {
+            "store_url": "https://thewonders.bandcamp.com/album/play",
+            "bandcamp_item_id": 1010,
+            "mb_release_id": "demo-rel-wonders",
+            "tagged": True,
+        },
+    },
 ]
 
 
@@ -616,6 +640,21 @@ MB_RELEASES: dict[str, Release] = {
         "Shout",
         ["Shout", "Shama Lama Ding Dong"],
     ),
+    "demo-rel-wonders": _release(
+        "demo-rel-wonders",
+        "The Wonders",
+        "Play!",
+        # 4 tracks on MB; the seeded album has the first 2 on disk AND its files
+        # say "2 of 2" — the release grew after the tagging (#252). That is the
+        # whole fixture: the album derives COMPLETE, so Re-tag sends
+        # `incomplete=False` and the guard refuses against this count.
+        [
+            "That Thing You Do!",
+            "Dance With Me Tonight",
+            "All My Only Dreams",
+            "Little Wild One",
+        ],
+    ),
 }
 
 
@@ -635,6 +674,7 @@ URL_RELS: dict[str, str] = {
     "https://stillwater.bandcamp.com/album/fever-dog-live": "demo-rel-fever-live",
     "https://bluesbrothers.bandcamp.com/album/rawhide": "demo-rel-blues-brothers",
     "https://otisday.bandcamp.com/album/shout": "demo-rel-otis-day",
+    "https://thewonders.bandcamp.com/album/play": "demo-rel-wonders",
 }
 
 

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -73,7 +73,29 @@ _FlatTrack = tuple[dict[str, Any], int, Track]
 
 
 class TagMismatchError(Exception):
-    """Raised when the file count doesn't match the MB release's track count."""
+    """Raised when the file count doesn't match the MB release's track count.
+
+    Carries the two counts, and `short` says which way round they are: True when
+    the release lists MORE tracks than the album has files. That is the one
+    direction a caller can resolve — by re-running in incomplete mode, which is
+    the user's decision to make (#252) — while the other direction (extra files
+    on disk) is out of scope for the tagger in both modes (design §15.3).
+
+    The counts are attributes rather than only prose in the message because the
+    web layer has to tell the two apart and name the numbers back to the user;
+    re-parsing the sentence for them would be a second, silently divergent copy
+    of what happened.
+    """
+
+    def __init__(self, message: str, *, files: int, tracks: int) -> None:
+        super().__init__(message)
+        self.files = files
+        self.tracks = tracks
+
+    @property
+    def short(self) -> bool:
+        """The album has fewer files than the release has tracks."""
+        return self.files < self.tracks
 
 
 @runtime_checkable
@@ -173,13 +195,17 @@ def tag_album(
     if not incomplete and len(files) != len(taggable):
         raise TagMismatchError(
             f"album {album_dir.name!r}: {len(files)} audio files but MB release "
-            f"has {len(taggable)} tracks"
+            f"has {len(taggable)} tracks",
+            files=len(files),
+            tracks=len(taggable),
         )
     if len(files) > len(flat_tracks):
         raise TagMismatchError(
             f"album {album_dir.name!r}: {len(files)} files exceeds MB release "
             f"track count {len(flat_tracks)} — extra files on disk are out of "
-            f"scope (see design §15.3)"
+            f"scope (see design §15.3)",
+            files=len(files),
+            tracks=len(flat_tracks),
         )
 
     # Assigned against EVERY track, not just the taggable ones: a file that

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -999,6 +999,22 @@ def _completeness_oob(request: Request, album: Album) -> str:
     return template.render(_ctx(request, album=album, oob=True))
 
 
+def _retag_short_oob(
+    request: Request, album: Album, *, files: int, tracks: int, overwrite_art: bool
+) -> str:
+    """The album page's alert slot, stating that MusicBrainz now lists more tracks
+    than the album has files, and offering the re-tag that accepts that (#252).
+
+    Rendered out of band because the page had no way to know: the counts only
+    disagree once the re-tag has fetched the release, and the album's own state
+    says what MusicBrainz said at *tagging* time (#195), not what it says now.
+    """
+    template = _templates(request).env.get_template("partials/_retag_short.html")
+    return template.render(
+        _ctx(request, album=album, files=files, tracks=tracks, overwrite_art=overwrite_art)
+    )
+
+
 def _library_limit(request: Request, limit: int | None) -> int:
     """The page size for this render: the URL's `?limit=` when it names one, else
     the size the reader last chose, else the default (#144).
@@ -3572,7 +3588,19 @@ def _register_routes(app: FastAPI) -> None:
         )
 
     @app.post("/retag/{album_id}", response_class=HTMLResponse)
-    def retag(request: Request, album_id: str, overwrite_art: bool = Form(False)) -> Response:
+    def retag(
+        request: Request,
+        album_id: str,
+        overwrite_art: bool = Form(False),
+        accept_short: bool = Form(False),
+    ) -> Response:
+        """Re-tag a Library album from the MusicBrainz release it names.
+
+        `accept_short=True` is the user's answer to the offer this endpoint makes
+        when the guard refuses (#252) — tag the files against a release that lists
+        more tracks than are on disk. It is a decision, so it arrives from a
+        control the user pressed; the endpoint never infers it from the counts.
+        """
         album = _find_album(request, album_id)
         sc = album.sidecar
         if not sc or not sc.mb_release_id:
@@ -3598,7 +3626,15 @@ def _register_routes(app: FastAPI) -> None:
                 # album Harmonist had ever tagged and distinguished nothing. The
                 # state does distinguish: a COMPLETE album still gets
                 # `incomplete=False` and the §15.3 guard still applies to it.
-                incomplete=album.state == AlbumState.INCOMPLETE,
+                #
+                # `accept_short` is the residual half (#252): the state answers
+                # "were the files short of what MusicBrainz said when they were
+                # tagged", and the guard asks "are they short of what it says
+                # now". They diverge on exactly the album a MusicBrainz
+                # correction has grown, and no derived fact can settle that — so
+                # the refusal below turns into a question, and this carries the
+                # user's answer to it.
+                incomplete=accept_short or album.state == AlbumState.INCOMPLETE,
                 overwrite_art=overwrite_art,
                 paths=album.folders,
             )
@@ -3616,12 +3652,57 @@ def _register_routes(app: FastAPI) -> None:
                 tasks_changed=False,
                 album=album,
             )
+        except tagger_mod.TagMismatchError as e:
+            if not e.short:
+                # More files than the release has tracks. Out of scope for the
+                # tagger in *both* modes (§15.3), so there is no decision to
+                # offer — it stays an error, as it was.
+                log.exception("retag failed")
+                return _flash_response(
+                    "Re-tag failed", str(e), level=Level.ERROR, tasks_changed=False, album=album
+                )
+            # Not a failure to report as one (#252). Nothing was written and the
+            # guard did its job; what the user needs is the two counts and the
+            # one control that resolves them, which rides back out of band.
+            log.info("retag: %s", e)
+            return _flash_response(
+                "MusicBrainz lists more tracks than you have",
+                f"{e.tracks} there, {e.files} here — re-tag as incomplete to take its tags anyway",
+                level=Level.WARNING,
+                tasks_changed=False,
+                album=album,
+                oob=_retag_short_oob(
+                    request, album, files=e.files, tracks=e.tracks, overwrite_art=overwrite_art
+                ),
+            )
         except Exception as e:
             log.exception("retag failed")
             return _flash_response(
                 "Re-tag failed", str(e), level=Level.ERROR, tasks_changed=False, album=album
             )
-        details = "artwork replaced" if overwrite_art else None
+        # Say what the re-tag DID, not only that it ran. A short re-tag has just
+        # written a longer tracklist's totals into the files, so the album derives
+        # INCOMPLETE from here (§13.3) and starts showing a shortfall badge — a
+        # visible change to how it is listed, which the entry should name rather
+        # than leave to be discovered. It stays in the Library either way.
+        detail_parts = [
+            *(["now listed as incomplete"] if accept_short else []),
+            *(["artwork replaced"] if overwrite_art else []),
+        ]
+        details = ", ".join(detail_parts) or None
+        # A re-tag can move the album's state — the totals it just wrote are what
+        # COMPLETE/INCOMPLETE is derived from (#195) — and the album page reloads
+        # itself on `album-retagged`. Refresh the snapshot in this request, or that
+        # reload races the async rescan and re-renders the state the re-tag has
+        # just replaced: a short album accepted as incomplete comes back still
+        # claiming to be complete (#252).
+        #
+        # NOT paired with `skip_rescan`, unlike the other single-album mutations:
+        # `refresh_now` patches the snapshot only, and a moved state also has to
+        # reach `live_counts`, which the full rescan is what resets.
+        runner = request.app.state.scan_runner
+        if runner.is_engaged():
+            runner.refresh_now()
         # Reload the open detail modal so its disk-vs-MB comparison + metadata
         # reflect the just-written tags (tasks-changed only refreshes the tiles).
         return _flash_response(

--- a/templates/partials/_retag_short.html
+++ b/templates/partials/_retag_short.html
@@ -1,0 +1,57 @@
+{# MusicBrainz now lists more tracks than this album has files (#252).
+
+   Swapped out of band into the album page's alert slot by /retag, which is the
+   only thing that can find out: the count guard compares the files against the
+   release's tracklist *as it is now*, and the album's own state is derived from
+   what MusicBrainz said at tagging time (#195). When the release has grown since,
+   the two disagree and the guard refuses — correctly, since nothing may be tagged
+   short without someone saying so.
+
+   So this states the disagreement and offers the saying-so, rather than reporting
+   a refusal the user can do nothing about. The escape hatch used to exist only via
+   Wrong MusicBrainz match → re-pick the same release → Confirm as incomplete,
+   which required calling a correct match wrong and discarded the album's link on
+   the way.
+
+   Amber, not red: nothing failed and nothing was written. The album still carries
+   the tags it had.
+
+   The button re-posts the SAME re-tag with `accept_short` set, `overwrite_art`
+   included, so the second press does what the first was asked to do plus the
+   decision. #}
+<div id="album-alert-{{ album.id }}" hx-swap-oob="true">
+    <div class="border border-amber-300 bg-amber-50 rounded-lg p-3 mb-3 flex items-start gap-3">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"
+             class="text-amber-700 flex-shrink-0 mt-0.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+        </svg>
+        <div class="flex-1 min-w-0">
+            <p class="text-xs font-bold text-amber-900">
+                MusicBrainz now lists {{ tracks }} track{{ 's' if tracks != 1 else '' }} — you have {{ files }}
+            </p>
+            <p class="text-2xs text-amber-800 mt-0.5">
+                The release has gained tracks since this album was tagged, and Harmonist
+                won't tag files against a longer tracklist unless you say the shortfall is
+                expected — that's what stops a half-finished download being tagged as a
+                whole album. Re-tagging as incomplete takes its current tags for the
+                {{ files }} file{{ 's' if files != 1 else '' }} you have and leaves the album
+                in your library, listed as incomplete. Nothing is written until you press it.
+            </p>
+        </div>
+        {# Same indicator as the button that raised this, so the second attempt shows
+           the same tagging overlay as the first. No hx-confirm: this IS the
+           confirmation, and it is not destructive — a re-tag rewrites tags the album
+           already had, and the history keeps what they were. #}
+        <button hx-post="/retag/{{ album.id }}"
+                hx-vals='{"accept_short": "true", "overwrite_art": "{{ 'true' if overwrite_art else 'false' }}"}'
+                hx-swap="none" hx-disabled-elt="this" hx-indicator="#tagging-{{ album.id }}"
+                class="flex-shrink-0 px-3 py-1.5 bg-amber-100 hover:bg-amber-200 text-amber-900 border border-amber-300 rounded text-xs font-bold uppercase tracking-widest transition"
+                {# The accessible name must CONTAIN the visible text (WCAG "label in
+                   name"), or voice control saying "Re-tag as incomplete" can't reach it. #}
+                aria-label="Re-tag as incomplete — take the new tags for the {{ files }} tracks you have"
+                title="Re-tag from MusicBrainz, accepting that {{ tracks - files }} track{{ 's are' if tracks - files != 1 else ' is' }} missing from disk. The album derives Incomplete afterwards.">
+            Re-tag as incomplete
+        </button>
+    </div>
+</div>

--- a/test/e2e/test_retag_short.py
+++ b/test/e2e/test_retag_short.py
@@ -1,0 +1,90 @@
+"""The "MusicBrainz has grown" offer lands on the page, and its button fires (#252).
+
+Two things the Python suite structurally cannot check, both of which have bitten
+this repo before:
+
+- The offer arrives as an **out-of-band swap**. `test_web.py` asserts the right
+  markup came back in the response; it cannot say whether htmx put it anywhere,
+  or whether `#album-alert-<id>` exists on the album page at all. A typo in the
+  id produces a perfectly correct-looking response that lands nowhere (#210).
+- The offered button carries `hx-vals`. Whether `accept_short` actually reaches
+  the server is a question about the browser, not about the template — and a
+  control that silently does nothing is the #40 bug class exactly.
+
+So the second test asserts on the POST body, then on the outcome.
+
+Drives a browser via `sync_playwright()` opened per test, like every other module
+here — see test_release_gone.py for why mixing in the pytest-playwright `page`
+fixture kills the rest of the session.
+
+Own module because the second test really does re-tag the demo album, which is
+not a thing to hand to a neighbouring test: `demo_server` is module-scoped, so
+that mutation stays in here.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1", reason="e2e disabled (set RUN_E2E=1)"
+)
+playwright_sync = pytest.importorskip("playwright.sync_api")
+
+# COMPLETE by its own files (2 of 2), while the demo catalogue's release lists 4
+# — the album the demo seeds for this state.
+ALBUM_ID = "demo-rel-wonders"
+
+# A COMPLETE album whose files and the catalogue agree, for the control.
+AGREEING_ALBUM_ID = "demo-rel-rural-juror"
+
+
+def test_a_re_tag_that_cannot_fit_offers_the_way_out(demo_server: str) -> None:
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+
+        page.goto(f"{demo_server}/album/{AGREEING_ALBUM_ID}")
+        page.wait_for_load_state("networkidle")
+        page.get_by_role("button", name="Re-tag from MB").click()
+        # The control first: an album that fits gets no alert at all, so the
+        # assertion below is about this state rather than about the slot always
+        # being full.
+        page.wait_for_timeout(1500)
+        assert page.locator("text=MusicBrainz now lists").count() == 0
+
+        page.goto(f"{demo_server}/album/{ALBUM_ID}")
+        page.wait_for_load_state("networkidle")
+        page.get_by_role("button", name="Re-tag from MB").click()
+
+        offer = page.locator("text=MusicBrainz now lists 4 tracks — you have 2")
+        offer.wait_for(timeout=10_000)
+        assert offer.is_visible(), "the OOB swap landed in #album-alert-*"
+        assert page.get_by_role("button", name="Re-tag as incomplete").is_visible()
+
+        browser.close()
+
+
+def test_the_offered_button_sends_the_decision(demo_server: str) -> None:
+    """`hx-vals` is the whole mechanism here: without `accept_short` on the wire
+    the second press hits the same guard as the first and nothing ever changes."""
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+
+        page.goto(f"{demo_server}/album/{ALBUM_ID}")
+        page.wait_for_load_state("networkidle")
+        page.get_by_role("button", name="Re-tag from MB").click()
+        page.locator("text=MusicBrainz now lists 4 tracks — you have 2").wait_for(timeout=10_000)
+
+        with page.expect_request(f"**/retag/{ALBUM_ID}") as request:
+            page.get_by_role("button", name="Re-tag as incomplete").click()
+        assert request.value.method == "POST"
+        assert "accept_short=true" in (request.value.post_data or "")
+
+        # The re-tag reloads the page (album.html's `album-retagged` listener),
+        # and the album now states the shortfall it just accepted.
+        page.wait_for_selector("text=2 of 4 tracks on disk", timeout=10_000)
+        browser.close()

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3107,19 +3107,115 @@ def test_retag_works_on_an_album_confirmed_as_incomplete(client, cfg, monkeypatc
 
 
 def test_retag_still_refuses_an_unconfirmed_short_album(client, cfg, monkeypatch):
-    """The control: an album not already known to be short must still be
-    refused, or the guard against tagging a partial download by accident is gone
-    (design §15.3). Its files carry no totals, so it derives COMPLETE and /retag
-    passes `incomplete=False`."""
-    d = _make_tagged_album(cfg, "Unconfirmed", mbid="rel-unc", tagged_at=datetime.now(UTC))
-    sc.write(d, Sidecar(mb_release_id="rel-unc", tagged_at=datetime.now(UTC)))  # no expectation
+    """The control: an album not already known to be short must still not be
+    tagged short, or the guard against tagging a partial download by accident is
+    gone (design §15.3). Its files carry no totals, so it derives COMPLETE and
+    /retag passes `incomplete=False`.
+
+    Since #252 the refusal is a question rather than an error, so what's asserted
+    is that nothing was written — the flash wording is the next test's subject."""
+    tagged = datetime(2026, 1, 1, tzinfo=UTC)
+    d = _make_tagged_album(cfg, "Unconfirmed", mbid="rel-unc", tagged_at=tagged)
+    sc.write(d, Sidecar(mb_release_id="rel-unc", tagged_at=tagged))  # no expectation
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=4)
     )
     monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
 
     r = client.post(f"/retag/{_id_for(cfg, d)}")
+    assert "Re-tagged" not in r.text
+    after = sc.read(d)
+    assert after is not None and after.tagged_at == tagged, "the files were left alone"
+
+
+def test_retag_offers_incomplete_when_mb_has_grown_tracks(client, cfg, monkeypatch):
+    """#252: the album's files agree among themselves that it is complete — one
+    of one — so it derives COMPLETE and `incomplete=False` goes to the tagger.
+    MusicBrainz has since gained tracks, so the guard refuses against the *new*
+    count and re-tagging was impossible for exactly the album a MusicBrainz
+    correction has touched.
+
+    The answer is the two counts and a control that resolves them, not a stack
+    trace. The control rides back out of band into the album page's alert slot."""
+    import json
+
+    from test.helpers import write_track_totals
+
+    tagged = datetime(2026, 1, 1, tzinfo=UTC)
+    d = _make_tagged_album(cfg, "Grown", mbid="rel-grown", tagged_at=tagged)
+    write_track_totals(d, track_total=1)  # one file, and the file says 1 of 1
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=3)
+    )
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    aid = _id_for(cfg, d)
+
+    r = client.post(f"/retag/{aid}")
+    assert r.status_code == 200
+    assert "Re-tag failed" not in r.text
+    # Both counts, said in the flash rather than left to the panel.
+    payload = json.loads(r.headers["HX-Trigger"])["harmonist-status"]
+    assert payload["level"] == "warning"
+    assert "3 there, 1 here" in payload["details"]
+    # The way out is one click from where the problem appeared.
+    assert f'id="album-alert-{aid}"' in r.text
+    assert 'hx-swap-oob="true"' in r.text
+    assert f'hx-post="/retag/{aid}"' in r.text
+    assert "accept_short" in r.text
+    # Nothing was written: the guard still holds until the user says so.
+    after = sc.read(d)
+    assert after is not None and after.tagged_at == tagged
+
+
+def test_retag_as_incomplete_takes_the_grown_releases_tags(client, cfg, monkeypatch):
+    """The other half of #252: pressing the offered control re-runs the same
+    re-tag with the shortfall accepted. The files take the release's current
+    tags — including its higher total — so the album then derives INCOMPLETE
+    (design §13.3), which is the true thing to say about it."""
+    from harmonist import scanner
+    from harmonist.models import AlbumState
+    from test.helpers import write_track_totals
+
+    d = _make_tagged_album(cfg, "Grown", mbid="rel-grown", tagged_at=datetime.now(UTC))
+    write_track_totals(d, track_total=1)
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=3)
+    )
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+
+    r = client.post(f"/retag/{_id_for(cfg, d)}", data={"accept_short": "true"})
+    assert r.status_code == 200
+    assert "Re-tagged" in r.text
+    album = next(a for a in scanner.scan(cfg.paths.music_dir) if a.path == d)
+    assert album.state == AlbumState.INCOMPLETE
+    assert album.expected_track_count == 3
+    # ...and the entry says so, rather than leaving the new badge to be found.
+    assert "now listed as incomplete" in r.text
+
+    # Idempotent, and nothing had to be persisted to make it so: the decision
+    # lives in the totals the re-tag wrote, so the album now derives INCOMPLETE
+    # and a PLAIN re-tag (no `accept_short`) goes through on its own.
+    again = client.post(f"/retag/{_id_for(cfg, d)}")
+    assert "Re-tagged" in again.text
+    assert "Re-tag failed" not in again.text
+    still = next(a for a in scanner.scan(cfg.paths.music_dir) if a.path == d)
+    assert (still.state, still.expected_track_count) == (AlbumState.INCOMPLETE, 3)
+
+
+def test_retag_reports_extra_files_as_a_failure_with_no_way_out(client, cfg, monkeypatch):
+    """The mismatch #252 does NOT turn into a decision: more files on disk than
+    the release has tracks is out of scope for the tagger in both modes (§15.3),
+    so incomplete mode would not help and must not be offered."""
+    d = _make_tagged_album(cfg, "Extra", mbid="rel-extra", tagged_at=datetime.now(UTC))
+    shutil.copy(SINE_M4A, d / "02 Track.m4a")
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
+    )
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+
+    r = client.post(f"/retag/{_id_for(cfg, d)}")
     assert "Re-tag failed" in r.text
+    assert "accept_short" not in r.text
 
 
 def test_album_action_records_activity_against_that_album(client, cfg, monkeypatch):


### PR DESCRIPTION
**Re-tag from MB** decided the tagger's mode from the album's *derived state*, which since #195 answers "were the files short of what MusicBrainz said **when they were tagged**". The tagger's count guard asks a different question: are they short of what it says **now**. Those diverge on exactly the album a MusicBrainz correction has touched — the files agree among themselves that the album is complete, so `incomplete=False` goes to the tagger and the guard refuses against the new count. The button could not be made to work, and the only way out was to call a correct match wrong, re-pick the same release, and Confirm as incomplete.

So the refusal becomes a decision. `/retag` catches `TagMismatchError` and answers with the two counts plus a **Re-tag as incomplete** control, swapped out of band into the album page's alert slot; pressing it re-runs the same re-tag with `accept_short`.

- The guard keeps doing its job — nothing is tagged short until someone says so, and `incomplete = files < tracks` at the call site stays rejected for the reason #133 rejected it.
- **Extra files on disk are still an error.** Incomplete mode cannot help there (§15.3), so no way out is offered — `TagMismatchError` now carries both counts and which way round they are, rather than leaving the web layer to re-parse its own prose.
- The album then derives `INCOMPLETE` from the totals the re-tag wrote, which is the true thing to say about it, and **stays in the Library**. The issue asked whether that should be a choice rather than a side effect: it is already the design's answer (§13.3), and INCOMPLETE is a terminal Library state, so the change is to *name* it — the success message says "now listed as incomplete" instead of leaving the new badge to be found.
- The snapshot is refreshed in the same request, or the album page's own reload (`album-retagged`) races the rescan and re-renders the state the re-tag just replaced.

## Verification

Red-first on the web-route rung: both new `test_web.py` cases fail against `main` with the reported `TagMismatchError`. The extra-files control was written after the fix and mutation-checked (dropping the `e.short` guard turns it red).

The OOB swap and the `hx-vals` on the offered button are the two things pytest structurally cannot see, so `test/e2e/test_retag_short.py` drives them in a browser and asserts on the POST body. Both were mutation-checked — a typo'd alert id and a dropped `hx-vals` each turn them red. Demo seeds `The Wonders — Play!` for the state.

`make check` and `make e2e` green; exercised by hand in demo mode.

Fixes #252