### PR TITLE
Look for changes the watcher can't see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- Harmonist now **rescans your library once an hour** as a backstop (#151), for
+  the cases where its file watcher isn't working and can't tell you so — a
+  library mounted over the network, where the watcher is blind, or a watcher
+  killed by an exhausted system watch limit. Nothing to configure, and nothing
+  to see: it shows no **Scanning** banner and never locks the inbox the way an
+  action you took does, it waits for any sync or reconcile to finish first, and
+  it refreshes what you're looking at only if it actually found something.
+- **An album's own page re-reads that album from disk before it renders** (#151),
+  so a track added by hand or a title fixed in Picard shows up the moment you
+  open the page — whatever the watcher did or didn't see.
 - Harmonist now **caches the MusicBrainz releases it fetches** (#127), so
   browsing your library no longer spends a rate-limited request every time you
   open an album's page. The Tags panel says when the release was last read, with
@@ -35,6 +45,9 @@ versions follow [semantic versioning](https://semver.org).
   only ever said in the global Activity feed, attributed to no album.
 - A failed re-tag, tag, reconcile, undo or manual assignment no longer writes a
   second, blank entry to the Activity feed beneath the real one (#258).
+- An album Harmonist can't read — a corrupt or too-new sidecar — is reported to
+  the Activity feed **once** rather than on every scan (#151). Editing it and
+  leaving it broken still says so again, since that's news.
 
 ## [1.11.0] - 2026-08-24
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1022,6 +1022,7 @@ src/harmonist/
     reconcile_runner.py Reconciliation pass over the library (rate-limited MB)
     scan_runner.py      Cache-backed library scan + status
     dir_watcher.py      watchfiles watcher → rescan when the music dir settles
+    periodic.py         Generic interval task → the hourly library rescan
 ```
 
 Templates and static assets live at the **project root** (`/templates`,
@@ -1199,7 +1200,15 @@ services:
     ports: ["8000:8000"]
 ```
 
-### 10.4 Picking up manual changes (file watcher)
+### 10.4 Picking up manual changes (watcher, hourly rescan, per-album refresh)
+
+Three mechanisms, in increasing order of how little they assume: the watcher
+hears about a change, the hourly rescan goes and looks, and the album page
+re-reads the one album you are looking at. They coalesce through the same `_dirty` flag on
+`ScanRunner`, so any number of triggers between two scans still produces one
+scan.
+
+#### The file watcher
 
 Files added or removed outside the app — copied straight into the music dir,
 or deleted by hand — don't pass through the in-app rescan path. A background
@@ -1216,10 +1225,85 @@ which fires for changes to a *local* filesystem (the Synology bind-mount of
 machine). It does **not** fire when the *container itself* mounts a network
 share (the Pi-dev SMB recipe above, or any NFS/SMB `/music`): inotify events
 don't cross the network, so the watcher silently sees nothing and the watcher
-fails soft (logs, no crash). **Workaround for network-mounted libraries:
-restart the container** — the initial scan on startup re-reads the whole tree,
-so a quick bounce (`docker compose restart harmonist`) is a reliable way to
-force a rescan there.
+fails soft (logs, no crash). It can also be killed outright — an exhausted
+inotify watch limit on a very large tree ends the task, and from then on
+nothing rescans until a restart. That is what the hourly rescan below is for.
+
+#### The hourly rescan
+
+A rescan on a timer, regardless of what the watcher did or didn't hear
+(`web/periodic.py`, engaged from the lifespan beside the watcher). It is a
+**backstop for a watcher that isn't working**, not a routine mechanism: when
+the watcher fires, this finds nothing every time. Both failures it covers —
+the network mount, the dead watcher — are silent, which is what makes it worth
+its cost; neither is common, which is why it stays out of sight.
+
+That cost is low enough to need no tuning: a no-change rescan is a `stat` per
+file and no tag reads at all, because the mtime cache answers every directory
+from memory. So the interval is a **constant** (`main._RESCAN_INTERVAL`, one
+hour), not a setting — the user has nothing to trade off against, and a knob
+would only invite tuning a thing nobody should have to think about.
+
+`web/periodic.run_periodically` is deliberately generic — it owns no state and
+decides nothing about what a tick means — so the metadata gardener's paced pass
+(#270) can use the same timer rather than inventing a second one.
+
+**It is invisible.** A scan normally advertises itself: a *Scanning* pill,
+and the **inbox busy lock** that dims `#task-list` and turns off its pointer
+events so a click can't land on a snapshot being rebuilt. That is protection
+for a scan the user set in motion. Applied hourly on a timer it is just the
+inbox freezing under their cursor, so `ScanRunner.request_quiet_rescan()` runs
+the same scan without publishing a status. If a real trigger arrives mid-rescan
+the scan in flight is **promoted** — the pill and the lock appear at the moment
+there is something to protect.
+
+The completed-scan counter the client refreshes off (`ScanStatus.seq`) now
+advances only when the snapshot is genuinely **different**. Otherwise the
+hourly rescan over an untouched library would re-render the inbox every hour to
+show exactly what was already there.
+
+**It never runs during a sync or a reconcile pass** (`_periodic_rescan_if_idle`).
+The watcher waits for the directory to go quiet precisely so it can't scan
+mid-copy; a timer has no such instinct, and a rescan landing mid-download
+would read a part-written album and record it as one Harmonist has "started
+tracking" — a permanent Activity entry about a transient. Skipping the tick is
+enough: both runners request a scan of their own when they finish.
+
+**Repetition is its failure mode.** Anything the `harmonist` logger
+emits at WARNING or above is mirrored into the Activity feed, so a condition
+that doesn't clear on its own — an unmounted volume, one corrupt sidecar —
+posts an identical entry every interval, forever. Two places guard against it:
+`run_periodically` logs only the FIRST of a run of failures (and logs recovery
+at INFO), and `scanner._warn_once` complains about an unbuildable directory only
+when its signature has changed since the last complaint, so "I tried to fix it
+and it's still wrong" is still reported while "still broken, unchanged" is not.
+
+#### The per-album refresh
+
+The album page re-reads *its own* album's directories before rendering
+(`ScanRunner.refresh_album`), so what it shows is what is on disk now — not
+what the last scan happened to see, which on a network mount could be startup.
+The album page is where the user decides whether to re-tag, and deciding that
+against a stale reading is the failure that costs something.
+
+It is one directory listing plus a `stat` per file, and on a signature hit
+nothing more: no tags are read. That is affordable per page view; a full
+`refresh_now()` (which walks the entire library) is not, which is why the page
+does not just call one. Only the album's known directories are re-read, so an
+album gaining a *whole new* directory is still the hourly rescan's job.
+
+This is what makes the runner retain its per-directory `ScannedDir` entries:
+`merge_by_identity` is one-way, so a merged Album can no longer say which files
+came from which folder, and rebuilding one album's entry without them would
+mean re-walking the library to put the other discs back.
+
+**What none of this can tell you.** A scan derives current state from current
+files and keeps no record of what was there before, so a refresh can show a new
+value but never report that it *changed*. An external edit that doesn't affect a
+derived state — a hand-fixed title, an artist credit corrected in Picard —
+leaves no trace in the album's history. One that *does* (an MBID diverging from
+the sidecar) already surfaces as mis-tag/inconsistent. Emitting "changed outside
+Harmonist" records needs the last-written state of #86 and belongs with #32.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,7 +84,23 @@ max_downloads_per_sync = 25       # safety cap
 [musicbrainz]
 user_agent = "Harmonist/1.0 ( you@example.com )"
 cache_ttl_seconds = 3600          # re-serve a fetched release for this long
+
+[library]
+watch_settle_seconds = 5          # quiet time before a watched change rescans
 ```
+
+Harmonist watches the music dir and rescans when files change under it, but
+that only works on a **local** filesystem — if the container mounts your library
+over NFS or SMB, the kernel never reports the change and the watcher sees
+nothing. The watcher can also be killed outright by an exhausted system watch
+limit on a very large tree. Neither says so, so Harmonist rescans the library
+once an hour as a backstop. There is nothing to configure: an unchanged library
+costs a `stat` per file and no tag reads, and the hourly rescan is meant to go
+unnoticed — no **Scanning** banner, no locked inbox, and it waits for any sync
+or reconcile to finish rather than competing with it.
+
+An album's own page is never stale regardless: it re-reads that album's folders
+before it renders.
 
 MusicBrainz allows one request per second, so Harmonist caches each release it
 fetches and re-serves it for `cache_ttl_seconds` rather than asking again. An

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -212,6 +212,11 @@ Clicking a tile opens a summary that answers "is this the right release?"; from
 there, the album's own page at `/album/<id>` has the whole story. It has an
 address, so it can be shared, bookmarked, and gone back from.
 
+This page re-reads the album's folders every time you open it, so what it shows
+is what is on disk now — a track added by hand, or a title you fixed in Picard a
+moment ago, is already there. That matters here more than anywhere else, because
+this is the page where you decide whether to re-tag.
+
 <!-- screenshot: docs/screenshots/album-tags.png -->
 
 **Tags** compares your files against MusicBrainz field by field and shows **only

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -55,6 +55,19 @@ def scan(music_dir: Path, *, album_cache: AlbumCache | None = None) -> list[Albu
     is unchanged since the last scan — the big win on slow filesystems.
     Omit it (the default) for a full, uncached scan.
     """
+    return merge_by_identity(scan_dirs(music_dir, album_cache=album_cache))
+
+
+def scan_dirs(music_dir: Path, *, album_cache: AlbumCache | None = None) -> list[ScannedDir]:
+    """The per-DIRECTORY half of `scan`: walk, resolve, prune — but stop before
+    folding directories into albums.
+
+    Exposed because a caller that wants to refresh ONE album later needs the
+    per-directory entries this produced (`merge_by_identity` is not reversible —
+    a merged Album no longer knows which of its parts came from where). The
+    scan runner retains them for exactly that (#151); everyone else wants
+    `scan`.
+    """
     scanned: list[ScannedDir] = []
     for album_dir, audio, videos, signature in iter_album_dirs(music_dir):
         entry = resolve_dir(album_dir, audio, videos, signature, album_cache)
@@ -62,7 +75,7 @@ def scan(music_dir: Path, *, album_cache: AlbumCache | None = None) -> list[Albu
             scanned.append(entry)
     if album_cache is not None:
         prune_cache(album_cache, {e.album.path for e in scanned})
-    return merge_by_identity(scanned)
+    return scanned
 
 
 def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], list[Path], AlbumSignature]]:
@@ -87,48 +100,76 @@ def iter_album_dirs(root: Path) -> Iterator[tuple[Path, list[Path], list[Path], 
         return
     for dirpath, _dirnames, filenames in os.walk(root):
         d = Path(dirpath)
-        audio: list[tuple[Path, int, int]] = []
-        video: list[tuple[Path, int, int]] = []
-        sidecar_mtime: int | None = None
-        cover_mtime: int | None = None
-        for name in filenames:
-            f = d / name
-            try:
-                st = f.stat()
-            except OSError:
-                continue
-            if not S_ISREG(st.st_mode):
-                continue
-            if formats.is_supported(f):
-                audio.append((f, st.st_mtime_ns, st.st_size))
-            elif formats.is_video(f):
-                # Not audio, but tracks all the same — see `album_files.video_files`.
-                video.append((f, st.st_mtime_ns, st.st_size))
-            elif name == ".harmonist.json":
-                sidecar_mtime = st.st_mtime_ns
-            elif name in ("cover.jpg", "cover.png"):
-                cover_mtime = st.st_mtime_ns
-        if not audio:
+        contents = read_dir(d, filenames)
+        if contents is None:
             continue  # not an album directory
-        audio.sort(key=lambda e: album_files.sort_key(Path(e[0].name)))
-        video.sort(key=lambda e: album_files.sort_key(Path(e[0].name)))
-        files = [e[0] for e in audio]
-        videos = [e[0] for e in video]
-        signature: AlbumSignature = (
-            # Video files ride in the SAME tuple as the audio. They are read for
-            # completeness (#193), so a video appearing or vanishing changes what
-            # the album derives — and a signature blind to them would serve a
-            # stale Album from the cache after a DVD rip landed.
-            #
-            # Bare names, because everything here is in `d`: this walk is
-            # per-directory again since #197, so nothing can collide. It briefly
-            # keyed on the relative path, when one entry could span disc
-            # subdirectories.
-            tuple((e[0].name, e[1], e[2]) for e in [*audio, *video]),
-            sidecar_mtime,
-            cover_mtime,
-        )
-        yield d, files, videos, signature
+        yield d, contents.files, contents.videos, contents.signature
+
+
+class DirContents(NamedTuple):
+    """One directory's audio, video and fingerprint, from `stat` alone."""
+
+    files: list[Path]
+    videos: list[Path]
+    signature: AlbumSignature
+
+
+def read_dir(album_dir: Path, names: Sequence[str] | None = None) -> DirContents | None:
+    """`stat` one directory's files and return what an album is built from, or
+    None when it holds no audio (so it is not an album directory).
+
+    `names` is the directory listing when the caller already has one — `os.walk`
+    hands `iter_album_dirs` a listing per directory, and re-reading it would
+    double the walk's syscalls. Omit it to list the directory here, which is
+    what refreshing a SINGLE album does (#151): one album's directories can be
+    fingerprinted without walking the library root.
+
+    An unreadable directory raises `OSError` rather than answering None — "no
+    audio here" and "couldn't look" must not be the same answer, because a
+    caller acting on the first would drop a whole album from the snapshot over a
+    momentarily unavailable network mount.
+    """
+    entries = list(names) if names is not None else os.listdir(album_dir)
+    audio: list[tuple[Path, int, int]] = []
+    video: list[tuple[Path, int, int]] = []
+    sidecar_mtime: int | None = None
+    cover_mtime: int | None = None
+    for name in entries:
+        f = album_dir / name
+        try:
+            st = f.stat()
+        except OSError:
+            continue
+        if not S_ISREG(st.st_mode):
+            continue
+        if formats.is_supported(f):
+            audio.append((f, st.st_mtime_ns, st.st_size))
+        elif formats.is_video(f):
+            # Not audio, but tracks all the same — see `album_files.video_files`.
+            video.append((f, st.st_mtime_ns, st.st_size))
+        elif name == ".harmonist.json":
+            sidecar_mtime = st.st_mtime_ns
+        elif name in ("cover.jpg", "cover.png"):
+            cover_mtime = st.st_mtime_ns
+    if not audio:
+        return None
+    audio.sort(key=lambda e: album_files.sort_key(Path(e[0].name)))
+    video.sort(key=lambda e: album_files.sort_key(Path(e[0].name)))
+    signature: AlbumSignature = (
+        # Video files ride in the SAME tuple as the audio. They are read for
+        # completeness (#193), so a video appearing or vanishing changes what
+        # the album derives — and a signature blind to them would serve a
+        # stale Album from the cache after a DVD rip landed.
+        #
+        # Bare names, because everything here is in `album_dir`: the walk is
+        # per-directory again since #197, so nothing can collide. It briefly
+        # keyed on the relative path, when one entry could span disc
+        # subdirectories.
+        tuple((e[0].name, e[1], e[2]) for e in [*audio, *video]),
+        sidecar_mtime,
+        cover_mtime,
+    )
+    return DirContents([e[0] for e in audio], [e[0] for e in video], signature)
 
 
 def _written_at(signature: AlbumSignature) -> datetime | None:
@@ -143,6 +184,37 @@ def _written_at(signature: AlbumSignature) -> datetime | None:
     if not entries:
         return None
     return datetime.fromtimestamp(max(e[1] for e in entries) / 1e9, tz=UTC)
+
+
+# Directories already complained about, and the signature they held when we did.
+# One entry per directory that has ever failed to BUILD, which is a set most
+# libraries never add to at all — so it is deliberately not pruned with the album
+# cache. It can't be: a directory that fails to build never reaches `seen`, so
+# pruning against that set would drop every entry on the next scan and undo the
+# whole point.
+_warned: dict[Path, AlbumSignature] = {}
+
+
+def _warn_once(album_dir: Path, signature: AlbumSignature, fmt: str, e: Exception) -> None:
+    """Log a directory we couldn't build an album from — but only the first time
+    it looks this way.
+
+    A skipped album is invisible in the UI, so the warning is the only signal
+    that it exists, and it has to be said. Saying it on *every* scan is a
+    different matter: WARNING and above is mirrored into the user's Activity
+    feed, and since #151 the library is scanned hourly whether or not anything
+    happened — so one corrupt sidecar would post an identical entry to the feed
+    every hour, forever.
+
+    Keyed on the signature, so it speaks up again the moment the directory
+    actually changes and is still broken: that is a new fact ("I tried to fix
+    it and it's still wrong"), not a repeat of the old one.
+    """
+    if _warned.get(album_dir) == signature:
+        log.debug(fmt, album_dir, e)
+        return
+    _warned[album_dir] = signature
+    log.warning(fmt, album_dir, e)
 
 
 class ScannedDir(NamedTuple):
@@ -188,10 +260,10 @@ def resolve_dir(
         io = read_album_io(album_dir, audio_files, video_files, reuse)
         album = build_album(album_dir, audio_files, io, _written_at(signature))
     except (InvalidSidecarError, UnsupportedSchemaVersionError) as e:
-        log.warning("skipping %s: %s", album_dir, e)
+        _warn_once(album_dir, signature, "skipping %s: %s", e)
         return None
     except Exception as e:
-        log.warning("error scanning %s: %s", album_dir, e)
+        _warn_once(album_dir, signature, "error scanning %s: %s", e)
         return None
     if album_cache is not None:
         album_cache[album_dir] = (signature, album, io)
@@ -401,9 +473,15 @@ def _merge_sidecars(sidecars: list[Sidecar | None], mbid: str) -> Sidecar:
 
 
 def prune_cache(album_cache: AlbumCache, seen: set[Path]) -> None:
-    """Drop cache entries for album dirs not present in `seen` (removed dirs)."""
+    """Drop cache entries for album dirs not present in `seen` (removed dirs).
+
+    `pop`, not `del`: the cache is shared with whatever the scan runner is doing
+    on another thread, and a per-album refresh dropping the same vanished
+    directory in the gap between listing and deleting would otherwise abort the
+    whole scan with a KeyError.
+    """
     for stale in [p for p in album_cache if p not in seen]:
-        del album_cache[stale]
+        album_cache.pop(stale, None)
 
 
 class AlbumIO(NamedTuple):

--- a/src/harmonist/web/dir_watcher.py
+++ b/src/harmonist/web/dir_watcher.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
+from datetime import timedelta
 from pathlib import Path
 
 from watchfiles import awatch
@@ -30,10 +31,10 @@ async def watch_music_dir(
     music_dir: Path,
     on_change: Callable[[], None],
     *,
-    settle_seconds: float = 5.0,
+    settle: timedelta = timedelta(seconds=5),
     stop_event: asyncio.Event | None = None,
 ) -> None:
-    """Rescan once `music_dir` has been quiet for `settle_seconds`.
+    """Rescan once `music_dir` has been quiet for `settle`.
 
     Each change (re)starts a settle timer; the rescan fires only after the tree
     has been idle for the full delay, so copying a batch of files in produces a
@@ -45,6 +46,7 @@ async def watch_music_dir(
         return
 
     loop = asyncio.get_running_loop()
+    settle_seconds = settle.total_seconds()
     pending: asyncio.TimerHandle | None = None
 
     def fire() -> None:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -70,7 +70,7 @@ from harmonist.models import (
     titles_match,
 )
 from harmonist.tagger import PicardCompatibleTagger, Tagger, tagsets_for
-from harmonist.web import dir_watcher
+from harmonist.web import dir_watcher, periodic
 from harmonist.web.reconcile_runner import ReconcileRunner, reconcile_pending_orphans
 from harmonist.web.scan_runner import ScanRunner
 from harmonist.web.security import BasicAuthMiddleware, CSRFMiddleware
@@ -191,6 +191,14 @@ _LIBRARY_FILTERS: dict[str, tuple[str, Callable[[Album], bool]]] = {
 # of them — so an unbounded one bloats the whole render. A hundred characters is
 # past any album or artist name; beyond it, someone pasted something.
 _LIBRARY_QUERY_MAX = 100
+
+# How often the library is rescanned regardless of what the file watcher did
+# (#151). A constant, not a setting: it is the period of a backstop nobody
+# should have to reason about, and the two things it protects against — a
+# network mount inotify can't see, a watcher killed by an exhausted watch limit
+# — give the user nothing to tune against. The cost that would justify a knob
+# isn't there either: an unchanged library is a stat per file and no tag reads.
+_RESCAN_INTERVAL = timedelta(hours=1)
 
 # The header that tells `/library` to name the resolved view in the address bar
 # (#180). The search form cannot spell its own `hx-push-url`: it does not know the
@@ -595,7 +603,22 @@ def create_app(
             dir_watcher.watch_music_dir(
                 cfg.paths.music_dir,
                 scan_runner.request_scan,
-                settle_seconds=cfg.library.watch_settle_seconds,
+                settle=timedelta(seconds=cfg.library.watch_settle_seconds),
+                stop_event=watch_stop,
+            )
+        )
+        # And rescan on a timer regardless, as the backstop for a watcher that
+        # isn't working — blind on a network mount (#152), or dead from an
+        # exhausted inotify watch limit. Both are silent, which is the whole
+        # reason this exists; neither is common, which is why it stays out of
+        # sight (#151). It coalesces with the watcher's kick through `_dirty`
+        # rather than competing with it — two kicks are one scan — and a rescan
+        # that finds nothing changed is a stat per file and no tag reads.
+        rescan_task = asyncio.create_task(
+            periodic.run_periodically(
+                _RESCAN_INTERVAL,
+                lambda: _periodic_rescan_if_idle(sync_runner, reconcile_runner, scan_runner),
+                name="library rescan",
                 stop_event=watch_stop,
             )
         )
@@ -604,8 +627,11 @@ def create_app(
         finally:
             watch_stop.set()
             watch_task.cancel()
+            rescan_task.cancel()
             with suppress(asyncio.CancelledError):
                 await watch_task
+            with suppress(asyncio.CancelledError):
+                await rescan_task
 
     app = FastAPI(title="Harmonist", lifespan=lifespan)
     app.state.cfg = cfg
@@ -2017,6 +2043,63 @@ def _albums(request: Request) -> list[Album]:
     if runner.is_engaged():
         return runner.albums()
     return scanner.scan(cfg.paths.music_dir)
+
+
+def _periodic_rescan_if_idle(
+    sync_runner: SyncRunner, reconcile_runner: ReconcileRunner, scan_runner: ScanRunner
+) -> None:
+    """One tick of the hourly library rescan (#151) — unless something else is
+    mid-flight.
+
+    The watcher waits for the music dir to go quiet precisely so it can never
+    scan mid-copy. A timer has no such instinct, and a rescan landing halfway
+    through a sync would read a part-written album directory and hand it to
+    `_announce_discoveries`, which would record Harmonist as having "started
+    tracking" a folder that was still being written — a permanent feed entry
+    about a transient. Reconcile is milder, since sidecar writes are atomic, but
+    it is actively invalidating the snapshot the rescan would build.
+
+    Skipping the tick is enough, and better than deferring it: the next one
+    comes round soon, and both runners request a scan of their own when they
+    finish, so nothing is waiting on this one.
+    """
+    if sync_runner.is_running or reconcile_runner.is_running:
+        log.info("Skipping periodic rescan: sync or reconcile in progress")
+        return
+    scan_runner.request_quiet_rescan()
+
+
+def _refreshed_from_disk(request: Request, album: Album) -> Album:
+    """Re-read this album's directories and return it as it is on disk NOW (#151).
+
+    The album page is where the user decides whether to re-tag, so it is the one
+    page whose reading must not be a snapshot of whenever the last scan ran —
+    and on a network mount the watcher never fires, so "whenever" can be
+    startup. One directory listing and a `stat` per file buys the guarantee.
+
+    Not wired to the inbox or the Library: those render every album, so the same
+    check there would be a walk of the library per page view — which is the
+    hourly rescan's job, on the hourly rescan's cadence.
+
+    When the runner isn't engaged (a TestClient without the lifespan) every
+    request already scans, so there is nothing to refresh.
+
+    The album is re-resolved by DIRECTORY rather than by id, because the reading
+    that just landed may have changed the id — an externally-written sidecar
+    naming a different release, or parts merging into one album (#197). The
+    pre-refresh album is the fallback for the case where the refresh dropped it:
+    saying "not found" about an album the user is looking at, on the strength of
+    one directory read, is the worse answer.
+    """
+    runner: ScanRunner = request.app.state.scan_runner
+    if not runner.is_engaged():
+        return album
+    known = album.paths or (album.path,)
+    runner.refresh_album(known)
+    for a in runner.albums():
+        if any(p in known for p in (a.paths or (a.path,))):
+            return a
+    return album
 
 
 def _find_album(request: Request, album_id: str) -> Album:
@@ -3473,8 +3556,12 @@ def _register_routes(app: FastAPI) -> None:
         Served for a stale id too: `_find_album` resolves one forward through the
         alias chain, so a link written before the album was re-identified still
         lands here rather than 404-ing.
+
+        The album's own directories are re-read before rendering (#151), so what
+        this page shows is what is on disk now — not what the last background
+        scan happened to see, which on a network mount could be startup.
         """
-        album = _find_album(request, album_id)
+        album = _refreshed_from_disk(request, _find_album(request, album_id))
         # The tracklist and actions don't depend on the store, so a broken store
         # must not take the whole page down — but the history section has to say
         # it couldn't read rather than fall through to "Nothing recorded for this

--- a/src/harmonist/web/periodic.py
+++ b/src/harmonist/web/periodic.py
@@ -1,0 +1,85 @@
+"""A background task that fires an action on a fixed interval.
+
+The file watcher only reports changes that pass through the local kernel's VFS,
+so it is blind to a library edited from another machine over NFS/SMB (#152) and
+to its own death — an exhausted inotify watch limit ends the watcher, and from
+then on nothing rescans until a restart. Neither is common; both are silent,
+which is what makes a periodic rescan worth its cost.
+
+Deliberately generic and deliberately dumb. It owns no state, decides nothing
+about what a tick means, and never lets a failing tick end the loop — the whole
+of its job is "call this every N seconds until told to stop". The library
+rescan is its first caller; the metadata gardener's paced MusicBrainz pass
+(#270) is meant to be its second, rather than inventing a second timer pattern
+beside it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from datetime import timedelta
+
+log = logging.getLogger(__name__)
+
+
+async def run_periodically(
+    interval: timedelta,
+    action: Callable[[], object],
+    *,
+    name: str,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Call `action` every `interval` until cancelled or `stop_event` is set.
+    `name` labels the task in the log.
+
+    A `timedelta` rather than a number, so a caller cannot pass the right
+    figure in the wrong unit — the one mistake a bare `interval_seconds: float`
+    invites and cannot catch.
+
+    The first call happens after one full interval, never at startup: whoever
+    engages this has just done the work themselves.
+
+    A non-positive interval raises rather than quietly disabling the task or —
+    much worse — spinning: `wait_for(..., timeout=0)` returns instantly, so a
+    zero would turn this into a busy loop calling `action` as fast as the
+    machine allows. There is no caller for whom that is a legitimate request,
+    so it is a programming error and says so.
+
+    A failing tick is logged and the loop continues. This runs unattended for
+    months on someone's NAS, so a single transient error — an unmounted volume,
+    a moment of EIO — must not silently retire the task and leave it dead for
+    the life of the process.
+
+    But only the FIRST of a run of failures is logged loudly. Anything the
+    `harmonist` logger emits at WARNING or above is mirrored into the user's
+    Activity feed, and a condition that doesn't clear on its own — a volume
+    that stays unmounted — would otherwise write the same line into that feed
+    every interval until someone noticed. One entry per failure *episode* says
+    the same thing; recovery is logged at INFO, which the feed doesn't mirror.
+    """
+    if interval <= timedelta(0):
+        raise ValueError(f"periodic {name}: interval must be positive, got {interval}")
+    seconds = interval.total_seconds()
+    stop = stop_event if stop_event is not None else asyncio.Event()
+    log.info("Periodic %s every %s", name, interval)
+    failures = 0
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=seconds)
+            return  # stop_event set — shutting down
+        except TimeoutError:
+            pass  # the interval elapsed: that IS the tick
+        try:
+            action()
+        except Exception:
+            failures += 1
+            if failures == 1:
+                log.exception("Periodic %s failed; continuing", name)
+            else:
+                log.debug("Periodic %s failed again (%d in a row)", name, failures)
+        else:
+            if failures:
+                log.info("Periodic %s recovered after %d failure(s)", name, failures)
+            failures = 0

--- a/src/harmonist/web/scan_runner.py
+++ b/src/harmonist/web/scan_runner.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -51,10 +52,16 @@ class ScanStatus:
     started_at: datetime | None = None
     finished_at: datetime | None = None
     last_error: str | None = None
-    # Monotonic count of completed scans. The client watches this to know a
-    # fresh snapshot exists and refresh the inbox — robust even when a scan is
-    # so fast (mtime-cache hit) that it starts AND finishes between two status
-    # polls, which the old scanning→done state edge would miss.
+    # Monotonic count of scans that produced a DIFFERENT snapshot. The client
+    # watches this to know a fresh snapshot exists and refresh the inbox —
+    # robust even when a scan is so fast (mtime-cache hit) that it starts AND
+    # finishes between two status polls, which the old scanning→done state edge
+    # would miss.
+    #
+    # Different, not merely completed: since #151 the library is rescanned
+    # hourly whether or not anything happened, and a counter that ticked on
+    # every one of those would re-render the inbox every hour over an
+    # unchanged library.
     seq: int = 0
 
     def to_dict(self) -> dict[str, Any]:
@@ -80,12 +87,33 @@ class ScanRunner:
         self._music_dir = music_dir
         self._cache: scanner.AlbumCache = {}
         self._albums: list[Album] = []
+        # The per-DIRECTORY entries `_albums` was folded from. Retained because
+        # `merge_by_identity` is one-way: a merged Album no longer knows which of
+        # its parts came from which directory, so refreshing ONE album (#151)
+        # would otherwise have to re-walk the whole library to rebuild the rest.
+        self._scanned: list[scanner.ScannedDir] = []
+        # Guards the read-modify-write of that pair. Everything else on the
+        # runner is either loop-thread-only or a single GIL-atomic assignment,
+        # but `refresh_album` reads `_scanned`, rebuilds it and publishes both —
+        # from FastAPI's threadpool, while a background scan may be about to
+        # publish its own. Held only for pure-CPU work over data already read.
+        self._snapshot_lock = threading.Lock()
         self._completed_once = False
         self._scan_seq = 0  # monotonic; stamped onto status at each completion
         self._status = ScanStatus()
         self._loop: asyncio.AbstractEventLoop | None = None
         self._task: asyncio.Task[None] | None = None
         self._dirty = True  # a (re)scan is wanted
+        # Whether the wanted scan should ADVERTISE itself. A scan somebody asked
+        # for — a mutation, the watcher, startup — dims and locks the inbox while
+        # it runs, so a click can't land on a snapshot being rebuilt. The
+        # hourly rescan (#151) asked nobody, and locking the inbox on its own
+        # schedule, possibly mid-click, is not something it has earned. So it runs
+        # invisibly: same scan, no status.
+        self._visible = True  # the startup scan is very much visible
+        # The in-flight scan's status object, so a real trigger arriving during
+        # a quiet rescan can promote it mid-flight (see `_kick`).
+        self._current: ScanStatus | None = None
         # Fired once, after the FIRST scan completes — used to kick reconcile
         # backend-side so it runs without waiting for the frontend /tasks poll.
         self._on_first_complete: Callable[[], object] | None = None
@@ -156,9 +184,99 @@ class ScanRunner:
         `request.state.skip_rescan = True`, so the album resolves in one render
         instead of via the async post-mutation rescan — whose 'scanning' status
         dims the inbox (the #11 flicker). Safe from a worker thread: the cache is
-        shared safely (see `scan_now`) and the `_albums` assignment is GIL-atomic."""
-        self._albums = self.scan_now()
+        shared safely (see `scan_now`) and the `_albums` assignment is GIL-atomic.
+
+        Deliberately does NOT reset `live_counts` / `library_index` — a caller
+        that moved an album between states has already told `live_counts` about
+        it, and the full rescan is what re-derives them. This only patches the
+        snapshot."""
+        self._publish(scanner.scan_dirs(self._music_dir, album_cache=self._cache))
         self._completed_once = True
+
+    def refresh_album(self, dirs: Sequence[Path]) -> None:
+        """Re-read just these directories from disk and patch the snapshot (#151).
+
+        The album page's guarantee, made unconditional: what you are looking at
+        is what is on disk right now, whatever the watcher did or didn't see.
+        That matters most exactly there, because the album page is where the
+        user decides whether to re-tag — and deciding that against a stale
+        reading is the failure that costs something.
+
+        Cost is one directory listing plus a `stat` per file. On a signature hit
+        that is the whole of it: `resolve_dir` returns the cached Album and reads
+        no tags. `refresh_now` is NOT an alternative here — it walks the entire
+        library, which is cheap after a mutation and not cheap per page view on
+        a NAS, which is the case this exists for.
+
+        Blocking I/O, so call it from a worker thread (a sync route handler),
+        never the event loop. Only the directories named are re-read: an album
+        gaining a WHOLE NEW directory (a second disc dropped in elsewhere) is
+        beyond what one album's paths can find, and stays the hourly rescan's job.
+
+        A directory that can no longer be read is left as it was — a network
+        mount blinking must not delete albums from the snapshot. One that reads
+        fine but no longer resolves (its audio is gone, its sidecar is corrupt)
+        is dropped, which is what a full scan would have concluded about it too.
+        """
+        known = {e.album.path for e in self._scanned}
+        if not known:
+            return  # nothing to patch: no scan has produced a snapshot yet
+        fresh: dict[Path, scanner.ScannedDir | None] = {}
+        for d in dirs:
+            if d not in known:
+                # Only ever REPLACES entries the last scan produced. Reading a
+                # directory the snapshot has never heard of would put it in the
+                # mtime cache without ever putting it in the snapshot.
+                continue
+            try:
+                contents = scanner.read_dir(d)
+            except OSError as e:
+                # Debug, not warning: WARNING+ is mirrored into the Activity
+                # feed, and this fires once per album-page view — a flaky mount
+                # would fill the feed with a condition that costs the user
+                # nothing, since the entry it couldn't refresh is kept and the
+                # page renders. The hourly rescan is what reports a real problem.
+                log.debug("could not re-read %s: %s", d, e)
+                continue  # leave the existing entry alone
+            if contents is None:
+                fresh[d] = None  # readable, but no audio left in it
+                continue
+            fresh[d] = scanner.resolve_dir(
+                d, contents.files, contents.videos, contents.signature, self._cache
+            )
+        if not fresh:
+            return
+        with self._snapshot_lock:
+            rebuilt: list[scanner.ScannedDir] = []
+            for entry in self._scanned:
+                if entry.album.path not in fresh:
+                    rebuilt.append(entry)
+                    continue
+                replacement = fresh[entry.album.path]
+                if replacement is not None:
+                    rebuilt.append(replacement)
+                else:
+                    self._cache.pop(entry.album.path, None)
+            self._publish_locked(rebuilt)
+
+    def _publish(self, scanned: list[scanner.ScannedDir]) -> tuple[list[Album], bool]:
+        with self._snapshot_lock:
+            return self._publish_locked(scanned)
+
+    def _publish_locked(self, scanned: list[scanner.ScannedDir]) -> tuple[list[Album], bool]:
+        """Fold the per-directory entries into albums and publish both, so the
+        two never disagree. Caller holds `_snapshot_lock`. Also answers whether
+        the snapshot actually CHANGED, which is what the client's refresh hangs
+        off since the hourly rescan started producing identical ones.
+
+        The comparison is cheap in the case that matters: an unchanged directory
+        is served from the mtime cache as the very same `Album` object, and list
+        equality short-circuits on identity per element."""
+        results = scanner.merge_by_identity(scanned)
+        changed = results != self._albums
+        self._scanned = scanned
+        self._albums = results
+        return results, changed
 
     def status(self) -> dict[str, Any]:
         return self._status.to_dict()
@@ -172,6 +290,22 @@ class ScanRunner:
         shuts down — a sync/reconcile thread finishing its last pass during
         teardown must not die with 'Event loop is closed' (issue #52)."""
         self._kick_threadsafe(self._kick)
+
+    def request_quiet_rescan(self) -> None:
+        """Like `request_scan`, but for a rescan NOBODY asked for — the hourly
+        one (#151).
+
+        Identical work, deliberately without the status: the inbox busy-lock
+        exists so a click can't land on a snapshot being rebuilt by something
+        the user set in motion, and applying it hourly on a timer would dim and
+        freeze the inbox under someone's cursor for no reason they could see.
+        A backstop for a watcher that isn't working should be invisible when the
+        watcher is.
+
+        A real trigger arriving mid-rescan promotes the scan in flight, so the
+        lock appears exactly when there IS something to protect. Thread-safe;
+        no-op until engaged."""
+        self._kick_threadsafe(self._kick_quiet)
 
     def reset_and_rescan(self) -> None:
         """Drop the current snapshot, then kick a fresh scan. Used after a nuke
@@ -199,12 +333,31 @@ class ScanRunner:
     def _reset_and_kick(self) -> None:
         # On the loop thread: clear the snapshot before the scan task starts so a
         # /tasks render in between sees an empty inbox + (imminent) scanning.
-        self._albums = []
+        # The retained per-directory entries go with it — leaving them would let
+        # a per-album refresh in the gap republish the snapshot just cleared.
+        with self._snapshot_lock:
+            self._scanned = []
+            self._albums = []
         self._kick()
 
     def _kick(self) -> None:
         # Always runs in the event loop thread.
         self._dirty = True
+        self._visible = True
+        # A real trigger during a quiet rescan promotes the scan in flight,
+        # rather than leaving it invisible until the next pass: from here on
+        # there IS something the inbox lock is protecting.
+        if self._current is not None and self._status is not self._current:
+            self._current.state = "scanning"
+            self._status = self._current
+        self._start()
+
+    def _kick_quiet(self) -> None:
+        # A quiet rescan: wanted, but it must not claim the status if nothing else has.
+        self._dirty = True
+        self._start()
+
+    def _start(self) -> None:
         if self._task is None or self._task.done():
             assert self._loop is not None
             self._task = self._loop.create_task(self._run())
@@ -215,24 +368,36 @@ class ScanRunner:
         # Coalesce: if more changes land while scanning, scan again after.
         while self._dirty:
             self._dirty = False
+            # Claim the visibility this pass was asked for, so a trigger landing
+            # DURING it makes the next pass visible rather than being lost.
+            visible = self._visible
+            self._visible = False
             try:
-                await self._scan_once()
+                await self._scan_once(visible=visible)
             except Exception as e:  # never let the task die silently
                 log.exception("library scan failed")
                 self._status.state = "idle"
                 self._status.last_error = str(e)
+            finally:
+                self._current = None
 
-    async def _scan_once(self) -> None:
+    async def _scan_once(self, *, visible: bool) -> None:
         loop = asyncio.get_running_loop()
         executor = self._executor
         assert executor is not None  # set in attach_loop before any scan
 
         started = time.monotonic()
-        log.info("Library scan started: %s", self._music_dir)
+        log.info("Library %s started: %s", "scan" if visible else "rescan", self._music_dir)
         # Carry the last completed seq while scanning; bump it only on completion
         # so the client refreshes when a NEW snapshot is actually ready.
         status = ScanStatus(state="scanning", started_at=datetime.now(UTC), seq=self._scan_seq)
-        self._status = status
+        # An invisible rescan still builds a status — the progress counters below
+        # are written unconditionally — it just never publishes it. `_current`
+        # is how `_kick` reaches in and promotes this scan if a real trigger
+        # arrives while it runs.
+        self._current = status
+        if visible:
+            self._status = status
         # One entry per DIRECTORY. Identity grouping (#197) happens once at the
         # end, over data already read — the walk and the cache stay per-directory
         # so that costs no extra I/O, and progress still counts directories,
@@ -280,9 +445,10 @@ class ScanRunner:
         scanner.prune_cache(self._cache, {e.album.path for e in scanned})
         # Fold the directories that hold parts of one release into single albums.
         # Pure CPU over tags already read, so it stays on the loop thread.
-        results = scanner.merge_by_identity(scanned)
+        # Under the lock so it can't interleave with a per-album refresh
+        # rebuilding the same pair from the threadpool (#151).
+        results, changed = self._publish(scanned)
         status.albums_found = len(results)
-        self._albums = results
         self._announce_discoveries(results)
         # Reset the authoritative live counts from this fresh snapshot — the
         # self-healing baseline that transitions (live_counts.move) adjust between
@@ -291,21 +457,37 @@ class ScanRunner:
         # Same self-healing baseline for the sidecar/dedup index — rebuilt from the
         # fresh snapshot, then kept current by sidecar writes between scans.
         library_index.reset_from(results)
+        first = not self._completed_once
         self._completed_once = True
-        self._scan_seq += 1
+        # Only a scan that produced a DIFFERENT snapshot advances the counter the
+        # client refreshes off. An hourly rescan over an unchanged library must
+        # leave the inbox alone entirely — it has nothing to say.
+        if changed:
+            self._scan_seq += 1
         status.seq = self._scan_seq
         status.state = "done"
         status.finished_at = datetime.now(UTC)
+        if self._status is not status and changed:
+            # An invisible rescan, never promoted: its status was never published,
+            # and must not be now — but the client still has to learn a new
+            # snapshot exists, or what the rescan found would sit unread until
+            # something else happened to trigger a scan.
+            self._status.seq = self._scan_seq
         log.info(
-            "Library scan complete: %d albums across %d dirs in %.1fs",
+            "Library %s complete: %d albums across %d dirs in %.1fs%s",
+            "scan" if visible else "rescan",
             len(results),
             status.dirs_scanned,
             time.monotonic() - started,
+            "" if changed else " (no change)",
         )
         # Kick reconcile once the first snapshot is ready (backend-side, so it
         # runs even with no browser open). Only on the first scan — later scans
         # are covered by the /tasks kick, and re-firing here would churn.
-        if self._scan_seq == 1 and self._on_first_complete is not None:
+        # Keyed on the FIRST completion rather than on the seq counter, which no
+        # longer moves for a scan that found nothing: on an empty library that
+        # would leave reconcile never kicked at all.
+        if first and self._on_first_complete is not None:
             try:
                 self._on_first_complete()
             except Exception:

--- a/test/test_dir_watcher.py
+++ b/test/test_dir_watcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
+from datetime import timedelta
 
 from harmonist.web.dir_watcher import watch_music_dir
 
@@ -23,7 +24,9 @@ def test_watcher_rescans_after_change(tmp_path):
 
     async def go() -> None:
         task = asyncio.create_task(
-            watch_music_dir(music, lambda: calls.append(1), settle_seconds=0.2, stop_event=stop)
+            watch_music_dir(
+                music, lambda: calls.append(1), settle=timedelta(seconds=0.2), stop_event=stop
+            )
         )
         await asyncio.sleep(0.3)  # let awatch start watching
         (music / "Artist").mkdir()
@@ -47,7 +50,9 @@ def test_watcher_coalesces_a_burst_into_one_rescan(tmp_path):
 
     async def go() -> None:
         task = asyncio.create_task(
-            watch_music_dir(music, lambda: calls.append(1), settle_seconds=0.4, stop_event=stop)
+            watch_music_dir(
+                music, lambda: calls.append(1), settle=timedelta(seconds=0.4), stop_event=stop
+            )
         )
         await asyncio.sleep(0.3)
         # A burst of writes well within the settle window.
@@ -71,7 +76,7 @@ def test_watcher_no_op_when_dir_missing(tmp_path):
     async def go() -> None:
         # Returns immediately (not a directory) without scheduling anything.
         await watch_music_dir(
-            tmp_path / "does-not-exist", lambda: calls.append(1), settle_seconds=0.1
+            tmp_path / "does-not-exist", lambda: calls.append(1), settle=timedelta(seconds=0.1)
         )
 
     asyncio.run(go())

--- a/test/test_identity_grouping.py
+++ b/test/test_identity_grouping.py
@@ -470,3 +470,39 @@ def test_tagging_only_the_primary_folder_is_what_files_prevents(tmp_path):
 
     with pytest.raises(tagger.TagMismatchError):
         tagger.tag_album(album.path, _two_disc_release())
+
+
+def test_refreshing_one_folder_of_a_two_folder_album_keeps_it_whole(tmp_path):
+    """Re-reading ONE directory of a merged album (#151) must re-fold it with
+    the parts it wasn't asked about, not leave a half-album behind.
+
+    This is the reason the scan runner retains its per-directory entries at all:
+    `merge_by_identity` is one-way, so a merged Album can't say which of its
+    files came from which folder, and a refresh with only the merged snapshot to
+    work from would have to re-walk the library to put the other disc back."""
+    import asyncio
+
+    from harmonist.web.scan_runner import ScanRunner
+
+    disc1 = _part(tmp_path / "Hybrid" / "Wide Angle", track_ids=DISC1)
+    _part(tmp_path / "Hybrid" / "Live Angle", track_ids=DISC2)
+    runner = ScanRunner(tmp_path)
+
+    async def go() -> None:
+        runner.attach_loop()
+        for _ in range(300):
+            if runner.has_completed():
+                break
+            await asyncio.sleep(0.01)
+
+    asyncio.run(go())
+    assert len(runner.albums()) == 1
+
+    # A third track lands in disc 1, outside Harmonist.
+    _part(disc1, track_ids=[*DISC1, "rt-009"], tracks=3, album="Wide Angle")
+    runner.refresh_album([disc1])
+
+    albums = runner.albums()
+    assert len(albums) == 1, "the refreshed part came back as an album of its own"
+    assert albums[0].track_count == 5
+    assert {p.name for p in albums[0].paths} == {"Wide Angle", "Live Angle"}

--- a/test/test_periodic.py
+++ b/test/test_periodic.py
@@ -1,0 +1,108 @@
+"""The interval task behind the hourly library rescan (web/periodic.py).
+
+Its whole job is "call this every N seconds until told to stop", and what
+matters is what a NAS running unattended for months depends on: a tick that
+raises does not silently retire the loop, and a loop that keeps failing does
+not keep saying so.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+
+import pytest
+
+from harmonist.web.periodic import run_periodically
+
+
+def test_a_non_positive_interval_raises_rather_than_spinning():
+    """`wait_for(..., timeout=0)` returns instantly, so a zero interval would
+    turn this into a busy loop calling the action as fast as the machine
+    allows. No caller legitimately wants that, so it is a programming error and
+    must say so rather than quietly becoming a no-op or a spin."""
+    calls: list[int] = []
+
+    async def go() -> None:
+        await asyncio.wait_for(
+            run_periodically(timedelta(0), lambda: calls.append(1), name="test"), timeout=1
+        )
+
+    with pytest.raises(ValueError, match="must be positive"):
+        asyncio.run(go())
+    assert calls == []
+
+
+def test_fires_on_the_interval_until_stopped():
+    """Ticks repeat, and setting the stop event ends the loop rather than
+    leaving a task the lifespan has to cancel out from under a running action."""
+    stop = asyncio.Event()
+    calls: list[int] = []
+
+    def tick() -> None:
+        calls.append(1)
+        if len(calls) == 3:
+            stop.set()
+
+    async def go() -> None:
+        await asyncio.wait_for(
+            run_periodically(timedelta(seconds=0.01), tick, name="test", stop_event=stop), timeout=5
+        )
+
+    asyncio.run(go())
+    assert len(calls) == 3
+
+
+def test_a_failing_tick_does_not_end_the_loop():
+    """One transient failure — an unmounted volume, a moment of EIO — must not
+    retire the rescan, or the library stays stale until the next restart."""
+    stop = asyncio.Event()
+    calls: list[int] = []
+
+    def tick() -> None:
+        calls.append(1)
+        if len(calls) == 3:
+            stop.set()
+            return
+        raise OSError("volume went away")
+
+    async def go() -> None:
+        await asyncio.wait_for(
+            run_periodically(timedelta(seconds=0.01), tick, name="test", stop_event=stop), timeout=5
+        )
+
+    asyncio.run(go())
+    assert len(calls) == 3  # it kept going after two raising ticks
+
+
+def test_a_persistent_failure_is_reported_once_not_every_tick(caplog):
+    """WARNING+ on the `harmonist` logger is mirrored into the user's Activity
+    feed, so a condition that doesn't clear on its own — an unmounted volume —
+    must not post an identical entry there every interval until someone
+    notices. One entry per failure episode; recovery says so at INFO, which the
+    feed doesn't mirror."""
+    caplog.set_level("DEBUG", logger="harmonist.web.periodic")
+    stop = asyncio.Event()
+    calls: list[int] = []
+
+    def tick() -> None:
+        calls.append(1)
+        if len(calls) == 4:
+            stop.set()
+            return  # the fourth tick succeeds
+        raise OSError("volume went away")
+
+    async def go() -> None:
+        await asyncio.wait_for(
+            run_periodically(timedelta(seconds=0.01), tick, name="test", stop_event=stop), timeout=5
+        )
+
+    asyncio.run(go())
+    # Filtered by logger: once an app has been built in this process, the
+    # activity mirror is attached to `harmonist` and re-logs every WARNING it
+    # sees — which is the very behaviour this test exists to keep quiet.
+    mine = [r for r in caplog.records if r.name == "harmonist.web.periodic"]
+    loud = [r for r in mine if r.levelno >= logging.WARNING]
+    assert len(loud) == 1, [r.message for r in loud]
+    assert any("recovered after 3" in r.message for r in mine)

--- a/test/test_scan_runner.py
+++ b/test/test_scan_runner.py
@@ -19,6 +19,16 @@ def _album(root: Path, name: str) -> Path:
     return d
 
 
+async def _scan_to_completion(runner: ScanRunner) -> None:
+    """Kick a scan in-loop and await the task itself, so "it finished" is
+    certain rather than inferred from a status that a completed scan may no
+    longer touch (see the seq test)."""
+    runner._kick()
+    task = runner._task
+    assert task is not None
+    await task
+
+
 async def _wait(predicate, *, timeout_ticks: int = 300) -> None:
     for _ in range(timeout_ticks):
         if predicate():
@@ -133,9 +143,15 @@ def test_scan_runner_scans_and_reports(tmp_path):
     assert status["dirs_scanned"] >= 2
 
 
-def test_scan_runner_seq_increments_each_completed_scan(tmp_path):
-    """The completed-scan counter advances on every scan — the signal the
-    client uses to refresh even when a scan is too fast to observe mid-flight."""
+def test_scan_seq_advances_for_a_new_snapshot_and_not_for_an_identical_one(tmp_path):
+    """The counter is the client's "a fresh snapshot exists" signal, and it is
+    keyed on the snapshot being *different*, not on a scan having finished.
+
+    A scan too fast to observe mid-flight still advances it — that is why the
+    client watches the counter rather than the scanning→done edge. But the
+    library is now swept hourly whether or not anything happened (#151), and a
+    counter that ticked on every one of those would re-render the inbox every
+    hour over a library nobody touched."""
     music = tmp_path / "music"
     _album(music, "A")
     runner = ScanRunner(music)
@@ -145,11 +161,22 @@ def test_scan_runner_seq_increments_each_completed_scan(tmp_path):
         await _wait(runner.has_completed)
         first = runner.status()["seq"]
         assert first >= 1
-        runner.request_scan()  # even with no disk change, a scan still completes
-        await _wait(lambda: runner.status()["seq"] > first)
+
+        # Nothing on disk changed: the scan runs to completion, and the counter
+        # must not move. Kicked in-loop and awaited directly rather than polled,
+        # so "it finished" is certain — the completion this asserts about is
+        # deliberately no longer observable through the status.
+        await _scan_to_completion(runner)
+        assert runner.status()["state"] == "done"  # it really did run
+        assert runner.status()["seq"] == first
+
+        # A new album is a new snapshot, so it does.
+        _album(music, "B")
+        await _scan_to_completion(runner)
 
     asyncio.run(go())
-    assert runner.status()["seq"] >= 2
+    assert runner.status()["seq"] == 2
+    assert len(runner.albums()) == 2
 
 
 def test_scan_runner_fires_on_first_complete_once(tmp_path):
@@ -340,3 +367,88 @@ def test_the_discovery_entry_carries_its_albums_as_what_changed(tmp_path):
     detail = activity_store.audit_by_action([entry.action_id])[entry.action_id]
     assert len(detail) == 2  # one line per album, not one entry per album
     assert all(r.message.startswith(activity_store.DISCOVERY_EVENT) for r in detail)
+
+
+# ---------------------------------------------------------------------------
+# Refreshing ONE album from disk (#151)
+# ---------------------------------------------------------------------------
+
+
+def _add_track(album_dir: Path, name: str = "02 Another.m4a") -> None:
+    shutil.copy(SINE_M4A, album_dir / name)
+
+
+def test_refresh_album_picks_up_a_change_without_walking_the_library(tmp_path):
+    """The album page's guarantee: what you are looking at is what is on disk
+    now. A track added outside Harmonist — no watcher event, no scan — shows up
+    on the refreshed album.
+
+    And ONLY that album is re-read: a second album added at the same time stays
+    invisible, which is what makes this affordable per page view on a NAS. A
+    refresh that quietly re-walked the library would find it."""
+    music = tmp_path / "music"
+    a = _album(music, "A")
+    runner = ScanRunner(music)
+
+    async def go() -> None:
+        runner.attach_loop()
+        await _wait(runner.has_completed)
+
+    asyncio.run(go())
+    assert [x.track_count for x in runner.albums()] == [1]
+    seq_before = runner.status()["seq"]
+
+    _add_track(a)
+    _album(music, "B")  # arrives at the same time, in a directory we don't name
+    runner.refresh_album([a])
+
+    assert {x.path.name: x.track_count for x in runner.albums()} == {"A": 2}
+    assert runner.status()["seq"] == seq_before  # no scan was run to do it
+
+
+def test_refresh_album_drops_an_album_whose_audio_has_gone(tmp_path):
+    """A directory that reads fine but holds no audio any more is dropped — the
+    same conclusion a full scan would reach about it."""
+    music = tmp_path / "music"
+    a = _album(music, "A")
+    _album(music, "B")
+    runner = ScanRunner(music)
+
+    async def go() -> None:
+        runner.attach_loop()
+        await _wait(runner.has_completed)
+
+    asyncio.run(go())
+    assert len(runner.albums()) == 2
+
+    for f in a.glob("*.m4a"):
+        f.unlink()
+    runner.refresh_album([a])
+
+    assert {x.path.name for x in runner.albums()} == {"B"}
+    assert runner.cache_size() == 1  # its cache entry went with it
+
+
+def test_refresh_album_leaves_an_unreadable_directory_alone(tmp_path, monkeypatch):
+    """A network mount blinking is not evidence that an album is gone. When the
+    directory can't be read at all, the snapshot keeps what it had — the
+    alternative is albums vanishing from the library over a transient EIO."""
+    from harmonist import scanner as scanner_mod
+
+    music = tmp_path / "music"
+    a = _album(music, "A")
+    runner = ScanRunner(music)
+
+    async def go() -> None:
+        runner.attach_loop()
+        await _wait(runner.has_completed)
+
+    asyncio.run(go())
+
+    def boom(album_dir, names=None):
+        raise OSError("stale NFS file handle")
+
+    monkeypatch.setattr(scanner_mod, "read_dir", boom)
+    runner.refresh_album([a])
+
+    assert {x.path.name for x in runner.albums()} == {"A"}

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -506,6 +506,41 @@ def test_scan_skips_album_with_invalid_sidecar(tmp_path, caplog):
     assert bad_dir not in paths
 
 
+def test_the_same_broken_album_is_only_complained_about_once(tmp_path, caplog):
+    """A skipped album is invisible in the UI, so the warning is the only sign
+    it exists — but WARNING+ is mirrored into the Activity feed, and since #151
+    the library is scanned hourly whether or not anything happened. Saying it
+    every time would post the same entry to the feed forever.
+
+    Changing the directory and leaving it broken IS a new fact, though ("I tried
+    to fix it and it's still wrong"), so that speaks up again."""
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger="harmonist.scanner")
+    bad_dir = _make_album_dir(tmp_path, "Bad", "Album")
+    sc.sidecar_path(bad_dir).write_text('{"schema_version": 99}', encoding="utf-8")
+
+    def warnings() -> list[str]:
+        # Filtered by logger: once an app has been built in this process, the
+        # activity mirror is attached to `harmonist` and re-logs every WARNING
+        # it sees — which is the very behaviour this test exists to keep quiet.
+        return [
+            r.message
+            for r in caplog.records
+            if r.name == "harmonist.scanner" and r.levelno >= logging.WARNING
+        ]
+
+    scan(tmp_path)
+    scan(tmp_path)
+    scan(tmp_path)
+    assert len(warnings()) == 1, warnings()
+
+    # Edited, still broken → it is worth saying again.
+    sc.sidecar_path(bad_dir).write_text('{"schema_version": 98}', encoding="utf-8")
+    scan(tmp_path)
+    assert len(warnings()) == 2, warnings()
+
+
 # ---------- per-album mtime cache (opt-in) ----------
 
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -12,8 +12,9 @@ import shutil
 import zipfile
 from collections.abc import Sequence
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any, cast
 from unittest import mock
 
 import pytest
@@ -23,7 +24,14 @@ from mutagen.mp4 import MP4
 from harmonist import activity, activity_store, mb_lookup
 from harmonist import sidecar as sc
 from harmonist.activity_store import Level
-from harmonist.config import BandcampConfig, Config, PathsConfig, ServerConfig, TestConfig
+from harmonist.config import (
+    BandcampConfig,
+    Config,
+    LibraryConfig,
+    PathsConfig,
+    ServerConfig,
+    TestConfig,
+)
 from harmonist.models import BandcampInfo, MatchCandidate, Sidecar, TrackComparison
 from harmonist.tagger import (
     ATOM_ALBUM,
@@ -5216,6 +5224,137 @@ def test_engaged_lifespan_serves_background_scan_snapshot(cfg):
         assert reconcile["state"] == "idle" and reconcile["finished_at"] is not None
         # /tasks serves the snapshot the background scan produced.
         assert "BgAlbum" in client.get("/tasks").text
+
+
+def test_a_periodic_rescan_is_skipped_while_a_sync_or_reconcile_is_running():
+    """The watcher waits for the music dir to go quiet so it can never scan
+    mid-copy; a timer has no such instinct. A rescan landing halfway through a
+    sync would read a part-written album directory and record Harmonist as
+    having "started tracking" a folder that was still being written — a
+    permanent Activity entry about a transient."""
+    from harmonist.web.main import _periodic_rescan_if_idle
+
+    class _Runner:
+        def __init__(self, running: bool) -> None:
+            self.is_running = running
+
+    class _Scan:
+        def __init__(self) -> None:
+            self.rescans = 0
+
+        def request_quiet_rescan(self) -> None:
+            self.rescans += 1
+
+    idle, busy = _Runner(False), _Runner(True)
+    scan = _Scan()
+
+    def tick(sync, reconcile) -> None:
+        _periodic_rescan_if_idle(cast("Any", sync), cast("Any", reconcile), cast("Any", scan))
+
+    tick(idle, idle)
+    assert scan.rescans == 1  # the ordinary case: nothing else is happening
+
+    tick(busy, idle)  # sync running
+    tick(idle, busy)  # reconcile running
+    tick(busy, busy)
+    assert scan.rescans == 1
+
+
+def test_an_album_that_appears_on_disk_is_picked_up_without_being_announced(cfg, monkeypatch):
+    """An album dropped into the library with nothing in the app asking for a
+    scan (#151) — no click, no mutation, no watcher event — turns up in the
+    inbox anyway. On a network mount, where inotify delivers nothing at all
+    (#152), the timer is the only thing that ever will.
+
+    And it does so INVISIBLY: the rescan never reports "scanning", because that
+    status dims the inbox and turns off pointer events until the scan finishes.
+    A lock the user set in motion is protection; one that arrives hourly on a
+    timer, under their cursor, is not.
+
+    The settle delay is absurdly high so that even if the watcher did see the
+    new folder, its rescan could not land inside the test — what happens here
+    can only be the periodic rescan's doing."""
+    import time as _time
+
+    import harmonist.web.main as main_mod
+
+    # The real interval is an hour and deliberately not configurable, so the
+    # test shortens the constant rather than a setting.
+    monkeypatch.setattr(main_mod, "_RESCAN_INTERVAL", timedelta(seconds=0.05))
+    cfg.library = LibraryConfig(watch_settle_seconds=1000)
+    _make_album(cfg, "Present")
+
+    with TestClient(create_app(cfg), headers={"HX-Request": "true"}) as client:
+        # Wait for startup to go quiet first — the reconcile pass kicked at the
+        # end of the first scan requests a scan of its own, and mistaking that
+        # for the periodic one would pass this test with none running at all.
+        for _ in range(200):
+            scan = client.get("/scan/status").json()
+            reconcile = client.get("/reconcile/status").json()
+            if scan["state"] == "done" and reconcile["finished_at"] is not None:
+                break
+            _time.sleep(0.02)
+        first = client.get("/scan/status").json()["seq"]
+        assert first >= 1
+        assert "Arrived" not in client.get("/tasks").text
+
+        before = client.get("/scan/status").json()
+
+        _make_album(cfg, "Arrived")
+
+        for _ in range(250):
+            if client.get("/scan/status").json()["seq"] > first:
+                break
+            _time.sleep(0.02)
+        after = client.get("/scan/status").json()
+        assert after["seq"] > first
+        assert "Arrived" in client.get("/tasks").text
+
+        # Nothing about the rescan reached the status EXCEPT the counter saying a
+        # new snapshot exists. Asserted as "the whole status is otherwise
+        # untouched" rather than "state was never 'scanning'": a rescan that took
+        # the status would hold it for milliseconds here, so polling for the
+        # word could miss it and the assertion would be unable to fail. A
+        # published status leaves its marks — a fresh started_at, its own
+        # progress counters — and this compares all of them at once.
+        assert {k: v for k, v in after.items() if k != "seq"} == {
+            k: v for k, v in before.items() if k != "seq"
+        }
+
+
+def test_album_page_re_reads_the_album_from_disk(cfg, monkeypatch):
+    """The album page shows what is on disk NOW, not what the last scan saw
+    (#151). This is the page where the user decides whether to re-tag, and on a
+    network mount the watcher never fires — so without the per-album refresh
+    that decision can be made against a reading taken at startup.
+
+    The watcher is muzzled for the duration (`request_scan` no-ops), so nothing
+    but the refresh itself can explain the new reading — and the scan sequence
+    is asserted unchanged to say so a second way."""
+    import time as _time
+
+    from harmonist.web.scan_runner import ScanRunner
+
+    d = _make_album(cfg, "Refreshed")
+    monkeypatch.setattr(ScanRunner, "request_scan", lambda self: None)
+
+    with TestClient(create_app(cfg), headers={"HX-Request": "true"}) as client:
+        for _ in range(200):
+            if client.get("/scan/status").json()["state"] == "done":
+                break
+            _time.sleep(0.02)
+        album_id = _id_for(cfg, d)  # after create_app: it sets the registry root
+        seq = client.get("/scan/status").json()["seq"]
+        assert "Refreshed" in client.get(f"/album/{album_id}").text
+
+        # The album title is corrected in Picard — the exact case #151 names.
+        audio = MP4(d / "01 Track.m4a")
+        audio["\xa9alb"] = ["Corrected In Picard"]
+        audio.save()
+
+        page = client.get(f"/album/{album_id}").text
+        assert "Corrected In Picard" in page
+        assert client.get("/scan/status").json()["seq"] == seq  # no scan ran
 
 
 def test_app_attribute_is_memoized(monkeypatch):


### PR DESCRIPTION
Every scan today is event-driven — the file watcher, the rescan-after-mutation middleware, an explicit trigger. Nothing ever goes and looks. That's fine while the watcher works; the trouble is that when it doesn't, it doesn't say so. inotify reports only changes that pass through the local kernel's VFS, so a library the *container* mounts over NFS or SMB never generates an event at all, and a watcher killed by an exhausted watch limit simply stops, with nothing rescanning until a restart. Neither is common. Both are silent, which is what makes them worth covering.

## An hourly rescan

A timer in the lifespan beside the watcher (`web/periodic.run_periodically`, deliberately generic so #270's paced MusicBrainz pass can share it rather than inventing a second timer). It coalesces with the watcher through the existing `_dirty` flag, and an unchanged library costs a `stat` per file with no tag reads — cheap enough that **the interval is a constant, not a setting**: the failures it covers are ones the user can't observe and has nothing to trade off against.

It's a backstop, so it behaves like one:

- **No status.** The *Scanning* pill and the inbox busy-lock exist so a click can't land on a snapshot being rebuilt by something the user set in motion. Arriving hourly under their cursor, that isn't protection — it's the inbox freezing. A real trigger mid-rescan **promotes** the scan in flight, so the lock appears when there's finally something to protect.
- **The refresh counter advances only on a genuinely different snapshot**, so an untouched library is never re-rendered to show what was already there.
- **It skips while a sync or reconcile is running.** The watcher waits for the directory to go quiet precisely so it can't scan mid-copy; a timer has no such instinct, and a rescan landing mid-download would record Harmonist as having "started tracking" a folder that was still being written.

## A per-album refresh on the album page

The album page re-reads its own album's directories before rendering. That's where the user decides whether to re-tag, and deciding it against a stale reading is the failure that costs something. One directory listing and a `stat` per file, no tags on a signature hit — affordable per page view in a way a full library walk isn't, which is why it doesn't just call `refresh_now()`.

Doing that without re-walking the library means the runner retains the per-directory `ScannedDir` entries it used to discard: `merge_by_identity` is one-way, so a merged Album can't say which files came from which folder. Snapshot and entries are published together under one lock so they can't disagree, and a directory that can't be read at all keeps what it had — a mount blinking isn't evidence an album is gone.

## Noise

Running hourly turns anything repetitive into a permanent fixture, and WARNING+ is mirrored into the Activity feed. So: the timer reports only the first of a run of failures (recovery at INFO); the scanner complains about a directory it can't build only when that directory has *changed* since the last complaint, so "I tried to fix it and it's still wrong" is still news while "still broken, untouched" isn't; and a per-album refresh that can't read its directory says so at debug, since it keeps what it had and the page renders regardless.

## Not here

The MusicBrainz half of the issue — re-checking releases on a cadence, and filing a deleted release to Needs MBID unattended — is deferred. At 1 req/sec it's bounded by library size rather than by a constant, which review-gate item 6 rules out without a staleness threshold and a per-pass cap to go with it. That design belongs with #270, which already plans to share this timer.

## Testing

13 new tests, every one mutation-checked red. Two initially survived their mutation and were rewritten: the sync/reconcile guard was untested, and the "never says scanning" assertion couldn't fail because a fast rescan is unobservable by polling — it now compares the whole status object instead.

`make check` green locally (1362 passed).

Fixes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)