### PR TITLE
Drop the Library's Refresh button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,10 @@ versions follow [semantic versioning](https://semver.org).
   heading is gone, since the tab directly above already names the Library and
   counts it — and "done" quietly disagreed with the Incomplete filter sitting
   underneath. The **Show N per page** control has moved down beside the pager,
-  where you reach for it after reading a page (#217).
+  where you reach for it after reading a page. The **Refresh** button is gone
+  too: it was the other half of that heading's row, and the grid has refreshed
+  itself for a while now — after every scan, every action, and every sync — so
+  the search box is now the top of the view (#217).
 
 ## [1.10.2] - 2026-08-22
 

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -12,11 +12,11 @@
 
 {# The query string naming one Library view: which page, at what size, under which
    filter, matching which search. ONE definition because the Library page renders
-   this string in seventeen places — the container's refresh wiring, the Refresh
-   button, the page-size form, every filter chip and both pager arrows (as an href
-   AND an hx-push-url each), and the tile links — and a parameter dropped from any
-   one of them is a control that silently throws away part of the view. That is not
-   hypothetical: the set has grown from `page` to `page + limit` to
+   this string in twenty places — the container's refresh wiring, the page-size
+   form, the search-widening link, every filter chip and both pager arrows (as an
+   href AND an hx-push-url each), and the tile links — and a parameter dropped from
+   any one of them is a control that silently throws away part of the view. That is
+   not hypothetical: the set has grown from `page` to `page + limit` to
    `page + limit + filter` to this in four issues (#139, #144, #174, #180).
 
    Because Jinja renders a missing argument as an empty Undefined rather than

--- a/templates/partials/library_page.html
+++ b/templates/partials/library_page.html
@@ -21,21 +21,24 @@
    it to tell an in-place swap from a page load. It used to hang off a `LIBRARY ·
    N done` heading here, which repeated the tab label and count directly above it
    and called every terminal album "done" while the chips below offered to filter
-   the Incomplete ones — so the heading went and the dataset stayed (#217). #}
+   the Incomplete ones — so the heading went and the dataset stayed (#217).
+
+   A **Refresh** button used to sit opposite that heading, and it went with it —
+   it was the other half of a header row, and alone it left the near-empty row
+   removing the heading was meant to remove (#217 again). It had also outlived
+   its job: it dates from the first Library commit, when the grid refreshed only
+   when asked, and the wiring on this element now does that on its own. A
+   completed scan fires `tasks-changed` off the runner's `seq` counter — keyed on
+   the counter precisely so a 0.1s cache-warm rescan between two 1.5s polls is
+   still caught — as does every action, and a sync or reconcile finishing fires
+   `library-refresh`. The grid is derived from the scanner's snapshot and nothing
+   else, so there was nothing left for a press to fetch. #}
 {% from 'macros.html' import library_query %}
 <div id="library-page" data-total-done="{{ total_done }}" data-page="{{ page }}"
      data-limit="{{ limit }}"
      hx-get="/library?{{ library_query(page, limit, filter, q) }}"
      hx-trigger="library-refresh from:body, tasks-changed from:body"
      hx-target="#library-rows" hx-swap="innerHTML">
-<div class="mb-3 flex justify-end">
-    <button hx-get="/library?{{ library_query(page, limit, filter, q) }}"
-            hx-target="#library-rows" hx-swap="innerHTML"
-            class="text-xs text-muted hover:text-accent transition uppercase tracking-widest font-bold">
-        Refresh
-    </button>
-</div>
-
 {# Search (#180). The filters below find albums that are *wrong*; this finds the
    album you have in mind, which at library scale is the more common errand and
    the one paging cannot help with.

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -4051,7 +4051,9 @@ def test_library_pager_links_do_not_inherit_a_competing_page_value(client, cfg):
     assert "hx-vals" not in fragment
     # Each render re-requests the page it is showing, at the size it is showing,
     # so a refresh mid-browse (every `tasks-changed`) can't yank the user back to
-    # the newest page or resize the one they're on.
+    # the newest page or resize the one they're on. Since #217 this wiring is the
+    # WHOLE of the Library's refreshing — the manual button it used to sit beside
+    # is gone — so losing it would leave the grid stale with nothing to press.
     assert 'hx-get="/library?page=2&limit=2"' in fragment
     assert "tasks-changed from:body" in fragment
 


### PR DESCRIPTION
Removing the `LIBRARY · N done` heading left **Refresh** alone in a right-aligned row of its own — it had been the other half of that header row, so the near-empty line #217 set out to remove is still there, only its contents changed.

It can simply go, because it has outlived its job. The button dates from the first Library commit (f359981), when the grid refreshed only when asked. The container's own wiring now does that:

```
hx-trigger="library-refresh from:body, tasks-changed from:body"
```

- `tasks-changed` on every **completed scan**, keyed on the scan runner's `seq` counter rather than a state edge — precisely so a cache-warm 0.1s rescan between two 1.5s polls is still caught (7ab4756);
- `tasks-changed` from every action's `HX-Trigger`;
- `library-refresh` on the running→idle edge of a sync and of a reconcile.

The grid is derived from the scanner's snapshot and nothing else, so a press re-requested the page you were on and got back what was already on screen.

The search box becomes the top of the Library, which is what #217 wanted. Nothing else moves: the container's `hx-get` and `hx-trigger` are untouched.

## Verification

No test is added. The live path here is the container's auto-refresh wiring, and `test_library_pager_links_do_not_inherit_a_competing_page_value` already asserts it present — its docstring now says why that assertion carries more weight (it is the whole of the Library's refreshing now). An assertion that the button's label is *absent* would be the kind that can never fail for a good reason, so there isn't one.

`make check` and `make e2e` green — including the two browser tests that drive this template (page size, search). Checked by hand in demo mode: the Library opens tabs → search → filter chips → grid, with no spare row.

Fixes #217