### PR TITLE
Let a mirrored log line say which album it is about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- When Harmonist keeps your existing per-track artwork instead of embedding the
+  album cover, that now appears in the album's own **History** (#260) — it was
+  only ever said in the global Activity feed, attributed to no album.
+- A failed re-tag, tag, reconcile, undo or manual assignment no longer writes a
+  second, blank entry to the Activity feed beneath the real one (#258).
+
 ## [1.11.0] - 2026-08-24
 
 ### Added

--- a/src/harmonist/activity.py
+++ b/src/harmonist/activity.py
@@ -120,6 +120,31 @@ def clear() -> None:
     activity_store.clear()
 
 
+def _album_ref(rec: logging.LogRecord) -> tuple[str | None, str | None]:
+    """The album a log record names via `extra=`, or `(None, None)`.
+
+    A call site that knows which album it is talking about says so —
+    `log.warning(..., extra={"album_id": ..., "album_label": ...})` — and the
+    mirrored entry then joins that album's history instead of floating in the
+    global feed attributed to nothing (#260). The mirror used to call
+    `record(msg, level)` and nothing else, so *every* mirrored line landed with
+    a NULL album and `album_history`, which selects by id, could never find it.
+
+    Opt-in on purpose: most WARNING+ records genuinely aren't about one album,
+    and they go on mirroring unattributed exactly as before.
+
+    Type-checked rather than trusted, because `extra` is an arbitrary dict — a
+    caller passing a `Path` or an `Album` here would otherwise put a non-string
+    into a TEXT column and break the reader, far from the call site that did it.
+    """
+    album_id = getattr(rec, "album_id", None)
+    album_label = getattr(rec, "album_label", None)
+    return (
+        album_id if isinstance(album_id, str) else None,
+        album_label if isinstance(album_label, str) else None,
+    )
+
+
 class _ActivityLogHandler(logging.Handler):
     """Mirror harmonist log records (WARNING+) into the activity feed so
     background failures (sync errors, skipped albums, …) are visible."""
@@ -132,7 +157,8 @@ class _ActivityLogHandler(logging.Handler):
         except Exception:
             return
         level = Level.ERROR if rec.levelno >= logging.ERROR else Level.WARNING
-        record(msg, level)
+        album_id, album_label = _album_ref(rec)
+        record(msg, level, album_id=album_id, album_label=album_label)
 
 
 _handler_installed = False

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -222,16 +222,30 @@ def tag_album(
     # rather than relying on the `and` below, which used to short-circuit this
     # read and stopped doing so when the digests were hoisted out.
     art_before = _art_digests(files) if cover is not None else {}
+    # Read before the artwork guard as well as before the loop: the guard's
+    # warning names the album it is about, and this is where that name comes
+    # from. Tagging can still move the id afterwards (temp_uid -> MBID), which is
+    # why `album_history` unions an album's alias chain — the same reason the
+    # `tag.album` line below gets away with the pre-write id.
+    album_id = sidecar_mod.album_id_for(album_dir)
     # DATA SAFETY: if the tracks carry DIFFERENT embedded art (a per-track-art
     # album, e.g. a compilation), embedding one album cover would destroy those
     # images. Preserve them — pass cover=None (write_tags leaves the existing
     # embedded cover untouched); the folder cover.* is still written separately.
     if cover is not None and not overwrite_art and _has_per_track_art(art_before):
+        # Attributed to the album (#260). This is a decision Harmonist made on
+        # the user's behalf about their files, so it has to reach that album's
+        # own History — and the feed's log mirror drops any record that doesn't
+        # say which album it means. The `art=preserved` token on the `tag.album`
+        # line below is not a substitute: it shows only under "Show details".
+        #
+        # The album's name is NOT repeated into the message; it rides in its own
+        # column, which is where the feed and the History both render it.
         log.warning(
-            "%s: tracks have per-track embedded artwork — keeping it, NOT embedding "
+            "tracks have per-track embedded artwork — keeping it, NOT embedding "
             "the album cover (folder cover.* is still written). Re-tag with "
             "'replace artwork' to override.",
-            album_dir.name,
+            extra={"album_id": album_id, "album_label": _album_label(release, album_dir)},
         )
         cover = None
     media_total = len(release.get("medium-list", [])) or 1
@@ -240,7 +254,6 @@ def tag_album(
     # audit log — it was the one core mutation with no record at all. The album
     # line is written BEFORE the loop so a crash part-way leaves evidence of what
     # was attempted, not silence.
-    album_id = sidecar_mod.album_id_for(album_dir)
     audit.record(
         "tag.album",
         album_id=album_id,
@@ -857,6 +870,20 @@ def _artist_ids(artist_credit: list[Any] | None) -> list[str]:
             if artist_id := artist.get("id"):
                 ids.append(artist_id)
     return ids
+
+
+def _album_label(release: dict[str, Any], album_dir: Path) -> str:
+    """The album's display name for an activity entry — "Artist — Title".
+
+    Taken from the release being tagged rather than the sidecar, because that is
+    what the files are about to say, and it is the same name the album will be
+    listed under once this tagging lands. Falls back to the folder name when the
+    release names neither, so an entry is never labelled with an empty string —
+    the feed hides the album column entirely when the label is blank, which would
+    lose the attribution this exists to add.
+    """
+    label = f"{_artist_phrase(release.get('artist-credit'))} — {release.get('title') or ''}"
+    return label.strip(" —") or album_dir.name
 
 
 def _artist_phrase(artist_credit: list[Any] | None) -> str:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -98,6 +98,18 @@ def _extract_mbid(value: str) -> str | None:
 
 log = logging.getLogger(__name__)
 
+# For a `log.exception` that sits beside a `_flash_response(..., album=...)`: the
+# traceback belongs in the SERVER log, not in the feed. `_flash_response` has
+# already recorded the failure as a user-facing entry, attributed to the album
+# and carrying the reason — so without this flag the feed's WARNING+ mirror
+# (activity._ActivityLogHandler) adds a second ERROR row saying "tag failed" and
+# nothing else, under no album at all. One failure, one entry (#258).
+#
+# Only for the paired sites. A `log.exception` with no flash beside it — the
+# background passes, the ignores-file writes — is the ONLY notice the user gets
+# and must go on mirroring.
+_LOG_ONLY = {"_activity": True}
+
 
 HARMONY_BASE = "https://harmony.pulsewidth.org.uk"
 
@@ -3657,7 +3669,7 @@ def _register_routes(app: FastAPI) -> None:
                 # More files than the release has tracks. Out of scope for the
                 # tagger in *both* modes (§15.3), so there is no decision to
                 # offer — it stays an error, as it was.
-                log.exception("retag failed")
+                log.exception("retag failed", extra=_LOG_ONLY)
                 return _flash_response(
                     "Re-tag failed", str(e), level=Level.ERROR, tasks_changed=False, album=album
                 )
@@ -3676,7 +3688,7 @@ def _register_routes(app: FastAPI) -> None:
                 ),
             )
         except Exception as e:
-            log.exception("retag failed")
+            log.exception("retag failed", extra=_LOG_ONLY)
             return _flash_response(
                 "Re-tag failed", str(e), level=Level.ERROR, tasks_changed=False, album=album
             )
@@ -3744,7 +3756,7 @@ def _register_routes(app: FastAPI) -> None:
                 "Couldn't undo", str(e), level=Level.ERROR, tasks_changed=False, album=album
             )
         except Exception as e:
-            log.exception("artwork restore failed")
+            log.exception("artwork restore failed", extra=_LOG_ONLY)
             return _flash_response(
                 "Couldn't undo", str(e), level=Level.ERROR, tasks_changed=False, album=album
             )
@@ -3794,7 +3806,7 @@ def _register_routes(app: FastAPI) -> None:
                 "Couldn't undo", str(e), level=Level.ERROR, tasks_changed=False, album=album
             )
         except Exception as e:
