### PR TITLE
Stop calling Picard's album title a mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- An album title carrying the **release disambiguation** — what Picard writes
+  with its "use disambiguation comment in album title" option on, e.g.
+  `Selected Ambient Works, Volume II (expanded edition)` — no longer reads as
+  differing from MusicBrainz (#283).
 - When MusicBrainz has **merged** the release an album names into another one,
   tagging now follows the surviving release and says so in the album's
   **History** (#268), naming both releases. Previously the album silently

--- a/docs/design.md
+++ b/docs/design.md
@@ -902,6 +902,16 @@ The `Owned` member values are exactly the `TagSet` attribute names, and a test a
 
 **Artwork is deliberately not in the set.** Embedded cover art is not a tag here — `tagger.tag_album` passes `cover=None` when the tracks carry differing per-track images precisely so `write_tags` leaves them alone, and clearing artwork with the owned set would make that protection a no-op. Per-track artwork is a third category that fits neither scope, which neither MusicBrainz nor Picard really models; it is handled in the tagger. See #131.
 
+### A second correct spelling of the album title
+
+Picard has an option to append the release's **disambiguation comment** to the album title, so a library tagged with it on carries `Selected Ambient Works, Volume II (expanded edition)` where MusicBrainz's release title is `Selected Ambient Works, Volume II`. That is the same album by the user's own deliberate setting, and reporting it as a difference costs more than a wrong row on the album page: `album` would differ on *every* pass forever, so the write-skip above could never fire on those albums and the classifier's Identity verdict would put the whole library in the Inbox on the gardener's first night (#283).
+
+So both places that judge a disk title against MusicBrainz's accept it: `compare.album_fields` for the album panel, and the tagging diff for the write-skip. The accepted spelling is built by `models.title_with_disambiguation` from the release already in hand, which costs no extra MusicBrainz request — `disambiguation` is a core field on the release entity.
+
+**Exactly one string, never a pattern.** `models.titles_match` would accept this pair too, and would accept `(deluxe edition)` and `(2019 remaster)` just as readily, since it judges on words alone. That latitude is earned where it is used, inside an artist-scoped and uniqueness-guarded purchase match. Here the release *states* its disambiguation, so accepting anything looser would be guessing an identity that was available for free — which review-gate item 2 forbids. Picard applies several other title transforms besides this one; recognising them is #284, and it is a survey of what is exactly checkable rather than a loosening of this rule.
+
+**Only the comparison is tolerant, not the write.** A re-tag that happens for some other reason still puts MusicBrainz's plain title on the file. Harmonist writes what MusicBrainz says; preserving a spelling it did not derive is a different question, and it is the one that needs a setting to match Picard's — deferred until someone wants it. The consequence is worth naming: on an album where nothing else has changed the disambiguated title survives indefinitely, and on one where something else has changed it does not.
+
 ### How significant a change is, and whether it needs review
 
 `Owned` is split a second way, by **significance**: what kind of change this is (#267). Deliberately *not* whether it needs a person — those are two questions, and an earlier draft answered them with one word. A change can be slight and still want an eye on it; a change can be far-reaching and still be one a particular user is happy to have applied for them. Significance is a property of the change. Review is a **policy over** significance.

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -283,12 +283,23 @@ def compare_value(
     mb: str | None = None,
     unreadable: bool = False,
     tracks: Consensus | None = None,
+    also_matches: str | None = None,
 ) -> FieldComparison:
     """Compare one on-disk value against one MusicBrainz value.
 
     The core of the model. A per-track field has exactly one on-disk value, so
     this is what the tracklist uses directly; `compare_field` wraps it for the
     album panel, where the on-disk value is a consensus across the tracks.
+
+    `also_matches` is a second on-disk spelling that counts as agreement — one
+    exact string, never a pattern. It exists because a field can have more than
+    one correct form on disk: Picard writes an album title with the release
+    disambiguation appended when told to, and that is the same album (#283).
+
+    This module stays deliberately free of runtime imports, so it is told the
+    accepted spelling rather than deriving it; what makes a second spelling
+    legitimate is MusicBrainz's business, and `models.title_with_disambiguation`
+    is where that knowledge lives.
     """
     if unreadable:
         return FieldComparison(label, kind, Agreement.UNREADABLE, mb=mb, consensus=tracks)
@@ -298,7 +309,7 @@ def compare_value(
         return FieldComparison(label, kind, Agreement.ONLY_MB, mb=mb, consensus=tracks)
     if mb is None:
         return FieldComparison(label, kind, Agreement.ONLY_DISK, disk=disk, consensus=tracks)
-    if disk == mb:
+    if disk == mb or disk == also_matches:
         return FieldComparison(label, kind, Agreement.MATCHES, disk=disk, mb=mb, consensus=tracks)
     disk_runs, mb_runs = diff_runs(disk, mb)
     return FieldComparison(
@@ -320,6 +331,7 @@ def compare_field(
     disk: Consensus | None = None,
     mb: str | None = None,
     unreadable: bool = False,
+    also_matches: str | None = None,
 ) -> FieldComparison:
     """Build one row of the ALBUM panel.
 
@@ -338,6 +350,7 @@ def compare_field(
         mb=mb,
         unreadable=unreadable,
         tracks=disk,
+        also_matches=also_matches,
     )
 
 
@@ -361,9 +374,17 @@ _ALBUM_FIELDS: tuple[tuple[str, str, str | None, Kind], ...] = (
 )
 
 
+#: The one album field with a second legitimate on-disk spelling — see
+#: `album_fields`. Named rather than inlined so the special case is visible from
+#: the table above rather than buried in the loop.
+_ALIASED_FIELD = "album"
+
+
 def album_fields(
     tracks: Sequence[tuple[str, TrackTags]],
     mb: TagSet | None,
+    *,
+    album_title_alias: str | None = None,
 ) -> tuple[FieldComparison, ...]:
     """Compare an album's per-track tags against what tagging would write.
 
@@ -375,6 +396,11 @@ def album_fields(
     identical across tracks. None when there's no MusicBrainz release to compare
     against, which leaves every field ONLY_DISK rather than pretending MB
     disagrees.
+
+    `album_title_alias` is a second album title that counts as agreement —
+    Picard's disambiguated spelling, built by `models.title_with_disambiguation`
+    from the release the caller already holds (#283). Only the Album row can
+    take one; nothing else here has a legitimate second form.
     """
     unreadable = all(t.unreadable for _, t in tracks) if tracks else False
     out: list[FieldComparison] = []
@@ -390,6 +416,7 @@ def album_fields(
             disk=consensus(values),
             mb=mb_value or None,
             unreadable=unreadable,
+            also_matches=album_title_alias if disk_attr == _ALIASED_FIELD else None,
         )
         # Marked here rather than threaded through `compare_value`, because THIS
         # table is where the knowledge lives: a field is comparable iff it names

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -115,6 +115,40 @@ def norm_title(s: str) -> str:
     return " ".join(s.split()).casefold()
 
 
+def title_with_disambiguation(title: str | None, disambiguation: str | None) -> str | None:
+    """`Title (disambiguation)` — how Picard spells an album title when its
+    "use release disambiguation comment in album title" option is on.
+
+    A library tagged that way carries `Selected Ambient Works Volume II
+    (expanded edition)` where MusicBrainz's release title is `Selected Ambient
+    Works Volume II`. That is the same album by the user's own deliberate
+    setting, so it is not a mismatch — and reporting it as one costs more than a
+    wrong row on a page: `album` would differ on every pass forever, so #266's
+    write-skip would never fire and #267's IDENTITY verdict would put the whole
+    library in the Inbox on the gardener's first night (#283).
+
+    None when either half is missing, meaning there is no second spelling to
+    accept. A release with no disambiguation has exactly one title, and a
+    bracketed suffix on such an album is a different title rather than the same
+    one spelled Picard's way.
+
+    Deliberately **not** `titles_match`, which would also accept this pair. That
+    rule is a word-level subsequence test, so it accepts *any* parenthetical
+    suffix — `(deluxe edition)`, `(2019 remaster)` — on the strength of the
+    words alone. It earns that latitude where it is used, inside an
+    artist-scoped and uniqueness-guarded purchase match. Here the release states
+    its disambiguation exactly, so accepting anything looser would be guessing
+    an identity that was available for free (review-gate item 2). Picard applies
+    several other title transforms besides this one; recognising them is #284,
+    and it is a survey rather than a loosening of this rule.
+    """
+    title = (title or "").strip()
+    disambiguation = (disambiguation or "").strip()
+    if not title or not disambiguation:
+        return None
+    return f"{title} ({disambiguation})"
+
+
 @dataclass
 class TrackComparison:
     """One row in a side-by-side files-vs-MB-release comparison.

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -64,7 +64,7 @@ from .formats.m4a import (  # noqa: F401 — back-compat re-exports
     ATOM_TRACK_NUM,
     LEGACY_RELEASE_ID,
 )
-from .models import Release, Track, norm_title
+from .models import Release, Track, norm_title, title_with_disambiguation
 
 log = logging.getLogger(__name__)
 
@@ -233,7 +233,14 @@ def tag_album(
     for file_path, (medium, track_pos_in_medium, track) in prep.pairs:
         tagset = _build_tagset(release, medium, track_pos_in_medium, track, prep.media_total)
         before = formats.read_owned(file_path)
-        changes = _changes_for(tagset, before, file_path, prep.art_before, prep.art_after)
+        changes = _changes_for(
+            tagset,
+            before,
+            file_path,
+            prep.art_before,
+            prep.art_after,
+            prep.accepted_album_title,
+        )
         if not changes and not formats.has_superseded_tags(file_path):
             # Nothing to write, so nothing is written. The file keeps its mtime
             # — which `reconcile.looks_externally_retagged` compares against
@@ -304,7 +311,12 @@ def plan_album(
     for file_path, (medium, track_pos_in_medium, track) in prep.pairs:
         tagset = _build_tagset(release, medium, track_pos_in_medium, track, prep.media_total)
         if file_changes := _changes_for(
-            tagset, formats.read_owned(file_path), file_path, prep.art_before, prep.art_after
+            tagset,
+            formats.read_owned(file_path),
+            file_path,
+            prep.art_before,
+            prep.art_after,
+            prep.accepted_album_title,
         ):
             changes[file_path] = file_changes
     return AlbumPlan(changes=changes, preserves_per_track_art=prep.preserves_per_track_art)
@@ -413,6 +425,11 @@ class _Prepared:
     art_after: str | None
     preserves_per_track_art: bool
     media_total: int
+    #: The one other album title that counts as already correct — Picard's
+    #: disambiguated spelling (#283). Album-constant, since every file's TagSet
+    #: carries the same `album`, so it is settled once here rather than rebuilt
+    #: per file.
+    accepted_album_title: str | None
 
 
 def _prepare(
@@ -494,6 +511,9 @@ def _prepare(
         art_after=_digest(cover) if cover is not None else None,
         preserves_per_track_art=preserves_per_track_art,
         media_total=len(release.get("medium-list", [])) or 1,
+        accepted_album_title=title_with_disambiguation(
+            release.get("title"), release.get("disambiguation")
+        ),
     )
 
 
@@ -503,6 +523,7 @@ def _changes_for(
     file_path: Path,
     art_before: dict[Path, str | None],
     art_after: str | None,
+    accepted_album_title: str | None = None,
 ) -> dict[str, list[Any]]:
     """What tagging this one file to `tagset` would change, as `{field: [was, now]}`.
 
@@ -515,6 +536,23 @@ def _changes_for(
     Only fields that actually changed appear — see `owned.diff`.
     """
     changes = owned.diff(before, {f.value: getattr(tagset, f.value) for f in owned.Owned})
+
+    # An album title carrying the release disambiguation is not a change (#283).
+    # Dropped from the diff rather than smoothed over in `owned.diff`, which
+    # compares values and rightly knows nothing about MusicBrainz: what makes
+    # this second spelling legitimate is a fact about the release.
+    #
+    # Only the diff is tolerant. A write that happens for some OTHER reason
+    # still puts MusicBrainz's plain title on the file — Harmonist writes what
+    # MusicBrainz says, and preserving a spelling it did not derive is the
+    # separate, configurable question this issue deliberately left alone.
+    album_change = changes.get(owned.Owned.ALBUM)
+    if (
+        album_change is not None
+        and accepted_album_title is not None
+        and album_change[0] == accepted_album_title
+    ):
+        del changes[owned.Owned.ALBUM]
 
     # Artwork rides alongside the owned fields but is not one of them: the
     # tagger, not `write_tags`, decides whether art is replaced or preserved,

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -66,6 +66,7 @@ from harmonist.models import (
     Release,
     Sidecar,
     store_name,
+    title_with_disambiguation,
     title_words,
     titles_match,
 )
@@ -799,7 +800,16 @@ def _album_comparison(
         # two halves disagreeing for good — a "label differs on 26 of 47 tracks"
         # pill that nothing on the page can clear.
         compare.AlbumComparison(
-            fields=compare.album_fields(audio, tagsets[0] if tagsets else None)
+            fields=compare.album_fields(
+                audio,
+                tagsets[0] if tagsets else None,
+                # Picard writes the release disambiguation into the album title
+                # when told to, and that is the same album — not a mismatch to
+                # report on every page view forever (#283).
+                album_title_alias=title_with_disambiguation(
+                    release.get("title"), release.get("disambiguation")
+                ),
+            )
         ),
         compare.tracklist(_in_track_order(audio + video), mb_tracks, _media_of(release)),
     )

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -714,3 +714,64 @@ def test_a_disk_only_album_panel_says_it_compared_nothing():
     assert AlbumComparison(fields=fields, mb_available=False).summary == (
         "No comparison — showing your files' tags"
     )
+
+
+# ---------- Picard's disambiguated album title (#283) ----------
+
+
+def _album_row(disk_album: str, *, alias: str | None = None, **track_overrides):
+    tags = TrackTags(album=disk_album, **track_overrides)
+    fields = album_fields([("1.flac", tags)], _tagset(album="Obreel"), album_title_alias=alias)
+    return {f.label: f for f in fields}
+
+
+def test_the_disambiguated_album_title_reads_as_a_match():
+    """Picard appends the release disambiguation to the album title when told to,
+    so `Obreel (expanded edition)` and `Obreel` are the same album by the user's
+    own setting — not a difference to report on every page view forever (#283).
+
+    The row still reports what is really on disk. Normalising the displayed value
+    to MusicBrainz's spelling would make the panel claim the files say something
+    they don't, which is the one thing this table exists to be trusted about.
+    """
+    row = _album_row("Obreel (expanded edition)", alias="Obreel (expanded edition)")["Album"]
+
+    assert row.agreement is Agreement.MATCHES
+    assert row.disk == "Obreel (expanded edition)"
+
+
+def test_the_same_title_differs_when_the_release_has_no_disambiguation():
+    """The other half, and what makes the test above mean something: with no
+    disambiguation there is no second spelling to accept, so the identical disk
+    value is a genuine difference."""
+    row = _album_row("Obreel (expanded edition)")["Album"]
+
+    assert row.agreement is Agreement.DIFFERS
+
+
+def test_only_the_disambiguation_is_accepted_not_any_parenthetical():
+    """One exact string, never a pattern. `models.titles_match` would accept this
+    on the strength of the words alone, and it is right to where it is used —
+    inside an artist-scoped, uniqueness-guarded purchase match. Here the release
+    states its disambiguation exactly, so accepting more would be guessing an
+    identity that was available for free (review-gate item 2).
+    """
+    row = _album_row("Obreel (deluxe edition)", alias="Obreel (expanded edition)")["Album"]
+
+    assert row.agreement is Agreement.DIFFERS
+
+
+def test_the_alias_applies_to_the_album_row_alone():
+    """Scoped to the one field with a second legitimate spelling. Handed to every
+    row it would silently excuse a real difference anywhere the string happened
+    to collide — an album artist genuinely renamed to the album's own title is
+    daft, and is exactly the kind of thing a loose special case lets through.
+    """
+    rows = _album_row(
+        "Obreel (expanded edition)",
+        alias="Obreel (expanded edition)",
+        album_artist="Obreel (expanded edition)",
+    )
+
+    assert rows["Album"].agreement is Agreement.MATCHES
+    assert rows["Album artist"].agreement is Agreement.DIFFERS

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -1479,3 +1479,71 @@ def test_every_change_a_real_plan_produces_can_be_classified(album_with_tracks, 
     assert owned.ARTWORK in seen  # the key most likely to be forgotten
     for field in seen:
         assert isinstance(tagger.significance_of(field, None, "x"), owned.Significance)
+
+
+# ---------- Picard's disambiguated album title (#283) ----------
+
+
+def _set_album_tag(album_dir, value: str) -> None:
+    """Put `value` in every file's ©alb — what Picard writes with its
+    "use release disambiguation in album title" option turned on."""
+    for f in sorted(album_dir.glob("*.m4a")):
+        audio = MP4(f)
+        audio[ATOM_ALBUM] = [value]
+        audio.save()
+
+
+def test_a_disambiguated_album_title_is_not_a_change(album_with_tracks):
+    """Picard can be told to append the release disambiguation to the album
+    title, so a library tagged that way carries `Test Album (expanded edition)`
+    where MusicBrainz's release title is `Test Album`.
+
+    That is the same album, by the user's own deliberate setting. Reported as a
+    change it would differ on every pass forever: #266's write-skip would never
+    fire on those albums, and #267 classifies `album` as IDENTITY, so #32's
+    nightly pass would put the whole library in the Inbox on its first night.
+    """
+    album_dir = album_with_tracks(2)
+    rel = _release_2_tracks()
+    rel["disambiguation"] = "expanded edition"
+    tagger.tag_album(album_dir, rel)
+    _set_album_tag(album_dir, "Test Album (expanded edition)")
+
+    assert tagger.plan_album(album_dir, rel).empty
+
+
+def test_a_real_retitle_is_still_a_change(album_with_tracks):
+    """The tolerance is exactly one string, not "anything in brackets".
+
+    A parenthetical that isn't the release's disambiguation is a different album
+    title, and guessing otherwise would be inventing an identity the release can
+    state for free — which review-gate item 2 forbids.
+    """
+    album_dir = album_with_tracks(2)
+    rel = _release_2_tracks()
+    rel["disambiguation"] = "expanded edition"
+    tagger.tag_album(album_dir, rel)
+    _set_album_tag(album_dir, "Test Album (deluxe edition)")
+
+    plan = tagger.plan_album(album_dir, rel)
+    assert not plan.empty
+    assert all("album" in c for c in plan.changes.values())
+
+
+def test_a_bracketed_suffix_is_a_change_when_the_release_has_no_disambiguation(album_with_tracks):
+    """With nothing to append there is no second spelling to accept, so a
+    bracketed suffix is just a different album title.
+
+    A behaviour assertion, not a test of the None-return in
+    `title_with_disambiguation` — a broken guard there yields `Test Album ()`,
+    which matches nothing either, and this would stay green. That guard is
+    covered directly in `test_title_match.py`. What this does cover is the
+    tagger reaching for a looser rule: swap the exact comparison for
+    `titles_match` and it fails.
+    """
+    album_dir = album_with_tracks(2)
+    rel = _release_2_tracks()
+    tagger.tag_album(album_dir, rel)
+    _set_album_tag(album_dir, "Test Album (expanded edition)")
+
+    assert not tagger.plan_album(album_dir, rel).empty

--- a/test/test_title_match.py
+++ b/test/test_title_match.py
@@ -8,7 +8,7 @@ the caller's artist-scoping + uniqueness guard, not this rule.
 
 from __future__ import annotations
 
-from harmonist.models import title_words, titles_match
+from harmonist.models import title_with_disambiguation, title_words, titles_match
 
 
 def _m(a: str, b: str) -> bool:
@@ -56,3 +56,36 @@ def test_different_titles_dont_match():
 def test_empty_never_matches():
     assert not _m("", "Anything")
     assert not _m("Anything", "")
+
+
+# ---------- the exact disambiguation rule, which is NOT the above (#283) ----------
+#
+# `titles_match` would accept "Obreel" against "Obreel (expanded edition)" — and
+# against "(deluxe edition)" or "(2019 remaster)" just as readily, since it judges
+# on words alone. That latitude is earned where it is used, inside an
+# artist-scoped and uniqueness-guarded purchase match. Comparing a file's tags
+# against the release they came from is a different question with a better answer
+# available: the release states its disambiguation, so the accepted spelling can
+# be built exactly instead of guessed at.
+
+
+def test_the_picard_spelling_is_built_from_the_release():
+    assert title_with_disambiguation("Obreel", "expanded edition") == "Obreel (expanded edition)"
+
+
+def test_there_is_no_second_spelling_without_a_disambiguation():
+    """The guard that stops a nonsense alias existing at all.
+
+    Without it the function yields `Obreel ()`, which no file carries — so the
+    behaviour above it looks correct while the value it is built on is garbage.
+    Asserted here rather than through the tagger, where a broken guard produces a
+    string that happens not to match anything and the test passes regardless.
+    """
+    assert title_with_disambiguation("Obreel", None) is None
+    assert title_with_disambiguation("Obreel", "") is None
+    assert title_with_disambiguation("Obreel", "   ") is None
+
+
+def test_there_is_no_second_spelling_without_a_title():
+    assert title_with_disambiguation(None, "expanded edition") is None
+    assert title_with_disambiguation("", "expanded edition") is None

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -7604,3 +7604,41 @@ def test_an_incomplete_album_that_comes_back_just_as_short_keeps_its_tags(
     write_track_totals(back, track_total=4)
     states = {a.path: a.state for a in scanner.scan(cfg.paths.music_dir)}
     assert states[back] == AlbumState.INCOMPLETE  # short, and honest about it
+
+
+def test_the_album_page_does_not_report_a_disambiguated_title_as_a_difference(cfg):
+    """The wiring, which is the half a unit test can't see.
+
+    `compare.album_fields` takes the accepted spelling; something has to hand it
+    one, and forgetting to would leave the whole of #283 inert with every unit
+    test still green. This drives the real call the album page makes.
+    """
+    from harmonist.tagger import tag_album
+    from harmonist.web.main import _album_comparison
+
+    release = {
+        "id": "rel-283",
+        "title": "Obreel",
+        "disambiguation": "expanded edition",
+        "artist-credit": [{"artist": {"id": "a1", "name": "Artist"}}],
+        "release-group": {"id": "rg-1", "primary-type": "Album"},
+        "medium-list": [
+            {
+                "position": "1",
+                "format": "Digital Media",
+                "track-list": [
+                    {"id": "t1", "title": "Track", "recording": {"id": "r1", "title": "Track"}}
+                ],
+            }
+        ],
+    }
+    d = _make_album(cfg, "Obreel")
+    tag_album(d, release)
+    audio = MP4(d / "01 Track.m4a")
+    audio[ATOM_ALBUM] = ["Obreel (expanded edition)"]  # what Picard's option writes
+    audio.save()
+
+    comparison, _ = _album_comparison(d, release)
+
+    assert [f.label for f in comparison.differing] == []
+    assert {f.label: f.disk for f in comparison.fields}["Album"] == "Obreel (expanded edition)"


### PR DESCRIPTION
Picard can be told to append a release's disambiguation comment to the album title, so a library tagged that way carries `Selected Ambient Works, Volume II (expanded edition)` where MusicBrainz's release title is `Selected Ambient Works, Volume II`. Harmonist compared the two for equality and reported a difference on every such album, forever.

## Why it stopped being cosmetic

That was merely rude until #266 and #267 landed. Now `album` differs on every pass, so:

- **#266's write-skip could never fire** on those albums — rewritten every time, mtime moved every time, which `reconcile.looks_externally_retagged` reads as somebody having tagged them in Picard (#220);
- **#267 classifies `album` as IDENTITY**, correctly, so #270's first night would have put an entire library in the Inbox over a difference that isn't one.

The album page was the visible symptom. The runner was the actual cost, which is why this went ahead of #269 and #270.

## The rule

Both places that judge a disk title against MusicBrainz's now accept the disambiguated spelling: `compare.album_fields` for the album panel, and the tagging diff for the write-skip. `disambiguation` is a core field on the release entity and is already in the payload Harmonist holds, so this costs **no extra MusicBrainz request**.

**Exactly one string, never a pattern.** `models.titles_match` would have accepted this pair for free — and `(deluxe edition)` and `(2019 remaster)` just as readily, since it judges on words alone. That latitude is earned where it is used, inside an artist-scoped and uniqueness-guarded purchase match. Here the release *states* its disambiguation, so accepting anything looser would be guessing an identity that was available exactly, which is what review-gate item 2 exists to refuse. Picard's other title transforms are #284 — a survey of what is exactly checkable, not a loosening of this.

**Only the comparison is tolerant, not the write.** A re-tag that happens for some other reason still puts MusicBrainz's plain title on the file: Harmonist writes what MusicBrainz says, and preserving a spelling it did not derive is a separate question needing a setting to match Picard's. The consequence is named in `docs/design.md` §5 rather than left to be discovered — on an album where nothing else changed the disambiguated title survives indefinitely, and on one where something else changed it does not.

## Shape

`compare.py` is deliberately free of runtime imports, so it is **told** the accepted spelling rather than deriving it — one exact alternative, and no knowledge of where it came from. What makes a second spelling legitimate is a MusicBrainz fact, and that lives in `models.title_with_disambiguation`. Scoped to the Album row via a named constant, since nothing else on that panel has a second legitimate form.

On the tagger side the accepted title is settled once per album in `_prepare` (every file's TagSet carries the same `album`) and `_changes_for` drops the entry. Not smoothed over inside `owned.diff`, which compares values and rightly knows nothing about MusicBrainz.

## Tests

The reproduction was genuinely red first, on its assertion: `{'album': ['Test Album (expanded edition)', 'Test Album']}`. The wiring test drives `_album_comparison` directly, because forgetting to pass the alias from `main.py` would leave the whole change inert with every unit test still green.

**One test was wrong and the mutation check caught it**, which is worth recording. `test_a_bracketed_suffix_is_a_change_when_the_release_has_no_disambiguation` looked like it covered the empty-disambiguation guard and did not: break the guard and the function yields `Test Album ()`, which matches nothing either, so it stayed green through the mutation. The guard is now tested directly against the function in `test_title_match.py` — beside `titles_match`, where the contrast between the two rules is now written down — and the tagger test's docstring says what it actually covers.

Nine mutation checks in total, all red on the intended assertions.

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)