### PR TITLE
Say how significant a MusicBrainz change is, separately from who decides it

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -902,6 +902,28 @@ The `Owned` member values are exactly the `TagSet` attribute names, and a test a
 
 **Artwork is deliberately not in the set.** Embedded cover art is not a tag here — `tagger.tag_album` passes `cover=None` when the tracks carry differing per-track images precisely so `write_tags` leaves them alone, and clearing artwork with the owned set would make that protection a no-op. Per-track artwork is a third category that fits neither scope, which neither MusicBrainz nor Picard really models; it is handled in the tagger. See #131.
 
+### How significant a change is, and whether it needs review
+
+`Owned` is split a second way, by **significance**: what kind of change this is (#267). Deliberately *not* whether it needs a person — those are two questions, and an earlier draft answered them with one word. A change can be slight and still want an eye on it; a change can be far-reaching and still be one a particular user is happy to have applied for them. Significance is a property of the change. Review is a **policy over** significance.
+
+The levels, ordered by how much of the album they call into question:
+
+- **Cosmetic** — whitespace or casing only; the same value spelled differently. Never declared for a field, only ever reached at runtime (see below).
+- **Enrichment** — MusicBrainz filling in or correcting a detail: `album_artist_sort`, `artist_sort`, `mb_album_status`, `mb_album_country`, `date`, `original_date`, `script`, `label`, `catalog_number`, `barcode`, `asin`, `disc_subtitle`, `media`, `isrcs`.
+- **Structure** — the same album, laid out differently: `track_num`, `track_total`, `disc_num`, `disc_total`.
+- **Identity** — what the album or one of its tracks *is*: `album`, `album_artist`, `artist`, `artists`, `title`, `mb_album_type`, and every MusicBrainz id.
+- **Artwork** — the cover image. Its own level rather than a rank among the others, because "let it update my cover art" is a trust decision people make separately from anything about tags.
+
+`SIGNIFICANCE` lives beside `SCOPE` in `owned.py` and is keyed exactly as a tagging diff is keyed — the `Owned` values plus `ARTWORK` — so a classifier iterating a plan's changes needs no special case for the one key that isn't an owned field. A totality test over that vocabulary is the point of the placement: **a field added to `Owned` later cannot slip through unclassified**, because the test fails until someone places it. The cost of forgetting `SCOPE` is a mis-rendered history row; the cost of forgetting this is a change whose significance nothing can state, in the table a trust setting is read through.
+
+**Every level currently goes to review.** `AUTO_APPLY` is empty and `needs_review` is true for everything. That is deliberate rather than unfinished: nothing has watched this classification run against a real library, and the way to find out whether `mb_album_type` really belongs under Identity is to see it arrive in the Inbox, not to argue it out in advance. Starting closed also means the first cut of the runner cannot write anything unattended, whatever else is wrong with it. `AUTO_APPLY` is the seam #273 turns into a setting: a user who trusts Enrichment gets that level in the set, and everything else keeps going to review.
+
+**No identifier is classified below Identity**, including the ones that can only have moved because MusicBrainz merged the entity behind them. The cheaper reading — the one §5's merge rule takes for the *release* id, that a merge has already happened so there is nothing to authorise — was considered and not taken. That rule rests on the merge being **provable**, and it is, exactly once, at the fetch, where the redirect names both the old id and the new. An id that simply arrives different inside an unchanged release payload carries no such evidence: it could be a merge, a re-point, or an edit that replaced the track outright, and nothing downstream can tell those apart.
+
+**One field's significance depends on its values.** `title` should read as cosmetic for a spacing or casing tidy-up and as identity for a real retitle, which no single table entry can say. `models.norm_title` — collapse whitespace, casefold — already draws exactly that line for `TrackComparison.title_differs`, so the classifier borrows it rather than inventing a second notion of cosmetic: a title the album page reports as unchanged must not be one the gardener treats as a retitle. Such fields are **declared at their higher significance and lowered** when the values turn out to differ trivially, never raised — overstating a change costs a glance, while understating a retitle as a spacing fix is, under a trust setting, a write nobody agreed to.
+
+**Identity is settled upstream of significance.** The diff the classifier reads must be computed against the release the album is *now known to be*, not the one it was last recorded as. A merged release arrives as a changed `mb_album_id`, and §5 settles that a merge always applies and is never held for review — so that correction belongs at the fetch, and by the time a diff reaches the classifier, `mb_album_id` moving means the album is being re-pointed at a genuinely different release.
+
 ### Recording what a tagging changed
 
 Every tagging records its per-field before/after, so an album's History can say `artist: Boards Of Canada → Boards of Canada` rather than just "this track was rewritten" (#86). The record is complete rather than filtered: Harmonist only writes fields it owns, so "everything we wrote" is already bounded, and noise control belongs in the rendering rather than in what gets kept.

--- a/src/harmonist/formats/owned.py
+++ b/src/harmonist/formats/owned.py
@@ -139,12 +139,160 @@ SCOPE: dict[Owned, Scope] = {
 ALBUM_FIELDS: tuple[Owned, ...] = tuple(f for f in Owned if SCOPE[f] is Scope.ALBUM)
 TRACK_FIELDS: tuple[Owned, ...] = tuple(f for f in Owned if SCOPE[f] is Scope.TRACK)
 
+
 #: Key under which a tagging records an artwork change, alongside the owned
 #: fields but deliberately NOT one of them — see the module docstring. Named
 #: here so the writer and the renderer can't drift on the spelling, and kept
 #: distinct from every `Owned` value so a reader iterating `Owned` skips it
 #: rather than trying to render a sha256 as a tag.
 ARTWORK = "artwork"
+
+
+class Significance(StrEnum):
+    """What KIND of change this is — deliberately *not* whether it needs review.
+
+    Those are two different questions and an earlier draft of this enum answered
+    them with one word, which was wrong: a change can be slight and still want a
+    person's eye, and a change can be far-reaching and still be one a particular
+    user is happy to have applied for them. Significance is a property of the
+    change; review is a policy over significance, and it belongs in `AUTO_APPLY`
+    below so #273 has somewhere to attach a per-level trust setting.
+
+    The levels are ordered by how much of the album they call into question, and
+    that ordering is the only thing a trust setting needs to be intelligible:
+    someone who trusts `STRUCTURE` almost certainly trusts `ENRICHMENT` too.
+    """
+
+    #: Whitespace or casing only — the same value, spelled differently. Never
+    #: declared in `SIGNIFICANCE`; only ever reached at runtime by a `BY_VALUE`
+    #: field whose two values turn out to differ this little.
+    COSMETIC = "cosmetic"
+    #: MusicBrainz filling in or correcting a detail — a catalogue number it
+    #: didn't have, a date narrowed from a year to a day. Nothing about what the
+    #: album is, or how it is laid out, moves.
+    ENRICHMENT = "enrichment"
+    #: How the album is laid out: track and disc numbers and totals. The album is
+    #: still the same album; which track is which has changed.
+    STRUCTURE = "structure"
+    #: What the album or one of its tracks IS — its name, its artist, or any of
+    #: the MusicBrainz ids that say which entity it points at.
+    IDENTITY = "identity"
+    #: The cover image. Its own level rather than a rank among the others,
+    #: because "let it update my cover art" is a trust decision people make
+    #: separately from anything about tags.
+    COVER_ART = "artwork"
+
+
+#: What kind of change each key of a tagging diff represents, keyed exactly as
+#: `diff` keys its result — the `Owned` values plus `ARTWORK`. Keyed by string
+#: for that reason: a classifier iterates a plan's changes, and artwork arrives
+#: in them under a key that is deliberately not an owned field. One lookup table
+#: for the whole diff means no caller has to remember which key is the exception.
+#:
+#: Placed here, beside `SCOPE`, so the totality test can hold: a field added to
+#: `Owned` later **cannot** slip through unclassified, because
+#: `test_every_owned_field_has_a_significance` fails until someone places it.
+#: That is the same discipline that keeps the three format backends in step, and
+#: it matters more here — the cost of forgetting `SCOPE` is a mis-rendered
+#: history row, the cost of forgetting this one is a change whose significance
+#: nothing can state, in the table a trust setting will be read through.
+SIGNIFICANCE: dict[str, Significance] = {
+    # --- Enrichment: MusicBrainz filling in or correcting a detail ---
+    Owned.ALBUM_ARTIST_SORT: Significance.ENRICHMENT,
+    Owned.ARTIST_SORT: Significance.ENRICHMENT,
+    Owned.MB_ALBUM_STATUS: Significance.ENRICHMENT,
+    Owned.MB_ALBUM_COUNTRY: Significance.ENRICHMENT,
+    Owned.DATE: Significance.ENRICHMENT,
+    Owned.ORIGINAL_DATE: Significance.ENRICHMENT,
+    Owned.SCRIPT: Significance.ENRICHMENT,
+    Owned.LABEL: Significance.ENRICHMENT,
+    Owned.CATALOG_NUMBER: Significance.ENRICHMENT,
+    Owned.BARCODE: Significance.ENRICHMENT,
+    Owned.ASIN: Significance.ENRICHMENT,
+    Owned.DISC_SUBTITLE: Significance.ENRICHMENT,
+    Owned.MEDIA: Significance.ENRICHMENT,
+    Owned.ISRCS: Significance.ENRICHMENT,
+    # --- Identity: what the album, or one of its tracks, IS ---
+    Owned.ALBUM: Significance.IDENTITY,
+    Owned.ALBUM_ARTIST: Significance.IDENTITY,
+    Owned.ARTIST: Significance.IDENTITY,
+    Owned.ARTISTS: Significance.IDENTITY,
+    # Identity even though it reads like a descriptor: MusicBrainz re-typing a
+    # release group from Album to EP is it saying this is a different sort of
+    # thing from what Harmonist recorded. The debatable one of this group — it
+    # would not be absurd as ENRICHMENT, and watching it in the Inbox is how
+    # that gets decided rather than by argument here.
+    Owned.MB_ALBUM_TYPE: Significance.IDENTITY,
+    # Every MusicBrainz id, including the ones that can only have moved because
+    # MusicBrainz merged the entity behind them. The cheaper reading — "a merge
+    # already happened, so there is nothing to authorise", which is what #268
+    # settled for the RELEASE id — was considered and not taken: that decision
+    # rests on the merge being *provable*, and it is, exactly once, at the fetch,
+    # where a redirect names both ids. An id that simply arrives different inside
+    # an unchanged release payload carries no such evidence. It is a merge, a
+    # re-point, or a MusicBrainz edit that replaced the track, and nothing here
+    # can tell those apart.
+    Owned.MB_ALBUM_ID: Significance.IDENTITY,
+    Owned.MB_RELEASE_GROUP_ID: Significance.IDENTITY,
+    Owned.MB_ALBUM_ARTIST_IDS: Significance.IDENTITY,
+    Owned.MB_ARTIST_IDS: Significance.IDENTITY,
+    Owned.MB_TRACK_ID: Significance.IDENTITY,
+    Owned.MB_RELEASE_TRACK_ID: Significance.IDENTITY,
+    # Identity by default, and the one field that can be less than that — see
+    # BY_VALUE below.
+    Owned.TITLE: Significance.IDENTITY,
+    # --- Structure: the same album, laid out differently ---
+    Owned.TRACK_NUM: Significance.STRUCTURE,
+    Owned.TRACK_TOTAL: Significance.STRUCTURE,
+    Owned.DISC_NUM: Significance.STRUCTURE,
+    Owned.DISC_TOTAL: Significance.STRUCTURE,
+    # --- Artwork ---
+    ARTWORK: Significance.COVER_ART,
+}
+
+#: Levels whose changes may be applied without asking anyone.
+#:
+#: **Empty, deliberately.** Every change goes to review, whatever its
+#: significance, because nothing has yet watched this classification run against
+#: a real library — and the way to find out whether `mb_album_type` really
+#: belongs under IDENTITY is to see it arrive in the Inbox, not to argue about
+#: it here. Starting closed also means the first version of #32's runner cannot
+#: write anything unattended, whatever else is wrong with it.
+#:
+#: This is the seam #273 turns into a setting: a user who trusts ENRICHMENT gets
+#: that level in this set, and everything else keeps going to review. Widening
+#: it is a decision about somebody's files, so it does not happen by a default
+#: drifting — `test_no_level_applies_itself_yet` fails if this set gains a
+#: member without that being the point of the change.
+AUTO_APPLY: frozenset[Significance] = frozenset()
+
+
+def needs_review(significance: Significance) -> bool:
+    """Whether a change of this kind has to be shown to a person first.
+
+    The policy over the classification, kept apart from it so the two can move
+    independently: significance describes the change and is a property of
+    MusicBrainz's data, while this describes how much a particular user trusts
+    Harmonist and is a property of their configuration (#273).
+    """
+    return significance not in AUTO_APPLY
+
+
+#: Fields whose significance cannot be given at field level, because it depends
+#: on how far the value actually moved. Only `title` so far: MusicBrainz tidying
+#: the spacing or casing of a track title is COSMETIC, and renaming the track is
+#: IDENTITY, and one entry in the table cannot say both.
+#:
+#: These are declared at their HIGHER significance and lowered when the values
+#: turn out to differ trivially — never raised. That direction is deliberate: a
+#: rule that fails to fire overstates a change, which costs a glance, while one
+#: that fires wrongly understates a retitle as a spacing fix, and under a trust
+#: setting that is a write nobody agreed to.
+#:
+#: The comparison itself lives with the caller (`tagger.significance_of`), which
+#: is where `models.norm_title` — the definition of "cosmetic" the album page
+#: already uses — can be imported without this module reaching upwards for it.
+BY_VALUE: frozenset[Owned] = frozenset({Owned.TITLE})
 
 
 def _absent(value: object) -> bool:

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -96,11 +96,22 @@ class BandcampInfo:
     candidate_item_ids: list[int] | None = None
 
 
-def _norm_title(s: str) -> str:
+def norm_title(s: str) -> str:
     """Light normalisation for comparing a disk title against an MB title:
     collapse whitespace and casefold. Deliberately *not* the aggressive
     `_norm_*` used for matching — here we want to surface real differences, so
-    only cosmetic noise (spacing, case) is ignored."""
+    only cosmetic noise (spacing, case) is ignored.
+
+    Public because it draws the line between a cosmetic title change and a real
+    one in two places now: `TrackComparison.title_differs`, and the significance
+    classifier (#267), which auto-applies a spacing or casing tidy-up and holds
+    a genuine retitle. Those two must agree — a title the album page reports as
+    unchanged is not one the gardener may treat as a retitle — so they share the
+    definition rather than each having a notion of "cosmetic".
+
+    Not to be confused with `bandcamp_hook._norm_title`, which is the aggressive
+    matching normaliser and deliberately answers a different question.
+    """
     return " ".join(s.split()).casefold()
 
 
@@ -127,7 +138,7 @@ class TrackComparison:
         not a metadata discrepancy, so it returns False. Derived, never stored."""
         if not self.file_title or not self.mb_track_title:
             return False
-        return _norm_title(self.file_title) != _norm_title(self.mb_track_title)
+        return norm_title(self.file_title) != norm_title(self.mb_track_title)
 
 
 @dataclass

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -64,7 +64,7 @@ from .formats.m4a import (  # noqa: F401 — back-compat re-exports
     ATOM_TRACK_NUM,
     LEGACY_RELEASE_ID,
 )
-from .models import Release, Track
+from .models import Release, Track, norm_title
 
 log = logging.getLogger(__name__)
 
@@ -338,6 +338,59 @@ class AlbumPlan:
     def empty(self) -> bool:
         """True when a re-tag would write no owned field on any file."""
         return not self.changes
+
+
+def significance_of(field: str, before: Any, after: Any) -> owned.Significance:
+    """What kind of change this one entry of a tagging diff is (#267).
+
+    `field` is a key from an `AlbumPlan`'s changes — an `owned.Owned` value or
+    `owned.ARTWORK` — and `before`/`after` are that entry's two values. The
+    field-level classification comes from `owned.SIGNIFICANCE`; this adds the one
+    rule that cannot be given at field level.
+
+    It says what the change IS, not what to do about it. Whether it needs a
+    person is `owned.needs_review`, which is policy over this answer rather than
+    part of it — today every level goes to review regardless, and #273 makes
+    that a setting.
+
+    **Identity is settled upstream of significance.** The diff handed to this
+    must have been computed against the release the album is *now known to be*,
+    not the one it was last recorded as. MusicBrainz redirects a merged MBID, so
+    a merge arrives as a changed `mb_album_id` — and #268 settled that a merge
+    always applies and is never held for review, there being nothing to
+    authorise once MusicBrainz has already done it. That correction belongs at
+    the fetch, where the redirect names both ids and the merge is provable. By
+    the time a diff reaches here, `mb_album_id` moving means the album is being
+    re-pointed at a genuinely different release, which is exactly the case its
+    REVIEW verdict is for. See `docs/design.md` §5.
+
+    Raises `KeyError` for a key that is neither owned nor artwork, rather than
+    guessing. A plan cannot produce one, and inventing a default here is how a
+    field would quietly acquire a significance nobody gave it — which, once
+    #273 lets a level be trusted, is how it would acquire permission to write
+    itself.
+    """
+    declared = owned.SIGNIFICANCE[field]
+    if field in owned.BY_VALUE and _only_cosmetically_different(before, after):
+        return owned.Significance.COSMETIC
+    return declared
+
+
+def _only_cosmetically_different(before: Any, after: Any) -> bool:
+    """Whether two values of a BY_VALUE field differ only in spacing or casing.
+
+    `models.norm_title` is the definition, borrowed rather than restated: it is
+    what `TrackComparison.title_differs` uses to decide whether the album page
+    shows a title as differing at all, and the two must agree. A title the page
+    reports as unchanged is not one the gardener may treat as a retitle.
+
+    Anything that isn't a pair of strings is not cosmetic — a field arriving or
+    disappearing is a real change, and the safe direction here is to fall
+    through to the higher significance the map already gave.
+    """
+    if not isinstance(before, str) or not isinstance(after, str):
+        return False
+    return norm_title(before) == norm_title(after)
 
 
 @dataclass(frozen=True)

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -739,6 +739,95 @@ def test_every_owned_field_has_a_scope():
     assert not set(ALBUM_FIELDS) & set(TRACK_FIELDS)
 
 
+def test_every_owned_field_has_a_significance():
+    """A field added to `Owned` cannot default into applying itself unattended.
+
+    This is the guard, and it is the whole reason the map lives beside `SCOPE`
+    rather than in the gardener that reads it: adding a field to `Owned` without
+    classifying it fails here, at the point of adding, rather than silently
+    inheriting whatever the classifier does with an unknown key. The cost of
+    forgetting `SCOPE` is a mis-rendered history row; the cost of forgetting this
+    one is an unattended write nobody authorised (#267).
+
+    Keyed over the whole diff vocabulary, not just `Owned`: `ARTWORK` is a key a
+    plan really produces, so leaving it out would be a hole exactly where the map
+    is supposed to be total.
+    """
+    from harmonist.formats.owned import ARTWORK, BY_VALUE, SIGNIFICANCE, Owned
+
+    assert set(SIGNIFICANCE) == {f.value for f in Owned} | {ARTWORK}
+    assert BY_VALUE <= set(Owned)
+
+
+def test_a_value_sensitive_field_is_declared_at_its_higher_significance():
+    """The runtime adjustment only ever lowers.
+
+    A `BY_VALUE` field is declared IDENTITY and *lowered* to COSMETIC when the
+    values turn out to differ trivially. Declared the other way round, the rule
+    failing to fire would understate a real retitle as a spacing fix — and once
+    #273 lets a level be trusted, understating is what writes something nobody
+    agreed to. Overstating only ever costs a glance.
+    """
+    from harmonist.formats.owned import BY_VALUE, SIGNIFICANCE, Significance
+
+    assert BY_VALUE
+    for field in BY_VALUE:
+        assert SIGNIFICANCE[field] is Significance.IDENTITY
+
+
+def test_cosmetic_is_never_declared_only_derived():
+    """COSMETIC describes a pair of values, not a field.
+
+    No field is inherently cosmetic — `title` is only cosmetic on the occasions
+    its two values differ by whitespace or casing. A field declared COSMETIC in
+    the table would be one claiming that of every change it could ever carry.
+    """
+    from harmonist.formats.owned import SIGNIFICANCE, Significance
+
+    assert Significance.COSMETIC not in SIGNIFICANCE.values()
+
+
+def test_no_level_applies_itself_yet():
+    """Every change goes to review, whatever its significance.
+
+    Deliberate, and the reason it is asserted rather than merely true: nothing
+    has watched this classification run against a real library yet, so the way to
+    find out whether the table is right is to see its verdicts arrive in the
+    Inbox. Starting closed also means the first cut of #32's runner cannot write
+    anything unattended, whatever else is wrong with it.
+
+    #273 turns `AUTO_APPLY` into a setting. Until it does, a member appearing
+    here is a decision about somebody's files, so it should be the point of the
+    change that adds it rather than a default that drifted.
+    """
+    from harmonist.formats.owned import AUTO_APPLY, Significance, needs_review
+
+    assert AUTO_APPLY == frozenset()
+    for level in Significance:
+        assert needs_review(level), level
+
+
+def test_no_identifier_is_classified_below_identity():
+    """Every MusicBrainz id is IDENTITY, including ones that only move on a merge.
+
+    Stated as a rule rather than left implicit in a list of thirty entries: an id
+    changing is the album being re-pointed at something else, and the one case
+    where that is settled rather than proposed — a merged release, which arrives
+    as a redirect naming both ids — is corrected at the fetch and never reaches
+    the classifier as a question (#268, `docs/design.md` §5).
+    """
+    from harmonist.formats.owned import SIGNIFICANCE, Owned, Significance
+
+    # By suffix, not by the `mb_` prefix: `mb_album_status` and
+    # `mb_album_country` are MusicBrainz's words for a release, not identifiers,
+    # and they ARE enrichment. The count is pinned so a filter that silently
+    # stopped selecting anything would fail here rather than pass vacuously.
+    ids = [f for f in Owned if f.value.endswith(("_id", "_ids"))]
+    assert len(ids) == 6
+    for field in ids:
+        assert SIGNIFICANCE[field] is Significance.IDENTITY, field
+
+
 @pytest.mark.parametrize(
     ("module_name", "table"),
     [

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -1358,3 +1358,124 @@ def test_retag_still_clears_a_legacy_atom_on_an_otherwise_unchanged_file(album_w
     tagger.tag_album(album_dir, _single_track_release())
 
     assert LEGACY_RELEASE_ID not in MP4(f)
+
+
+# ---------- which changes may apply unattended (#267) ----------
+
+
+def test_a_detail_musicbrainz_filled_in_is_enrichment():
+    """Nothing about what the album is, or how it is laid out, moves."""
+    assert (
+        tagger.significance_of("catalog_number", None, "CAT-001") is owned.Significance.ENRICHMENT
+    )
+    assert tagger.significance_of("isrcs", [], ["GBTEST2100001"]) is owned.Significance.ENRICHMENT
+    assert tagger.significance_of("date", "2021", "2021-06-15") is owned.Significance.ENRICHMENT
+
+
+def test_what_the_album_is_reads_as_identity():
+    for field, was, now in [
+        ("album", "Geogaddi", "Geogaddi (Remastered)"),
+        ("album_artist", "Boards Of Canada", "Boards of Canada"),
+        ("mb_album_id", "rel-aaa", "rel-bbb"),
+        ("mb_track_id", "rec-001", "rec-999"),
+    ]:
+        assert tagger.significance_of(field, was, now) is owned.Significance.IDENTITY, field
+
+
+def test_how_the_album_is_laid_out_reads_as_structure():
+    """The same album, renumbered — distinct from the album becoming a different
+    album, which is what separating the two levels is for."""
+    for field, was, now in [
+        ("track_num", 3, 4),
+        ("track_total", 12, 13),
+        ("disc_num", 1, 2),
+        ("disc_total", 1, 2),
+    ]:
+        assert tagger.significance_of(field, was, now) is owned.Significance.STRUCTURE, field
+
+
+def test_a_title_tidy_up_is_cosmetic_but_a_retitle_is_identity():
+    """The one classification a field-level map cannot give.
+
+    Whitespace and casing are the line `models.norm_title` already draws, and the
+    album page draws it in the same place — a title it reports as unchanged must
+    not be one the gardener treats as a retitle.
+    """
+    assert (
+        tagger.significance_of("title", "Dawn  Chorus", "Dawn Chorus")
+        is owned.Significance.COSMETIC
+    )
+    assert (
+        tagger.significance_of("title", "DAWN CHORUS", "Dawn Chorus") is owned.Significance.COSMETIC
+    )
+    assert (
+        tagger.significance_of("title", "Dawn Chorus", "Dawn Chorus (Alt. Take)")
+        is owned.Significance.IDENTITY
+    )
+
+
+def test_a_title_arriving_or_leaving_is_not_cosmetic():
+    """A field appearing or vanishing is a real change however the strings would
+    have normalised, so it falls through to the REVIEW the map already gave."""
+    assert tagger.significance_of("title", None, "Dawn Chorus") is owned.Significance.IDENTITY
+    assert tagger.significance_of("title", "Dawn Chorus", None) is owned.Significance.IDENTITY
+
+
+def test_artwork_is_its_own_level():
+    """Artwork arrives in a plan's changes under a key that is deliberately not
+    an owned field, and it still has to be classified — `owned.ARTWORK` is in the
+    table so the classifier can't meet a key it has no answer for.
+
+    Its own level rather than a rank among the others because "let it update my
+    cover art" is a trust decision people make separately from anything about
+    tags, and #273's setting is per level.
+    """
+    assert tagger.significance_of(owned.ARTWORK, "sha-a", "sha-b") is owned.Significance.COVER_ART
+
+
+def test_an_unknown_key_is_refused_rather_than_guessed():
+    """No default. A plan cannot produce a key outside the map, and inventing one
+    here is how a field would quietly acquire a significance nobody gave it —
+    which is the failure the totality test exists to prevent, defeated at the
+    reader instead of at the map."""
+    with pytest.raises(KeyError):
+        tagger.significance_of("genre", None, "Ambient")
+
+
+def test_every_change_reaching_the_runner_still_goes_to_review():
+    """The policy today, asserted through the pair of calls the runner will make.
+
+    `significance_of` says what a change is; `needs_review` says what to do about
+    it, and for now the answer is the same for every level. Asserted here as well
+    as over the enum because this is the shape #270 will actually use, and the
+    two halves being separable is the whole point of the correction that split
+    them (#273 attaches a per-level setting to the second one).
+    """
+    for field, was, now in [
+        ("catalog_number", None, "CAT-001"),
+        ("title", "Dawn  Chorus", "Dawn Chorus"),
+        ("album", "A", "B"),
+        ("track_num", 1, 2),
+        (owned.ARTWORK, "sha-a", "sha-b"),
+    ]:
+        assert owned.needs_review(tagger.significance_of(field, was, now)), field
+
+
+def test_every_change_a_real_plan_produces_can_be_classified(album_with_tracks, tmp_path):
+    """The map and the diff must agree about the vocabulary they share.
+
+    The totality test asserts that over `Owned` as declared; this asserts it over
+    what a tagging actually emits, which is the thing the runner will iterate. A
+    plan that produced a key the map had never heard of would pass the first test
+    and raise in production (#270).
+    """
+    album_dir = album_with_tracks(2)
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(_minimal_jpeg())
+
+    plan = tagger.plan_album(album_dir, _release_2_tracks(), cover_path=cover)
+
+    seen = {f for changes in plan.changes.values() for f in changes}
+    assert owned.ARTWORK in seen  # the key most likely to be forgotten
+    for field in seen:
+        assert isinstance(tagger.significance_of(field, None, "x"), owned.Significance)


### PR DESCRIPTION
The classifier #32 needs, and the primitive #270's runner, #271's review surface and #273's setting are all built on.

## Two questions, not one

The issue described this as two buckets, *enrichment* and *review*. That reads as a classification and is really a verdict, and the two don't line up: a change can be slight and still want an eye on it, and a change can be far-reaching and still be one a particular user is happy to have applied for them. Fused into one word there is nowhere for a trust setting to attach, and #273 would have had to unpick it before it could add one.

**`Significance` says what kind of change it is.** `COSMETIC`, `ENRICHMENT`, `STRUCTURE`, `IDENTITY`, `COVER_ART` — ordered by how much of the album they call into question, which is the only property a trust setting needs to be intelligible, since someone who trusts structure almost certainly trusts enrichment. The issue's single *Review* bucket was internally two different things, and splitting them is exactly what a setting will want: renumbering an album is not the album becoming a different album. Artwork is a level of its own rather than a rank among the others, because "let it update my cover art" is a decision people make separately from anything about tags.

**`owned.needs_review(significance)` says whether a person has to see it**, over `AUTO_APPLY`, which is an empty frozenset. Every level goes to review today. That is a position rather than an unfinished edge: nothing has watched this classification run against a real library, so the way to find out whether `mb_album_type` really belongs under Identity is to see it arrive in the Inbox, not to argue it out in advance. It also means #270's first cut cannot write anything unattended whatever else is wrong with it. `test_no_level_applies_itself_yet` asserts the set is empty, so widening it has to be the point of a change rather than a default that drifted. #273 is where it becomes a setting — commented there.

## Totality is the point of the placement

`SIGNIFICANCE` lives beside `SCOPE` in `owned.py` so a field added to `Owned` later **cannot slip through unclassified** — the test fails until someone places it. Keyed by string rather than by `Owned`, and covering `ARTWORK`, because it is keyed exactly as `diff` keys its result: a classifier walking a plan's changes then has one table for the whole vocabulary and no caller has to remember which key is the exception. A map total over `Owned` alone would have left a hole precisely where totality is the point.

There are two totality tests, deliberately. One asserts it over `Owned` as declared; the other classifies every key a **real** plan emits. Those can diverge, and only the second would catch a plan producing a key the map had never heard of.

## Three decisions worth reading

**No identifier is classified below Identity**, including ones that can only have moved because MusicBrainz merged the entity behind them. The cheaper reading was available and is deliberately not taken: #268 lets a merged *release* id apply unasked, and it earns that by the merge being **provable** — exactly once, at the fetch, where the redirect names both ids. An id that simply arrives different inside an unchanged release payload carries no such evidence; merge, re-point and an edit that replaced the track outright look identical from there.

**`mb_album_type`, `mb_track_id` and `mb_artist_ids`** were in neither of the issue's lists. All three are Identity. `mb_album_type` is the shakiest of the thirty placements and the map says so — it would not be absurd as Enrichment, and watching it arrive in the Inbox is how that gets settled.

**The value-sensitive rule only ever lowers.** `title` is declared Identity and lowered to Cosmetic when `models.norm_title` (whitespace + casefold, now public) says the values differ trivially — never raised. Overstating a change costs a glance; understating a retitle as a spacing fix is, once a level is trusted, a write nobody agreed to. A test pins the direction, because it reads fine backwards.

## Notes

- **Review-gate item 3, same exception as #266**: nothing in production reads this yet. It is the primitive the issue asks for ahead of its consumers.
- No changelog entry — nothing reads it, so nothing changes for a user.
- `docs/design.md` §5 gains "How significant a change is, and whether it needs review".
- Five mutation checks on the reworked tests, all red on the intended assertions.

Fixes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)