-            log.exception("tag revert failed")
+            log.exception("tag revert failed", extra=_LOG_ONLY)
             return _flash_response(
                 "Couldn't undo", str(e), level=Level.ERROR, tasks_changed=False, album=album
             )
@@ -4067,7 +4079,7 @@ def _register_routes(app: FastAPI) -> None:
         try:
             sc = reconcile.reconcile_album(album.path, fetch_urls=mb_lookup.fetch_release_urls)
         except Exception as e:
-            log.exception("reconcile failed")
+            log.exception("reconcile failed", extra=_LOG_ONLY)
             return _flash_response(
                 "Reconcile failed",
                 str(e),
@@ -4173,7 +4185,7 @@ def _register_routes(app: FastAPI) -> None:
                 )
                 return _flash_response("Tagged", "match found via Recheck", album=album)
             except Exception as e:
-                log.exception("tag after recheck failed")
+                log.exception("tag after recheck failed", extra=_LOG_ONLY)
                 return _flash_response(
                     "Tagging failed",
                     str(e),
@@ -4205,7 +4217,7 @@ def _register_routes(app: FastAPI) -> None:
                 paths=album.folders,
             )
         except Exception as e:
-            log.exception("tag failed")
+            log.exception("tag failed", extra=_LOG_ONLY)
             return _flash_response(
                 "Tagging failed", str(e), level=Level.ERROR, tasks_changed=False, album=album
             )
