### PR TITLE
Follow the release MusicBrainz actually gave us

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- When MusicBrainz has **merged** the release an album names into another one,
+  tagging now follows the surviving release and says so in the album's
+  **History** (#268), naming both releases. Previously the album silently
+  flickered through **Tagging**, and its identity was rewritten by the
+  reconciler as though you had re-tagged it in Picard.
 - Decisions you record about an album — **Keep in Library** for a purchase that
   no longer exists, and accepting an incomplete album as finished — are no
   longer erased by ordinary operations like a sync, a recheck, or rejecting a

--- a/docs/design.md
+++ b/docs/design.md
@@ -859,6 +859,20 @@ the odds get worse the longer the release, and the failure is silent and
 targeted — one file in sixteen given another track's title and ids, on an album
 that otherwise looks right, which nobody re-checks.
 
+### The release a tagging follows, when MusicBrainz has moved it
+
+MusicBrainz **merges** releases routinely, and it does not 404 a merged MBID — it *redirects*, so `fetch_release(old)` answers with the surviving release under a different `id`. That difference is the whole notification: cheap, exact, and available on a request Harmonist was making anyway.
+
+**A tagging follows the release it actually got.** The sidecar records `release["id"]`, not the id that was asked for, because the tagger writes `release["id"]` into every file. Recording the requested one instead left the two disagreeing, and the album then derived `TAGGING` from its own freshly written files — so the Inbox picked it up and reconcile rewrote the identity from the tags, laundering an identity change through machinery meant for "the user re-tagged in Picard" (#268). It self-healed, which is why it went unnoticed; at the scale of #32's nightly pass it would be continuous churn.
+
+**A merge is named, not just applied.** The album's History gets an audit line carrying both MBIDs and a plain-language activity entry saying what happened, because `sidecar.update` alone — which already renders `mbid=old->new` for any identity change — cannot be told apart from the user re-matching the album by hand. The alias linking the old id to the new one needs no special call: `sidecar.write` records one whenever an album's canonical id changes, and this is one of those.
+
+**A merge always applies, and is never held for review** — including under #32's unattended pass. There is nothing to authorise: the merge has already happened on MusicBrainz, and Harmonist is only noticing it. Offering a choice would imply the old release still exists to stay on, which it does not. This is deliberately *not* the classifier's business (#267): that map decides which **tag changes** may auto-apply, and a merge is an identity fact arriving alongside them, not one of them.
+
+The escape hatch is the one every tagging has — **Undo**, which restores the previous tags from the album's own history (#157) — plus fixing the merge on MusicBrainz, which is where a wrong one is actually wrong. What a merge must never be is *silent*, which is what the record above is for.
+
+A **deletion** is the sibling case and behaves differently: MusicBrainz 404s, `fetch_release` raises `ReleaseGoneError`, and nothing is written at all (§2.4.1, #194).
+
 ### The tags Harmonist owns
 
 `formats/owned.py` names them, and the list is the concrete form of the promise not to touch tags Harmonist doesn't understand: **these fields, and only these, are the ones it writes, overwrites, and removes.** Each backend maps `Owned` to its native keys and clears that mapping before writing, so a field absent from the new `TagSet` — a release with no catalogue number, say — is *removed* rather than left stale from a previous tagging. Before #149 only the Vorbis backend did this, so a mis-tag correction left the wrong release's label on MP3 and M4A files indefinitely.

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -2574,6 +2574,42 @@ def _claim_pending_by_store_url(store_url: str | None) -> None:
             pending_downloads.remove(p.item_id)
 
 
+def _record_merge(album_path: Path, old_mbid: str, new_mbid: str) -> None:
+    """Say that MusicBrainz merged one release into another (#268).
+
+    Called AFTER the sidecar write, for two reasons. The album's id has just
+    moved with it, and an entry stamped with the pre-write id would hang off a
+    release the sidecar no longer names (#65). And the entry is a report of
+    something that happened, not of something attempted — a tagging that threw
+    part-way should not leave a line claiming the identity moved.
+
+    The alias that keeps the album's pre-merge history reachable is NOT recorded
+    here: `sidecar.write()` already records one whenever the canonical id
+    changes, and this is one of those. Adding a call would duplicate it at one
+    call site while leaving every other identity change relying on the write —
+    the shape the event-recording skill warns about.
+
+    Both sinks, because they answer different questions. The activity entry is
+    the outcome in the user's language, and the audit line is the pair of ids —
+    which is forensics, and doesn't belong in prose the feed renders next to an
+    album name it already shows in its own column.
+    """
+    album_id = sidecar_mod.album_id_for(album_path)
+    audit.record(
+        "release.merged",
+        album_id=album_id,
+        album=album_path,
+        old=old_mbid,
+        new=new_mbid,
+    )
+    activity.record(
+        "MusicBrainz merged the release this album named into another one — "
+        "it now follows the surviving release",
+        album_id=album_id,
+        album_label=album_path.name,
+    )
+
+
 def _tag_with_release(
     album_path: Path,
     mbid: str,
@@ -2587,6 +2623,10 @@ def _tag_with_release(
 ) -> None:
     """Fetch MB release, fetch cover, write tags, update sidecar.
 
+    `mbid` is what to ask MusicBrainz for, not necessarily what the album ends
+    up tagged as: a merged release redirects, and this follows the release it
+    actually got (#268). See the rebinding below.
+
     `incomplete=True` runs the tagger in incomplete mode (file_count <
     MB track count allowed). Nothing is persisted about the count: the tagging
     writes the release's own totals into every file, and that is what the
@@ -2599,6 +2639,27 @@ def _tag_with_release(
     purchase and the album can never link, falling through to surrender.
     """
     release = mb_lookup.fetch_release(mbid)
+    # MusicBrainz REDIRECTS a merged MBID, so the release that comes back can
+    # carry a different id from the one asked for. That difference IS the merge
+    # notification — cheap, exact, and the only one there is (#268). Everything
+    # downstream follows the id the release actually has, because the tagger
+    # writes `release["id"]` into the files either way: disagreeing with it left
+    # the sidecar naming a release that no longer exists, the album deriving
+    # TAGGING off its own files, and reconcile rewriting the identity through a
+    # path meant for "the user re-tagged in Picard".
+    #
+    # `mbid` is REBOUND rather than a second name being introduced, so the
+    # correction holds by construction: a line added below that reaches for the
+    # album's release gets the one it was tagged as, not the one that was asked
+    # for. Only the merge check itself wants the original.
+    #
+    # Unconditional, and it stays unconditional under #32's unattended pass:
+    # there is nothing to authorise, because the merge has already happened on
+    # MusicBrainz and this is only noticing it. Undo is the escape hatch, as it
+    # is for any tagging. Not the significance classifier's business (#267) —
+    # that decides which TAG changes may auto-apply, and this is an identity
+    # fact arriving beside them.
+    requested_mbid, mbid = mbid, release["id"]
     rg = release.get("release-group") or {}
     cover_path = cover_art.ensure_cover(
         album_path,
@@ -2653,6 +2714,8 @@ def _tag_with_release(
         video_media=mb_lookup.video_media_of(release),
     )
     sidecar_mod.write(album_path, new)
+    if mbid != requested_mbid:
+        _record_merge(album_path, requested_mbid, mbid)
     _claim_pending_by_store_url(store_url)
 
 

--- a/test/test_mb_merge.py
+++ b/test/test_mb_merge.py
@@ -1,0 +1,223 @@
+"""What happens when MusicBrainz has merged the release an album names (#268).
+
+MusicBrainz *redirects* a merged MBID: `fetch_release(old)` answers with the
+**target** release, carrying a different `id`. Two writers then disagree —
+`tagger._build_tagset` puts `release["id"]` (the new id) into every file while
+`_tag_with_release` wrote the *requested* id to the sidecar. The album derives
+TAGGING off that disagreement, the Inbox kicks the reconciler, and reconcile
+adopts the file tags: an identity change laundered through machinery built for
+"the user re-tagged in Picard", with nothing anywhere saying a merge happened.
+
+Merges are common, and #32's nightly pass would walk into every one that has
+happened since an album was tagged — so the album has to come out of a re-tag
+settled, and its History has to say why its identity moved.
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from mutagen.mp4 import MP4
+
+from harmonist import activity_store, mb_lookup, scanner
+from harmonist import sidecar as sidecar_mod
+from harmonist.config import BandcampConfig, Config, PathsConfig, ServerConfig, TestConfig
+from harmonist.models import AlbumState, Sidecar
+from harmonist.web.main import create_app
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+SINE_M4A = FIXTURES_DIR / "sine.m4a"
+
+OLD_MBID = "11111111-2222-3333-4444-555555555555"
+NEW_MBID = "99999999-8888-7777-6666-555555555555"
+TAGGED_AT = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    return Config(
+        paths=PathsConfig(config_dir=tmp_path / "config", music_dir=tmp_path / "music"),
+        bandcamp=BandcampConfig(),
+        server=ServerConfig(),
+        test=TestConfig(mode="fixture"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def no_cover_fetch(monkeypatch):
+    """No cover-art requests: this module is about identity, and CAA is off-box."""
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+
+
+@pytest.fixture
+def client(cfg):
+    cfg.paths.music_dir.mkdir(parents=True, exist_ok=True)
+    cfg.paths.config_dir.mkdir(parents=True, exist_ok=True)
+    # HX-Request: the CSRF middleware requires it on every state-changing call.
+    return TestClient(create_app(cfg), headers={"HX-Request": "true"})
+
+
+def _release(mbid: str) -> dict:
+    """A 2-track CD carrying `mbid` as its own id."""
+    return {
+        "id": mbid,
+        "title": "Test Album",
+        "status": "Official",
+        "artist-credit": [{"artist": {"id": "art-1", "name": "Artist"}, "name": "Artist"}],
+        "release-group": {"id": "rg-1", "primary-type": "Album"},
+        "medium-list": [
+            {
+                "position": "1",
+                "format": "CD",
+                "track-list": [
+                    {
+                        "id": f"rt-{i}",
+                        "position": str(i),
+                        "title": f"Track {i}",
+                        "recording": {"id": f"rec-{i}", "title": f"Track {i}", "length": "1000"},
+                    }
+                    for i in range(1, 3)
+                ],
+            }
+        ],
+    }
+
+
+def _redirects_to(monkeypatch, mbid: str) -> None:
+    """Every fetch answers with the release `mbid` names, whatever was asked for
+    — which is exactly what MusicBrainz does for an id that has been merged
+    away, and the only signal there is that it happened."""
+    monkeypatch.setattr(mb_lookup, "fetch_release", lambda requested: _release(mbid))
+
+
+def _album(cfg) -> Path:
+    """A 2-track album tagged as OLD_MBID, sitting COMPLETE in the Library."""
+    d = cfg.paths.music_dir / "Artist" / "Album"
+    d.mkdir(parents=True)
+    for i in (1, 2):
+        f = d / f"0{i} Track {i}.m4a"
+        shutil.copy(SINE_M4A, f)
+        a = MP4(f)
+        a["\xa9alb"] = ["Test Album"]
+        a["\xa9ART"] = ["Artist"]
+        a["trkn"] = [(i, 2)]
+        a["----:com.apple.iTunes:MusicBrainz Album Id"] = [OLD_MBID.encode()]
+        a.save()
+    sidecar_mod.write(d, Sidecar(mb_release_id=OLD_MBID, tagged_at=TAGGED_AT))
+    return d
+
+
+def _scanned(cfg, album_dir: Path):
+    for a in scanner.scan(cfg.paths.music_dir):
+        if a.path == album_dir:
+            return a
+    raise AssertionError(f"no album at {album_dir}")
+
+
+def _file_mbids(album_dir: Path) -> set[str]:
+    key = "----:com.apple.iTunes:MusicBrainz Album Id"
+    return {MP4(f)[key][0].decode() for f in sorted(album_dir.glob("*.m4a"))}
+
+
+def _messages() -> list[str]:
+    return [e.message for e in activity_store.recent(50)]
+
+
+def test_a_merge_leaves_the_sidecar_and_the_files_naming_the_same_release(client, cfg, monkeypatch):
+    """The two writers have to agree. The files get `release["id"]` and always
+    did; the sidecar used to get the id that was *asked for*, which after a
+    redirect names a release that no longer exists."""
+    d = _album(cfg)
+    _redirects_to(monkeypatch, NEW_MBID)
+
+    r = client.post(f"/retag/{_scanned(cfg, d).id}")
+    assert r.status_code == 200
+
+    after = sidecar_mod.read(d)
+    assert after is not None
+    assert after.mb_release_id == NEW_MBID
+    assert _file_mbids(d) == {NEW_MBID}
+
+
+def test_a_merge_does_not_leave_the_album_looking_externally_retagged(client, cfg, monkeypatch):
+    """The disagreement derived TAGGING (`scanner._derive_state`), so the Inbox
+    picked the album up and reconcile rewrote its identity from the file tags —
+    self-healing, but through a path meant for a re-tag done in Picard."""
+    d = _album(cfg)
+    _redirects_to(monkeypatch, NEW_MBID)
+
+    client.post(f"/retag/{_scanned(cfg, d).id}")
+
+    assert _scanned(cfg, d).state == AlbumState.COMPLETE
+
+
+def test_a_merge_says_so_in_the_albums_history_naming_both_releases(client, cfg, monkeypatch):
+    """A merge is qualitatively different from a tag change, and usually arrives
+    with one. Nothing said it had happened.
+
+    Asserted against `album_history`, which is the surface the album's History
+    page renders: it unions activity and audit over the alias chain, so this
+    covers the entry being *attributed* to the album as well as written.
+
+    The two conditions are deliberately on ONE message. Split, they both pass
+    for free: `sidecar.update` already renders `mbid=old->new` whenever an
+    album's identity moves, so "some line names both ids" is true of a user
+    re-matching an album by hand — which is the very thing a merge has been
+    indistinguishable from. Naming it is the whole point of the record.
+    """
+    d = _album(cfg)
+    _redirects_to(monkeypatch, NEW_MBID)
+
+    client.post(f"/retag/{_scanned(cfg, d).id}")
+
+    history = [e.message for e in activity_store.album_history(NEW_MBID)]
+    assert [m for m in history if "merged" in m.lower() and OLD_MBID in m and NEW_MBID in m], (
+        history
+    )
+    # And in the user's own language, in the feed — the ids above are forensics.
+    feed = [e.message for e in activity_store.recent(50, source=activity_store.Source.ACTIVITY)]
+    assert [m for m in feed if "merged" in m.lower()], feed
+
+
+def test_a_merge_links_the_old_id_to_the_new_one(client, cfg, monkeypatch):
+    """Everything recorded under the old id — the album's whole history, and any
+    deep link already written into the feed — is orphaned without the alias."""
+    d = _album(cfg)
+    _redirects_to(monkeypatch, NEW_MBID)
+
+    client.post(f"/retag/{_scanned(cfg, d).id}")
+
+    assert activity_store.resolve_alias(OLD_MBID) == NEW_MBID
+
+
+def test_a_second_retag_after_a_merge_reports_nothing(client, cfg, monkeypatch):
+    """Idempotency, which is the invariant #32 is built on: the second pass over
+    a merged album finds the id it asked for is the id it got, so there is
+    nothing to name. Without it a nightly pass would re-announce the same merge
+    every night for the rest of the album's life."""
+    d = _album(cfg)
+    _redirects_to(monkeypatch, NEW_MBID)
+
+    client.post(f"/retag/{_scanned(cfg, d).id}")
+    before = len([m for m in _messages() if "merged" in m.lower()])
+    client.post(f"/retag/{_scanned(cfg, d).id}")
+
+    assert before == 2, _messages()  # the activity entry and its audit line
+    assert len([m for m in _messages() if "merged" in m.lower()]) == before, _messages()
+    assert _scanned(cfg, d).state == AlbumState.COMPLETE
+
+
+def test_an_ordinary_retag_says_nothing_about_a_merge(client, cfg, monkeypatch):
+    """The control, and the invariant #32 cares about: don't narrate a no-op.
+    A re-tag against a release that has not moved must not mention one."""
+    d = _album(cfg)
+    _redirects_to(monkeypatch, OLD_MBID)
+
+    client.post(f"/retag/{_scanned(cfg, d).id}")
+
+    assert not [m for m in _messages() if "merged" in m.lower()], _messages()
+    assert activity_store.resolve_alias(OLD_MBID) is None


### PR DESCRIPTION
MusicBrainz **redirects** a merged MBID rather than 404ing it, so `fetch_release(old)` answers with the surviving release under a different `id`. The tagger has always written `release["id"]` into the files; `_tag_with_release` wrote the *requested* id to the sidecar. The two then disagreed, so the album derived `TAGGING` off its own freshly written files, the Inbox kicked the reconciler, and reconcile rewrote the identity from the tags — an identity change laundered through machinery meant for "the user re-tagged in Picard", with nothing anywhere saying a merge had happened.

It self-healed, which is why it went unnoticed as a bug. Under #32's nightly pass it becomes continuous identity churn across the library, so it wants fixing before anything re-tags unattended.

## The fix

`mbid` is **rebound** to `release["id"]` immediately after the fetch, so the correction holds by construction rather than by two writers remembering to agree — a line added later that reaches for the album's release gets the one it was tagged as.

The merge is then **named** in the album's History: an audit `release.merged old=… new=…` line, plus a plain-language activity entry. Both are needed. `sidecar.update` already renders `mbid=old->new` for *any* identity change, so the id pair alone is indistinguishable from the user re-matching the album by hand — which is precisely the confusion this removes.

The alias that keeps the album's pre-merge history reachable needs **no new call**: `sidecar.write` records one whenever the canonical id moves, and this is one of those. Adding one at this call site would duplicate it here while leaving every other identity change relying on the write.

## Policy: a merge always applies

Never held for review, unattended included. There is nothing to authorise — the merge has already happened on MusicBrainz and Harmonist is only noticing it, and offering a choice would imply the old release still exists to stay on. Undo is the escape hatch, as it is for any tagging; a genuinely wrong merge is wrong *on MusicBrainz*, which is where it gets fixed.

Deliberately **not** the significance classifier's business (#267): that map decides which *tag changes* may auto-apply, and a merge is an identity fact arriving beside them. Written into `docs/design.md` §5 so #270 and #273 inherit the decision rather than re-opening it.

## Testing

Six tests in `test/test_mb_merge.py`, web-route rung — the bug is a disagreement between two writers and its consequence is a derived state, so only the route exercises both together. Four were red first, for the predicted reasons.

Worth recording: the "History names both MBIDs" assertion initially **passed with the audit line deleted**, free-riding on `sidecar.update`. Catching that is what sharpened the design above. All three components of the fix are now individually mutation-checked red, including the idempotency guard (review-gate item 7 — a second pass over a merged album reports nothing).

Fixes #268