### PR TITLE
Stop twelve sidecar rewrites from erasing the user's decisions

### DIFF
--- a/.claude/skills/sidecar/SKILL.md
+++ b/.claude/skills/sidecar/SKILL.md
@@ -148,7 +148,7 @@ changed behind the user's back, would they need to be able to reconstruct what
 it was? If yes, it is audited. See the `event-recording` skill for the traps
 around getting the record itself right.
 
-## 6. Never hand-roll the write
+## 6. Never hand-roll the write — or the rebuild
 
 `sidecar.write()` is the only writer, and it does five things besides
 serialising JSON:
@@ -169,6 +169,42 @@ need to change one field, read, `dataclasses.replace`, write.
 old on a large library; writing it back clobbers anything that landed in
 between. `reconcile.backfill_track_count` re-reads and re-checks its
 precondition for exactly this reason.
+
+### Rebuild with `replace`, never by naming the fields to keep
+
+`sidecar.write()` being the only writer is not enough on its own, because it
+writes whatever it is handed. The other half of the rule is how you build that
+object:
+
+```python
+new = replace(sc, mb_release_id=None, mb_match_candidate=candidate)   # yes
+new = Sidecar(store_url=sc.store_url, mb_release_id=None, ...)        # no
+```
+
+A fresh `Sidecar(...)` listing what to carry forward silently resets **every
+field you didn't name** to its default. That is not a hypothetical: #239 found
+it in `_tag_with_release` and fixed that one site; #263 found the same
+construction at **twelve** more, all of them dropping `video_media` and
+`tracks_unavailable`, eleven dropping `purchase_unavailable`. The surrenders are
+the worst case — they are decisions with no evidence on disk, so once defaulted
+they cannot be recovered by anything, and the album re-surrenders or re-accuses
+itself of missing tracks on the next pass.
+
+`replace()` carries unnamed fields **by construction**, so a field added to the
+model tomorrow needs no edit at any call site and cannot be dropped. That
+property is what makes rule 3's "add a field" safe at all.
+
+`test_sidecar_carries.py` enforces this by parsing `src/` for `Sidecar(...)`
+constructions that mention an existing sidecar. If your new code trips it, use
+`replace`; do not add yourself to the exemption set.
+
+**The one exemption is `scanner._merge_sidecars`,** which builds an album's view
+of its folders' sidecars (#197) and genuinely needs a rule per field — first /
+earliest / latest / any — which `replace()` off some arbitrary part cannot
+express. It pays for that by being held **total**: a second test asserts it names
+every field on the model, including the ones it deliberately drops (`temp_uid`).
+**Adding a field to `models.Sidecar` means adding a merge rule there**, and that
+test will tell you so.
 
 ## 7. `delete_all` is the escape hatch, and it is the user's to pull
 
@@ -191,6 +227,8 @@ Before committing a sidecar content change:
 - [ ] New field has a reader and a visible affordance (rule 3)
 - [ ] `_to_dict` omits the default (rule 3)
 - [ ] `_audit_sidecar_change`'s load-bearing list considered explicitly (rule 5)
+- [ ] Every rewrite uses `replace`, not a fresh `Sidecar(...)` (rule 6)
+- [ ] `scanner._merge_sidecars` gives the new field a merge rule (rule 6)
 - [ ] `docs/design.md` §4 updated — schema block *and* prose
 - [ ] Round-trip test: write → read → identical `Sidecar`
 - [ ] Old-sidecar test: a dict without the new key loads at the default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Decisions you record about an album — **Keep in Library** for a purchase that