@@ -4233,7 +4245,7 @@ def _register_routes(app: FastAPI) -> None:
                 paths=album.folders,
             )
         except Exception as e:
-            log.exception("incomplete tag failed")
+            log.exception("incomplete tag failed", extra=_LOG_ONLY)
             return _flash_response(
                 "Tagging failed", str(e), level=Level.ERROR, tasks_changed=False, album=album
             )
@@ -4443,7 +4455,7 @@ def _register_routes(app: FastAPI) -> None:
                 album=album,
             )
         except Exception as e:
-            log.exception("manual assign failed")
+            log.exception("manual assign failed", extra=_LOG_ONLY)
             return _flash_response(
                 "Assignment failed",
                 str(e),

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 
 import pytest
@@ -863,3 +864,34 @@ def test_append_failure_does_not_re_enter_the_feed_mirror(broken_store, caplog):
     failures = [r for r in caplog.records if r.levelname == "ERROR"]
     assert len(failures) == 1
     assert getattr(failures[0], "_activity", False) is True
+
+
+def test_mirrored_log_record_carries_the_album_it_names(caplog):
+    """#260: a WARNING mirrored into the feed reaches the album's history when
+    the call site says which album it is about.
+
+    Without this the mirror called `record(msg, level)` and nothing else, so
+    every mirrored line landed with `album_id=None` — present in the global feed,
+    invisible to `album_history`, which selects by id.
+    """
+    activity.install_log_handler()
+    logging.getLogger("harmonist.tagger").warning(
+        "kept the existing per-track artwork",
+        extra={"album_id": "rel-260", "album_label": "Some Artist — Some Album"},
+    )
+
+    history = activity_store.album_history("rel-260")
+    assert [e.message for e in history] == ["kept the existing per-track artwork"]
+    assert history[0].level == "warning"
+    # The label rides along so the feed can render (and link) the album's name.
+    assert history[0].album_label == "Some Artist — Some Album"
+
+
+def test_mirrored_log_record_without_an_album_still_reaches_the_feed():
+    """The opt-in must not become a requirement: the overwhelming majority of
+    WARNING+ records name no album, and they go on mirroring unattributed."""
+    activity.install_log_handler()
+    logging.getLogger("harmonist.sync").warning("sync could not reach Bandcamp")
+
+    entry = next(e for e in activity.recent() if "reach Bandcamp" in e.message)
+    assert (entry.album_id, entry.album_label) == (None, None)

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -629,6 +629,43 @@ def test_tag_album_preserves_per_track_artwork(album_with_tracks, tmp_path):
     assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == art_b  # preserved
 
 
+def test_preserved_per_track_artwork_reaches_the_album_history(album_with_tracks, tmp_path):
+    """#260: declining to overwrite the user's artwork is a decision Harmonist
+    made about their files, so it belongs in that album's own History — not only
+    in the global feed as an unattributed mirrored warning.
+
+    The `art=preserved` token on the `tag.album` audit line is not this: it shows
+    only with "Show details" ticked, as one token among a dozen. This is the
+    sentence that says it.
+    """
+    from datetime import UTC, datetime
+
+    from harmonist import activity, activity_store
+    from harmonist import sidecar as sidecar_mod
+    from harmonist.models import Sidecar
+
+    activity_store.init(tmp_path / "activity.db")
+    activity.install_log_handler()
+    album_dir = album_with_tracks(2)
+    sidecar_mod.write(
+        album_dir, Sidecar(mb_release_id="rel-aaa", tagged_at=datetime(2026, 1, 1, tzinfo=UTC))
+    )
+    _embed_cover(album_dir / "01 Track 1.m4a", _minimal_jpeg())
+    _embed_cover(album_dir / "02 Track 2.m4a", _minimal_jpeg() + b"_different")
+    new_cover = tmp_path / "cover.jpg"
+    new_cover.write_bytes(b"\xff\xd8\xff\xe0NEW_ALBUM_COVER\xff\xd9")
+
+    tagger.tag_album(album_dir, _release_2_tracks(), cover_path=new_cover)
+
+    entry = next(
+        e
+        for e in activity_store.album_history("rel-aaa")
+        if "per-track embedded artwork" in e.message
+    )
+    assert entry.level == "warning"
+    assert entry.album_label == "Test Artist — Test Album"
+
+
 def test_tag_album_overwrite_art_forces_replacement(album_with_tracks, tmp_path):
     """overwrite_art=True is the explicit override: embed the album cover even over
     differing per-track art."""

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -4305,6 +4305,37 @@ def test_retag_emits_album_retagged_trigger(client, cfg, monkeypatch):
     assert "album-retagged" in r.headers.get("HX-Trigger", "")
 
 
+def test_a_failed_action_reaches_the_feed_once_and_names_its_album(
+    client, cfg, monkeypatch, caplog
+):
+    """#258: a failure produces ONE feed entry, and it is the one that says which
+    album failed and why.
+
+    The `log.exception` beside each of these `_flash_response(..., album=...)`
+    calls is there for the server log's traceback. It mirrored into the feed too
+    (activity._ActivityLogHandler), so every failed action wrote a SECOND error
+    row — "retag failed", no album, no detail — beneath the real one. Two rows
+    for one failure, the useless copy last, and only the useless copy reached
+    nobody's album history.
+    """
+    caplog.set_level("ERROR")
+    d = _make_tagged_album(cfg, "FailRetag", mbid="rel-1", tagged_at=datetime.now(UTC), item_id=1)
+
+    def boom(mbid):
+        raise RuntimeError("mb down")
+
+    monkeypatch.setattr("harmonist.mb_lookup.fetch_release", boom)
+    album_id = _id_for(cfg, d)
+    assert "Re-tag failed" in client.post(f"/retag/{album_id}").text
+
+    errors = [e for e in activity.recent() if e.level == "error"]
+    assert [e.message for e in errors] == ["Re-tag failed — mb down"]
+    assert errors[0].album_id == album_id
+    # The traceback still reaches the server log — suppressing the MIRROR must
+    # not suppress the thing you actually want three weeks later.
+    assert any(r.exc_info for r in caplog.records if r.name == "harmonist.web.main")
+
+
 def test_retag_failure_does_not_emit_refresh_trigger(client, cfg, monkeypatch):
     """A failed re-tag must not fire album-retagged (nothing changed to refresh)."""
     d = _make_tagged_album(cfg, "FailRetag", mbid="rel-1", tagged_at=datetime.now(UTC), item_id=1)


### PR DESCRIPTION
Two issues, one cause.

Every WARNING+ record on the `harmonist` logger is mirrored into the Activity feed. The mirror called `record(msg, level)` and nothing else, so the entry landed with a NULL `album_id` — and `album_history`, which selects by id, could never find it. The album's own History was missing statements that were about that album and nothing else.

## #260 — the artwork decision

Declining to overwrite a compilation's per-track embedded artwork is a decision Harmonist makes about the user's files, and it was said only in the global feed, attributed to no album. The album's History carried the fact only as the `art=preserved` token on the `tag.album` audit line — visible with **Show details** ticked, as one monospace token among a dozen. The user-facing sentence existed and was in the wrong place.

`tagger.py` now names the album on that warning, so the sentence reaches the History. The album's name came *out* of the message and into its own column: for a single-folder album the old prefix rendered as "Test Artist — Test Album · Test Album: tracks have…".

## #258 — the premise was wrong, and the residue is a duplicate

Filed as "a failed re-tag leaves no trace in the album's history". It does leave one: `_flash_response(..., album=album)` records an attributed ERROR entry, so the History already showed `Re-tag failed — mb down` against the album. The partial-write case is covered too — `tag.album` is written before the write loop, so a crash part-way leaves evidence of what was attempted. Detail in a comment on the issue.

What is actually wrong is the opposite: a **duplicate**. The `log.exception` beside each of those flashes mirrored into the feed as a second ERROR row — "retag failed", no album, no detail — sitting under the real one. Two rows for one failure, the useless copy last.

The nine `log.exception` sites paired with an attributed `_flash_response` now log without mirroring; the traceback still reaches the server log. The unpaired ones — background passes, ignores-file writes, where the mirror is the user's only notice — are untouched.

## The mechanism

`activity._album_ref()` reads `album_id` / `album_label` off the record's `extra`, type-checked rather than trusted since `extra` is an arbitrary dict — a `Path` or an `Album` in there would otherwise put a non-string into a TEXT column, far from the call site that did it. Opt-in: most WARNING+ records genuinely aren't about one album and go on mirroring unattributed.

## Tests

Three, all written red-first and each failed on its own assertion before the fix: empty `album_history`, `StopIteration` on the artwork sentence, and `['Re-tag failed — mb down', 'retag failed'] != ['Re-tag failed — mb down']`. `make check` green locally — 1306 passed, ruff + format + mypy clean. No templates touched, so no CSS rebuild.

## One judgment call worth flagging

The artwork line now lands in the History on *every* re-tag of a per-track-art album, since the decision recurs rather than changing anything. That is right today — the user pressed Re-tag, and this is what happened — and `tag.album` already accumulates a row per run in the same history. Under the metadata gardener (#32) a nightly auto-re-tag would stack one loud entry per night on those albums; the lever then is recording it only when the run actually wrote something.

Fixes #260
Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016emoJJZvLEb5dw83voQcEW