+  no longer exists, and accepting an incomplete album as finished — are no
+  longer erased by ordinary operations like a sync, a recheck, or rejecting a
+  suggestion (#263). Albums that lost one would re-surrender, or start reporting
+  missing tracks again, the next time Harmonist looked at them.
+- An album whose folders are split across directories no longer forgets that its
+  absent disc was video (#263), so it stays **Complete** instead of reporting the
+  DVD you never ripped as missing tracks.
 - When Harmonist keeps your existing per-track artwork instead of embedding the
   album cover, that now appears in the album's own **History** (#260) — it was
   only ever said in the global Activity feed, attributed to no album.

--- a/src/harmonist/bandcamp_hook.py
+++ b/src/harmonist/bandcamp_hook.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -179,18 +180,16 @@ def write_sidecar_for_item(item: Any, album_dir: Path, *, prefer_item_url: bool 
             else (existing.bandcamp.band_id if existing.bandcamp else None),
             is_private=is_private,
         )
-        merged = Sidecar(
-            schema_version=existing.schema_version,
+        # `replace`, not a fresh `Sidecar(...)` — anything not named here carries
+        # through BY CONSTRUCTION (#263). Naming the fields to keep dropped the
+        # two surrenders and `video_media` on every linked purchase.
+        merged = replace(
+            existing,
             # Keep the existing canonical URL, unless a slug match told us to
             # adopt the item's (purchase-authoritative) URL instead.
             store_url=url if prefer_item_url else (existing.store_url or url),
             bandcamp=merged_bandcamp,
             downloaded_at=existing.downloaded_at or datetime.now(UTC),
-            added_at=existing.added_at,
-            mb_release_id=existing.mb_release_id,
-            mb_match_candidate=existing.mb_match_candidate,
-            tagged_at=existing.tagged_at,
-            notes=existing.notes,
         )
         sidecar_mod.write(album_dir, merged)
         return True
@@ -222,17 +221,8 @@ def write_ambiguous_candidates(album_dir: Path, item_ids: list[int]) -> bool:
         is_private=bc.is_private if bc else False,
         candidate_item_ids=sorted({int(i) for i in item_ids}),
     )
-    merged = Sidecar(
-        schema_version=existing.schema_version,
-        store_url=existing.store_url,
-        bandcamp=merged_bc,
-        downloaded_at=existing.downloaded_at,
-        added_at=existing.added_at,
-        mb_release_id=existing.mb_release_id,
-        mb_match_candidate=existing.mb_match_candidate,
-        tagged_at=existing.tagged_at,
-        notes=existing.notes,
-    )
+    # `replace`, not a fresh `Sidecar(...)` — see the note in `write_sidecar` (#263).
+    merged = replace(existing, bandcamp=merged_bc)
     sidecar_mod.write(album_dir, merged)
     return True
 

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -360,6 +360,14 @@ def _merge_sidecars(sidecars: list[Sidecar | None], mbid: str) -> Sidecar:
     about a folder: it has existed since the first of its parts did, it was last
     tagged when the last of them was, and a decision recorded on any part (a
     surrender, an accepted incompleteness) was made about the album.
+
+    **Every field is named, and that is enforced** (#263). A merge needs a rule
+    per field — first / earliest / latest / any — so unlike the rest of the
+    codebase this cannot be a `replace()` off some arbitrary part. The price is
+    that a field added to the model and forgotten here would be reset to its
+    default on every multi-folder album, silently, which is exactly what happened
+    to `video_media` and the two surrender flags. `test_sidecar_carries` holds
+    this call total so the next field cannot repeat it.
     """
     present = [s for s in sidecars if s is not None]
     return Sidecar(
@@ -368,10 +376,27 @@ def _merge_sidecars(sidecars: list[Sidecar | None], mbid: str) -> Sidecar:
         downloaded_at=min((s.downloaded_at for s in present if s.downloaded_at), default=None),
         added_at=min((s.added_at for s in present if s.added_at), default=None),
         mb_release_id=mbid,
+        # Dropped deliberately, and named so rather than omitted: exactly one of
+        # `(mb_release_id, temp_uid)` is non-null on a persisted sidecar (§4),
+        # and the line above just set the MBID — a merged album is grouped BY its
+        # release, so it always has one and can never still be wearing a temp id.
+        temp_uid=None,
+        # A suggestion recorded against any part is a suggestion about the album,
+        # by the same reasoning as the surrenders below. It cannot change the
+        # merged album's STATE — `mb_release_id` is set from the tags just above,
+        # so this view never derives NEEDS_MBID — it only lets the card render
+        # the suggestion instead of pretending no one made it.
+        mb_match_candidate=next(
+            (s.mb_match_candidate for s in present if s.mb_match_candidate), None
+        ),
         tagged_at=max((s.tagged_at for s in present if s.tagged_at), default=None),
         notes=next((s.notes for s in present if s.notes), None),
         purchase_unavailable=any(s.purchase_unavailable for s in present),
         tracks_unavailable=any(s.tracks_unavailable for s in present),
+        # "Not asked" is None and "asked, none are video" is `()`, so the first
+        # part that ASKED wins — `any`/`or` would collapse those two into each
+        # other and re-ask MusicBrainz forever on a release with no video (#206).
+        video_media=next((s.video_media for s in present if s.video_media is not None), None),
     )
 
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1398,19 +1398,14 @@ def _demote_to_needs_mbid(
     clear the wrong MBID but KEEP the store_url, and pre-load the correct
     release as `mb_match_candidate` — the NEEDS_MBID card then shows the
     side-by-side and a one-click Confirm."""
+    # `replace`, not a fresh `Sidecar(...)` (#263). The surrenders are claims
+    # about the SOURCE — no purchase exists, no more tracks exist — so a demote
+    # over the release identity leaves them as true as it found them. Stale
+    # `video_media` rides along harmlessly: nothing reads it while the album has
+    # no MBID, and `_tag_with_release` recomputes it from the release it uses.
     sidecar_mod.write(
         album_path,
-        Sidecar(
-            schema_version=sc.schema_version,
-            store_url=sc.store_url,
-            bandcamp=sc.bandcamp,
-            downloaded_at=sc.downloaded_at,
-            added_at=sc.added_at,
-            mb_release_id=None,
-            mb_match_candidate=candidate,
-            tagged_at=None,
-            notes=sc.notes,
-        ),
+        replace(sc, mb_release_id=None, mb_match_candidate=candidate, tagged_at=None),
     )
     # Surrender / mis-tag demote: the album was an unlinked NEEDS_SYNC, now back
     # to NEEDS_MBID. Keep the live counts moving between scans.
@@ -1420,22 +1415,20 @@ def _demote_to_needs_mbid(
 def _link_album_to_purchase(album_path: Path, sc: Sidecar, *, item_id: int, store_url: str) -> None:
     """Fill in the Bandcamp item_id on an already-tagged album's sidecar (Needs
     Sync → Library), adopting the matched purchase URL as the store_url."""
+    # `replace`, not a fresh `Sidecar(...)` (#263).
     sidecar_mod.write(
         album_path,
-        Sidecar(
-            schema_version=sc.schema_version,
+        replace(
+            sc,
             store_url=store_url,
             bandcamp=BandcampInfo(
                 item_id=item_id,
                 band_id=sc.bandcamp.band_id if sc.bandcamp else None,
                 is_private=sc.bandcamp.is_private if sc.bandcamp else False,
             ),
-            downloaded_at=sc.downloaded_at,
-            added_at=sc.added_at,
-            mb_release_id=sc.mb_release_id,
-            mb_match_candidate=sc.mb_match_candidate,
-            tagged_at=sc.tagged_at,
-            notes=sc.notes,
+            # Cleared deliberately — see `_link_pending_to_album`. A linked
+            # purchase falsifies "there is no purchase to link, ever".
+            purchase_unavailable=False,
         ),
     )
     # NEEDS_SYNC → Library (COMPLETE proxy; the scan reset splits the library
@@ -2410,20 +2403,23 @@ def _link_pending_to_album(album: Album, p: pending_downloads.PendingPurchase) -
     resolved_mbid = cand.mb_release_id if (surrendered and cand is not None) else sc.mb_release_id
     sidecar_mod.write(
         album.path,
-        Sidecar(
-            schema_version=sc.schema_version,
+        # `replace`, not a fresh `Sidecar(...)` (#263).
+        replace(
+            sc,
             store_url=p.url,
             bandcamp=BandcampInfo(
                 item_id=p.item_id,
                 band_id=sc.bandcamp.band_id if sc.bandcamp else None,
                 is_private=sc.bandcamp.is_private if sc.bandcamp else False,
             ),
-            downloaded_at=sc.downloaded_at,
-            added_at=sc.added_at,
             mb_release_id=resolved_mbid,
             mb_match_candidate=None if surrendered else sc.mb_match_candidate,
-            tagged_at=sc.tagged_at,
-            notes=sc.notes,
+            # Cleared DELIBERATELY, not carried (#263). `purchase_unavailable`
+            # is the claim "there is no purchase to link, ever" — and a purchase
+            # is being linked on this very line, so the claim is now false. This
+            # is the one place the flag is falsified by evidence rather than by
+            # the user changing their mind.
+            purchase_unavailable=False,
         ),
     )
     # If it's now tagged, it leaves the inbox for the Library — move counts from
@@ -2547,15 +2543,13 @@ def _apply_best_match(
         return "tagged", "Match exact — files tagged."
 
     existing = sidecar_mod.read(album_path)
-    new = Sidecar(
-        store_url=existing.store_url if existing else None,
-        bandcamp=existing.bandcamp if existing else None,
-        downloaded_at=existing.downloaded_at if existing else None,
+    # `replace` off whatever is there (#263) — a recheck that lands a suggestion
+    # must not also silently undo a surrender the user recorded.
+    new = replace(
+        existing or Sidecar(),
         added_at=(existing.added_at if existing else None) or datetime.now(UTC),
         mb_release_id=None,
         mb_match_candidate=candidate,
-        tagged_at=existing.tagged_at if existing else None,
-        notes=existing.notes if existing else None,
     )
     sidecar_mod.write(album_path, new)
     return (
@@ -4161,16 +4155,11 @@ def _register_routes(app: FastAPI) -> None:
         assert candidate is not None  # releases is non-empty (mbids guarded)
         mbid = candidate.mb_release_id
 
-        new_sc = Sidecar(
-            schema_version=sc.schema_version,
-            store_url=sc.store_url,
-            bandcamp=sc.bandcamp,
-            downloaded_at=sc.downloaded_at,
-            added_at=sc.added_at,
+        # `replace`, not a fresh `Sidecar(...)` (#263).
+        new_sc = replace(
+            sc,
             mb_release_id=mbid if candidate.confidence == "exact" else None,
             mb_match_candidate=None if candidate.confidence == "exact" else candidate,
-            tagged_at=sc.tagged_at,
-            notes=sc.notes,
         )
         sidecar_mod.write(album.path, new_sc)
 
@@ -4257,17 +4246,8 @@ def _register_routes(app: FastAPI) -> None:
         sc = album.sidecar
         if sc is None or sc.mb_match_candidate is None:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "no candidate to reject")
-        new_sc = Sidecar(
-            schema_version=sc.schema_version,
-            store_url=sc.store_url,
-            bandcamp=sc.bandcamp,
-            downloaded_at=sc.downloaded_at,
-            added_at=sc.added_at,
-            mb_release_id=None,
-            mb_match_candidate=None,
-            tagged_at=sc.tagged_at,
-            notes=sc.notes,
-        )
+        # `replace`, not a fresh `Sidecar(...)` (#263).
+        new_sc = replace(sc, mb_release_id=None, mb_match_candidate=None)
         sidecar_mod.write(album.path, new_sc)
         return _flash_response("Match rejected", album=album)
 
@@ -4340,16 +4320,14 @@ def _register_routes(app: FastAPI) -> None:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "not a surrendered album")
         sidecar_mod.write(
             album.path,
-            Sidecar(
-                schema_version=sc.schema_version,
-                store_url=sc.store_url,
-                bandcamp=sc.bandcamp,
-                downloaded_at=sc.downloaded_at,
-                added_at=sc.added_at,
+            # `replace`, not a fresh `Sidecar(...)` (#263) — recording one
+            # surrender used to erase the other, so an album accepted as
+            # incomplete re-accused itself of missing tracks the moment its
+            # purchase was accepted as gone.
+            replace(
+                sc,
                 mb_release_id=cand.mb_release_id,
                 mb_match_candidate=None,
-                tagged_at=sc.tagged_at,
-                notes=sc.notes,
                 purchase_unavailable=True,
             ),
         )
@@ -4476,33 +4454,19 @@ def _register_routes(app: FastAPI) -> None:
         sc = album.sidecar
         if sc is None:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "no sidecar")
-        new_sc = Sidecar(
-            schema_version=sc.schema_version,
-            store_url=None,
-            bandcamp=None,
-            downloaded_at=sc.downloaded_at,
-            added_at=sc.added_at,
-            mb_release_id=sc.mb_release_id,
-            mb_match_candidate=sc.mb_match_candidate,
-            tagged_at=sc.tagged_at,
-            notes="marked as purchased elsewhere",
-        )
+        # `replace`, not a fresh `Sidecar(...)` (#263).
+        new_sc = replace(sc, store_url=None, bandcamp=None, notes="marked as purchased elsewhere")
         sidecar_mod.write(album.path, new_sc)
         return _flash_response("Marked manual", "purchased elsewhere", album=album)
 
 
 def _replace_url(sc: Sidecar, new_url: str, new_bandcamp: BandcampInfo | None) -> Sidecar:
     """Build a new Sidecar with store_url and bandcamp block replaced."""
-    return Sidecar(
-        schema_version=sc.schema_version,
+    # `replace`, not a fresh `Sidecar(...)` (#263).
+    return replace(
+        sc,
         store_url=new_url,
         bandcamp=new_bandcamp,
-        downloaded_at=sc.downloaded_at,
-        added_at=sc.added_at,
-        mb_release_id=sc.mb_release_id,
-        mb_match_candidate=sc.mb_match_candidate,
-        tagged_at=sc.tagged_at,
-        notes=sc.notes,
     )
 
 

--- a/test/test_identity_grouping.py
+++ b/test/test_identity_grouping.py
@@ -300,6 +300,27 @@ def test_a_decision_recorded_on_any_part_holds_for_the_album(tmp_path, part):
     assert album.sidecar.purchase_unavailable is True
 
 
+@pytest.mark.parametrize("part", ["a", "b"])
+def test_an_absent_video_medium_stays_forgiven_across_the_merge(tmp_path, part):
+    """`video_media` is a fact about the ALBUM, not about a folder (#206).
+
+    A 3-medium release whose DVD was never ripped, with the two CDs in separate
+    folders. Only together are they the whole album — each part alone really is
+    short of a CD — so the merged view is the only place the DVD can be forgiven.
+    Dropping the field there costs the album #206 outright, and costs one
+    MusicBrainz call per scan to re-learn what its sidecar already recorded.
+    """
+    _part(tmp_path / "a", track_ids=DISC1, disc=2, disc_total=3, track_total=2)
+    _part(tmp_path / "b", track_ids=DISC2, disc=3, disc_total=3, track_total=2)
+    _edit(tmp_path / part, video_media=(1,))
+
+    album = scan(tmp_path)[0]
+
+    assert album.absent_media == frozenset({1})
+    assert album.sidecar.video_media == (1,)
+    assert album.state == AlbumState.COMPLETE
+
+
 def test_every_part_keeps_its_own_sidecar_on_disk(tmp_path):
     """No primary, no shards: a folder moved out of the group is still a
     complete album on its own."""

--- a/test/test_sidecar_carries.py
+++ b/test/test_sidecar_carries.py
@@ -1,0 +1,182 @@
+"""A sidecar rewrite must not silently drop the fields it wasn't told about (#263).
+
+Twelve places rebuilt a `Sidecar` from an existing one by naming the fields to
+keep. Every field left off the list was reset to its default — including
+`purchase_unavailable` and `tracks_unavailable`, decisions the user recorded that
+have no evidence on disk and so cannot be recovered once lost.
+
+#239 diagnosed exactly this and fixed one site. Its comment is still in
+`_tag_with_release`, and its last sentence is why this file exists:
+
+    A field added to the model later would have joined them, silently, with no
+    test to notice.
+
+So this is that test. It is a source check rather than a behavioural one on
+purpose: the behavioural version needs one case per site per field, and would
+still say nothing about the *next* site someone writes.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import fields as dc_fields
+from pathlib import Path
+
+import pytest
+
+from harmonist.models import Sidecar
+
+SRC = Path(__file__).parent.parent / "src" / "harmonist"
+
+#: Names a construction site uses for the sidecar it is carrying forward. A
+#: `Sidecar(...)` call mentioning one of these is rebuilding an existing sidecar
+#: rather than minting a fresh one, and is therefore in scope here.
+CARRIER_PREFIXES = ("sc.", "existing.", "base.", "s.", "cached.")
+
+#: `_merge_sidecars` is the one site that legitimately spells every field out:
+#: merging N sidecars needs a rule per field (first / earliest / latest / any),
+#: which `replace()` off some arbitrary part cannot express. It is allowed to
+#: construct, but not to be incomplete — `test_the_merge_names_every_field`
+#: holds it total.
+EXPLICIT_BY_DESIGN = {("scanner.py", "_merge_sidecars")}
+
+
+def _sidecar_calls() -> list[tuple[Path, ast.Call, str, str | None]]:
+    """Every `Sidecar(...)` construction in `src/`, with its enclosing function."""
+    out = []
+    for path in sorted(SRC.rglob("*.py")):
+        if path.name == "demo.py":  # a fixture generator, not a rewrite path
+            continue
+        src = path.read_text()
+        tree = ast.parse(src)
+        enclosing: dict[int, str] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                for child in ast.walk(node):
+                    enclosing.setdefault(getattr(child, "lineno", -1), node.name)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "Sidecar":
+                seg = ast.get_source_segment(src, node) or ""
+                out.append((path, node, seg, enclosing.get(node.lineno)))
+    return out
+
+
+def test_no_sidecar_rewrite_names_the_fields_to_keep():
+    """A site that carries an existing sidecar forward must use `replace()`.
+
+    `replace(base, ...)` keeps every unnamed field BY CONSTRUCTION, so a field
+    added to the model tomorrow needs no edit here and cannot be dropped.
+    """
+    offenders = []
+    for path, node, seg, func in _sidecar_calls():
+        if not node.keywords or not any(p in seg for p in CARRIER_PREFIXES):
+            continue
+        if (path.name, func) in EXPLICIT_BY_DESIGN:
+            continue
+        offenders.append(f"{path.relative_to(SRC.parent.parent)}:{node.lineno} in {func}()")
+
+    assert not offenders, (
+        "these rebuild a Sidecar from an existing one by naming fields to keep, "
+        "so any field they omit is silently reset to its default — use "
+        "`dataclasses.replace(sc, ...)` instead:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_merge_names_every_field():
+    """The one site allowed to construct explicitly must name every field.
+
+    `_merge_sidecars` builds the album's view of its folders' sidecars (#197).
+    A field it forgets is defaulted on every multi-folder album — which is how
+    `video_media` came to be dropped there, costing those albums #206 and one
+    MusicBrainz request per scan to re-learn it.
+    """
+    named: set[str] = set()
+    for path, node, _seg, func in _sidecar_calls():
+        if (path.name, func) in EXPLICIT_BY_DESIGN:
+            named = {k.arg for k in node.keywords if k.arg}
+    assert named, "_merge_sidecars not found — has it been renamed or moved?"
+
+    expected = {f.name for f in dc_fields(Sidecar)} - {"schema_version"}
+    assert expected - named == set(), (
+        "_merge_sidecars does not say what to do with these fields, so they are "
+        f"defaulted on every multi-folder album: {sorted(expected - named)}"
+    )
+
+
+def test_linking_a_purchase_clears_the_surrender(tmp_path):
+    """Carrying fields forward must not carry one its own evidence refutes.
+
+    `purchase_unavailable` says "there is no purchase to link, ever". Linking a
+    purchase does exactly that, so it is cleared — deliberately, which is a
+    different act from the accidental defaulting the rest of #263 is about.
+    Without it, converting this path to `replace()` would leave the album
+    flagged as having no purchase while wearing the item id of the one it just
+    got, and the flag would go on suppressing Needs Link forever.
+    """
+    import shutil
+
+    from harmonist import sidecar as sidecar_mod
+    from harmonist.pending_downloads import PendingPurchase
+    from harmonist.scanner import scan
+    from harmonist.web.main import _link_pending_to_album
+
+    album_dir = tmp_path / "Artist" / "Surrendered"
+    album_dir.mkdir(parents=True)
+    shutil.copy(Path(__file__).parent / "fixtures" / "sine.m4a", album_dir / "01 Track.m4a")
+    sidecar_mod.write(
+        album_dir,
+        Sidecar(
+            store_url="https://x.bandcamp.com/album/surrendered",
+            purchase_unavailable=True,
+        ),
+    )
+    album = next(a for a in scan(tmp_path) if a.path == album_dir)
+
+    _link_pending_to_album(
+        album,
+        PendingPurchase(
+            item_id=4242,
+            band="X",
+            title="Surrendered",
+            url="https://x.bandcamp.com/album/surrendered",
+            fmt="flac",
+        ),
+    )
+
+    after = sidecar_mod.read(album_dir)
+    assert after is not None
+    assert after.bandcamp is not None and after.bandcamp.item_id == 4242
+    assert after.purchase_unavailable is False, (
+        "the purchase turned out to exist, so the no-purchase surrender is refuted"
+    )
+
+
+@pytest.mark.parametrize("field", [f.name for f in dc_fields(Sidecar)])
+def test_every_sidecar_field_survives_a_replace(field):
+    """The property the fix relies on, stated once rather than assumed.
+
+    Guards against a field being given a non-init default or otherwise dropping
+    out of `replace()`, which would make every converted site quietly wrong
+    again while both tests above stayed green.
+    """
+    from dataclasses import replace
+
+    markers: dict[str, object] = {
+        "schema_version": 99,
+        "store_url": "https://example.bandcamp.com/album/x",
+        "notes": "note",
+        "purchase_unavailable": True,
+        "tracks_unavailable": True,
+        "video_media": (1, 2),
+        "temp_uid": "uid",
+        "mb_release_id": "11111111-2222-3333-4444-555555555555",
+    }
+    if field not in markers:
+        pytest.skip(f"{field} has no simple distinguishable value")
+    marker = markers[field]
+
+    # `setattr` rather than a `**kwargs` splat: the field name is only known at
+    # runtime, so a splat cannot be typed against the constructor.
+    original = Sidecar()
+    setattr(original, field, marker)
+    assert getattr(replace(original, added_at=None), field) == marker


### PR DESCRIPTION
Sixteen places built a fresh `Sidecar(...)` with an explicit field list. Twelve of them read an existing sidecar and carried only some of it forward, so every field left off the list was reset to its default — `video_media` and `tracks_unavailable` at all twelve, `purchase_unavailable` at eleven.

The surrenders are the damage that matters. Both are decisions with no evidence on disk — *"there is no purchase to link, ever"*, *"these tracks are not obtainable"* — so once defaulted nothing can recover them, and the album re-surrenders or starts reporting missing tracks again on the next pass. A sync, a recheck, rejecting a suggestion, or simply scanning an album split across folders was enough to lose one.

This is #239 exactly, at the sites #239 didn't reach.

## What changed

The eleven carrying sites become `replace(sc, ...)`, which keeps unnamed fields **by construction** — so a field added to the model tomorrow needs no edit at any call site and cannot be dropped.

`scanner._merge_sidecars` stays explicit: merging N sidecars needs a rule per field (first / earliest / latest / any), which `replace()` off some arbitrary part cannot express. It pays for that by being held **total** — a new test asserts it names every field on the model, so adding a field to `models.Sidecar` forces a merge rule to be chosen. `temp_uid` is named as deliberately dropped rather than omitted, since a merged album is grouped by its release and can never still be wearing a temp id.

One field is **cleared** rather than carried: linking a purchase refutes `purchase_unavailable` on the same line it sets the item id, so both link paths clear it explicitly. That is evidence falsifying the claim, not the accidental defaulting the rest of this PR is about — and it was caught by the review gate *after* the mechanical conversion introduced it.

## Tests

- `test_identity_grouping.py` — the reproduction: a 3-medium release whose DVD was never ripped with its two CDs in separate folders. Only the merged view can forgive the absent DVD, and the merge dropped `video_media` on the way, so the album derived `INCOMPLETE`. Written red, confirmed to fail on its own assertion, green after the fix.
- `test_sidecar_carries.py` — the structural guard #239's comment asked for. Parses `src/` for `Sidecar(...)` constructions that mention an existing sidecar; holds `_merge_sidecars` total; asserts every field survives a `replace()`; and covers the purchase-link clearing behaviourally. Both source checks were mutation-checked by reintroducing the bug.

`make check` green — 1319 passed, 31 skipped.

## Not in this PR

`purchase_unavailable` is set in one place and unset nowhere — there is no UI control that clears it. Until now the accidental resets were an unintended escape hatch; closing them is correct, but it leaves the flag with less of a way out than `tracks_unavailable`, which has a proper toggle. Raised separately rather than widened into this fix.

Fixes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016emoJJZvLEb5dw83voQcEW