### PR TITLE
Find the albums MusicBrainz has something new for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- The Library has an **Update available** filter (#287), gathering albums whose
+  MusicBrainz release has moved on since their files were tagged. Until now the
+  only way to find one was to open its page and look, so upstream corrections
+  landed where nobody saw them. Harmonist fills the filter in from the releases
+  it has already fetched — no MusicBrainz traffic — and keeps it current as you
+  browse; re-tagging an album takes it off the list.
 - Harmonist now **rescans your library once an hour** as a backstop (#151), for
   the cases where its file watcher isn't working and can't tell you so — a
   library mounted over the network, where the watcher is blind, or a watcher

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -166,7 +166,8 @@ has to match, but where and in what order doesn't, so `aphex ambient` finds
 <!-- screenshot: docs/screenshots/library-filters.png -->
 
 Finished isn't the same as right, so the filter chips find the albums that are
-done but still wrong, each with its count:
+done but still wrong — and the album whose MusicBrainz entry has improved since
+you tagged it — each with its count:
 
 - **Incomplete** — fewer tracks on disk than the MusicBrainz release has. The tile
   badges "N of M". The count comes from your files' own tags, which Harmonist and
@@ -195,6 +196,17 @@ done but still wrong, each with its count:
   A half-finished tagging run, or Picard applied to part of a folder, leaves this.
 - **No artwork** — correctly tagged, fully linked, and still a grey square in
   Plex or Navidrome.
+- **Update available** — nothing is wrong with these. MusicBrainz has simply
+  learned something since you tagged them: an ISRC filled in, a catalogue number
+  corrected, a release date fixed, a track retitled. Re-tag from the album's page
+  to take it, and the album drops off the list.
+
+  Harmonist works this out from the MusicBrainz releases it has already fetched,
+  so the filter costs no lookups and fills in as you browse — an album you open
+  is checked while you're there. That does mean the list is what Harmonist has
+  had reason to look at, not the whole library: an album nobody has opened since
+  Harmonist met it hasn't been compared yet, so it won't be here even if there is
+  something waiting. The filter under-reports rather than inventing work.
 
 Search and the filters compose: searching inside a filter narrows within it, and
 the chip counts follow the search, so each one tells you what it would actually

--- a/src/harmonist/formats/__init__.py
+++ b/src/harmonist/formats/__init__.py
@@ -16,6 +16,11 @@ from types import ModuleType
 from typing import Any
 
 from . import flac, m4a, mp3, ogg, opus
+
+# `READ_ERRORS` is re-exported (redundant alias) rather than used here: this
+# package is where mutagen stops, so `formats.READ_ERRORS` is how the rest of
+# the codebase names an unreadable file without importing mutagen to do it.
+from .types import READ_ERRORS as READ_ERRORS
 from .types import ScanFields, TagSet, TrackTags, UnsupportedFormatError
 
 _MODULES: tuple[ModuleType, ...] = (m4a, mp3, flac, ogg, opus)

--- a/src/harmonist/formats/types.py
+++ b/src/harmonist/formats/types.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import NamedTuple
 
+from mutagen import MutagenError
+
 from .quality import AudioQuality
 
 
@@ -204,3 +206,19 @@ class TrackTags:
 
 class UnsupportedFormatError(Exception):
     """Raised when no audio module handles a given file extension."""
+
+
+#: Everything a per-file tag read can fail with, as one name a caller can catch.
+#:
+#: The point of this package is that mutagen stays inside it, and a caller that
+#: has to tolerate an unreadable file was otherwise forced to break that: an
+#: `except OSError` looks complete and misses the common case, because
+#: `MutagenError` is NOT an `OSError` — a truncated or non-audio file raises
+#: `MP4StreamInfoError`, which inherits straight from `Exception`. That gap is
+#: silent, which is the worst kind: the catch reads as thorough and the failure
+#: goes straight past it.
+#:
+#: Only for callers that genuinely have a truthful answer for "I could not read
+#: this" and can carry on. Anything writing on the user's behalf should let it
+#: propagate — see the error-handling skill.
+READ_ERRORS: tuple[type[Exception], ...] = (OSError, MutagenError, UnsupportedFormatError)

--- a/src/harmonist/gardener.py
+++ b/src/harmonist/gardener.py
@@ -1,0 +1,176 @@
+"""Whether MusicBrainz has anything for an album that its files don't have yet.
+
+The detector half of #32's metadata gardener, and the whole of what #287's
+"Update available" Library filter reads. It answers one question — *would a
+re-tag against the release MusicBrainz currently holds change any owned tag?* —
+and records the answer on the in-memory `Album`.
+
+## Why this and not the album page's comparison
+
+`compare.album_fields` / `compare.tracklist` are display-shaped: their per-track
+vocabulary is Title and Artist, and they deliberately show fields they never
+compare (#164). A verdict taken from them would fire on things a re-tag cannot
+write and stay silent on most of what one would. `tagger.plan_album` (#266) is
+a dry run of the real write, over exactly the fields `owned.Owned` covers, so
+the flag, the audit records and Undo all speak the same vocabulary.
+
+## Disk vs. MusicBrainz, never MusicBrainz vs. MusicBrainz
+
+The tempting cheap version compares a fresh payload against the cached one and
+calls a difference an update. It is wrong twice over:
+
+* a release that has not moved since we last looked still has an outstanding
+  update if the files never took the previous one — so an unchanged payload must
+  never clear the flag;
+* a release edited and then reverted (A → B → A) has nothing outstanding, and a
+  payload comparison would flag it until something cleared it by hand.
+
+Deriving from the plan gets both right for free: the plan is empty exactly when
+the files already carry what MusicBrainz says.
+
+That payload comparison still earns its keep as #270's early exit — it decides
+whether recomputing is worth the file reads — but it decides *whether to look*,
+not what the answer is.
+
+## Nothing here is persisted
+
+No sidecar field, no table, no lifecycle. The flag is a hint that can be rebuilt
+from durable state at any time (`warm_from_cache`), so there is nothing to
+migrate, nothing to dismiss, and nothing for review-gate item 3 to object to.
+The album's state stays derived.
+
+A finding that a human has to *act* on is a different object with a different
+lifetime, and it lives in `activity.db` (#271). This is only the flag.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterable
+from datetime import timedelta
+
+from . import album_files, formats, mb_cache, tagger
+from .models import Album, AlbumState, Release
+
+log = logging.getLogger(__name__)
+
+# How long the warm-up rests between albums. It is bounded by disk rather than
+# by MusicBrainz's 1 req/s, so this is not a rate limit — it is politeness to a
+# NAS that is also serving Plex, and to the library scan this runs behind.
+# Small enough that a 2,000-album library warms in a few minutes.
+WARM_PAUSE = timedelta(milliseconds=50)
+
+
+def would_change(album: Album, release: Release) -> bool:
+    """Whether re-tagging `album` against `release` would change an owned tag.
+
+    `TagMismatchError` counts as **True**, not as a failure: the file count no
+    longer matching the release's tracklist is a structural change, which is one
+    of the loudest things MusicBrainz can do to an album and precisely what the
+    user needs to be told about (#266, #267).
+
+    Artwork is out of scope — `cover_path=None`, so the plan leaves each file's
+    own art alone and the verdict is about tags only. Asking the Cover Art
+    Archive here would spend a separate budget per album per pass, which
+    review-gate item 6 forbids and #269 owns instead.
+
+    A superseded tag spelling — MP4's legacy `MUSICBRAINZ_RELEASEID`, which a
+    write clears without ever reading back — is deliberately NOT an update, even
+    though `formats.has_superseded_tags` exists precisely because `plan_album`
+    cannot see it. This filter answers "has MusicBrainz got something the files
+    haven't", and a tidy-up Harmonist owes itself is not that. Counting it would
+    permanently flag whole swathes of an adopted library for a reason the user
+    could do nothing about but re-tag.
+
+    Raises whatever a tag read raises (`formats.READ_ERRORS`) when a file cannot
+    be read: that is "I could not tell", which is not the same as "nothing to
+    take" and must not be returned as one. `refresh_flag` absorbs it.
+    """
+    try:
+        plan = tagger.plan_album(
+            album.path,
+            release,
+            cover_path=None,
+            # Same reading the re-tag button makes (`web/main.py:3829`), so the
+            # flag never promises an update that the button would refuse to
+            # apply. Without it every INCOMPLETE album raises below and flags
+            # permanently — a defect the Incomplete filter already gathers, and
+            # not an update MusicBrainz is offering.
+            incomplete=album.state == AlbumState.INCOMPLETE,
+            # An album can span several directories (#197); planning over the
+            # primary one alone would miss whatever the other discs need.
+            files=album_files.for_paths(album.folders),
+        )
+    except tagger.TagMismatchError:
+        return True
+    return bool(plan.changes)
+
+
+def refresh_flag(album: Album, release: Release) -> bool:
+    """Set `album.update_available` from `release`, and return what it now says.
+
+    The tolerant wrapper every caller uses. A file that cannot be read leaves
+    the flag **as it was** rather than clearing it: the album page's comparison
+    and the warm-up both run against libraries on network mounts, and a blinking
+    mount must not quietly empty the filter. Under-reporting is the direction
+    this feature fails in by design (see `Album.update_available`).
+
+    Mutating the Album in place is what makes the flag visible to the Library:
+    `ScanRunner.albums()` hands out the live snapshot, so this is the same
+    object the grid will render.
+    """
+    try:
+        album.update_available = would_change(album, release)
+    except formats.READ_ERRORS:
+        # Loud, per the unattended rule: at 3am the log is the only channel.
+        # ERROR rather than WARNING — nothing recovered, we simply cannot say
+        # whether this album has an update, and it will keep reporting whatever
+        # it last said until something can read it.
+        log.exception("could not tell whether %s has a tag update available", album.path)
+    return album.update_available
+
+
+def warm_from_cache(albums: Iterable[Album], *, pause: timedelta = WARM_PAUSE) -> int:
+    """Rebuild the update-available flags from stored releases. Returns how many
+    albums were flagged.
+
+    The flag lives in process memory, so a restart blanks it and the filter
+    would read zero until the background pass next came round — potentially a
+    whole sweep interval on a NAS, which reads as a broken control rather than
+    an empty one.
+
+    It does not have to. Both inputs to the verdict survive a restart: the
+    release payload is in `mb_release_cache` and the tags are on disk. So this
+    reaches the *same* answer the pass would, with **zero MusicBrainz
+    requests** — the pass's fetch exists only to refresh the payload this is
+    already reading. The half being skipped is the rate-limited one: a full pass
+    is bounded by 1 req/s (~35 minutes for 2,000 albums), this is bounded by
+    disk.
+
+    An album MusicBrainz was never asked about has no row and simply keeps its
+    False — see the under-reporting note on `Album.update_available`.
+
+    Blocking I/O (one read per file, per `plan_album`), so call it from a worker
+    thread, never the event loop.
+    """
+    flagged = 0
+    looked = 0
+    for album in albums:
+        sc = album.sidecar
+        if sc is None or not sc.mb_release_id:
+            continue  # nothing to compare against; not an error
+        release = mb_cache.stored_release(sc.mb_release_id)
+        if release is None:
+            continue  # never fetched, or fetched under a different `inc`
+        looked += 1
+        if refresh_flag(album, release):
+            flagged += 1
+        if pause > timedelta(0):
+            time.sleep(pause.total_seconds())
+    log.info(
+        "update-available warm-up: %d of %d albums with a stored release have an update",
+        flagged,
+        looked,
+    )
+    return flagged

--- a/src/harmonist/mb_cache.py
+++ b/src/harmonist/mb_cache.py
@@ -125,6 +125,24 @@ def fetch_release(mbid: str, *, max_age: timedelta | None = None) -> Release:
     return release
 
 
+def stored_release(mbid: str) -> Release | None:
+    """What MusicBrainz last said about `mbid`, or None if we never asked.
+
+    **Reads the store and never the network**, whatever the row's age — the one
+    caller that wants that is #287's warm-up, which rebuilds the update-available
+    flags after a restart and must cost zero rate-limited requests. Age is
+    irrelevant to it: a stale row is still the last thing MusicBrainz said, which
+    is exactly the baseline the flag is derived against, and a fresher answer is
+    the background pass's job to go and get (#270).
+
+    Distinct from `fetch_release(max_age=...)`, which answers "give me a release"
+    and will spend a request to do it. This answers "have we got one already",
+    and a None is an answer rather than a reason to go and ask.
+    """
+    cached = activity_store.cached_release(mbid, _key(mb_lookup.RELEASE_INCLUDES))
+    return cached.payload if cached is not None else None
+
+
 def fetch_release_urls(mbid: str, *, max_age: timedelta | None = None) -> list[str]:
     """`mb_lookup.fetch_release_urls`, served from the cache when fresh enough.
 

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -370,6 +370,26 @@ class Album:
     # OUTSIDE Harmonist — in Picard, which is what Harmonist asks users to do
     # (#220). Scanner-derived; not persisted.
     files_written_at: datetime | None = None
+    # True when a re-tag against the release MusicBrainz currently holds would
+    # change at least one owned tag (#287). NOT scanner-derived and NOT
+    # persisted: it is set by `gardener.refresh_flag` — from the album page's
+    # comparison, from the startup warm-up, and later from the background pass
+    # (#270) — and it lives here so the Library can filter on it for free.
+    #
+    # False therefore means "nothing to take, as far as we have looked", which
+    # on a cold start is not the same as "nothing to take". The flag
+    # UNDER-reports by design: an album we have never compared, or one whose
+    # files could not be read, stays False. That is the safe direction — the
+    # filter can miss an album, but it can never invite the user to act on an
+    # update that isn't there.
+    #
+    # Survives a rescan for the usual single-directory album, because
+    # `resolve_dir` returns the cached Album on a signature hit and
+    # `merge_by_identity` passes a one-part album straight through — the same
+    # object, flag intact. An album whose files or sidecar changed is rebuilt
+    # and starts False again, which is the self-invalidation we want: a re-tag
+    # that took the update clears the flag by construction.
+    update_available: bool = False
 
     @property
     def folders(self) -> tuple[Path, ...]:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -12,6 +12,7 @@ import os
 # out of the production import path entirely.
 import re
 import sys
+import threading
 import unicodedata
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import asynccontextmanager, suppress
@@ -38,6 +39,7 @@ from harmonist import (
     compare,
     cover_art,
     formats,
+    gardener,
     id_registry,
     library_index,
     live_counts,
@@ -155,15 +157,30 @@ _INDEX_TABS = ("inbox", "library", "activity")
 
 
 # Library filters (#174), slug → (label, predicate). Every predicate reads a field
-# the SCANNER already derived, so filtering costs no lookup and no rescan (#140's
-# no-MB-on-the-request-path constraint) and persists nothing — the grid asks a
-# question about state it can already see, it does not record an answer.
+# already on the in-memory Album, so filtering costs no lookup and no rescan
+# (#140's no-MB-on-the-request-path constraint) and persists nothing — the grid
+# asks a question about state it can already see, it does not record an answer.
 #
-# All three pick out albums that are *terminal but wrong*, which is the whole
-# point: the Library is where a defect goes to be forgotten. INCOMPLETE at least
-# has a tile badge; a partially tagged album derives COMPLETE (`_files_tagged_with`
-# is an `any()`) and shows nothing but a 10-pixel "8/10 tagged" line, and a
-# coverless album shows nothing at all. Neither is findable at library scale.
+# The control asks TWO questions, not one.
+#
+# *What is broken?* — the first three, which pick out albums that are terminal but
+# wrong. That is the Library's original problem: it is where a defect goes to be
+# forgotten. INCOMPLETE at least has a tile badge; a partially tagged album derives
+# COMPLETE (`_files_tagged_with` is an `any()`) and shows nothing but a 10-pixel
+# "8/10 tagged" line, and a coverless album shows nothing at all. Neither is
+# findable at library scale.
+#
+# *What has moved that I could take?* — `update-available` (#287), which is not the
+# same question and must not be read as one. An album whose release has grown an
+# ISRC is not wrong; it is current as of the last time anything looked. It is
+# invisible for a different reason: today the only way to discover an update is to
+# open that album's page, so at library scale improvements to MusicBrainz land
+# where nobody sees them.
+#
+# `update_available` is the one predicate NOT derived by the scanner — it is set by
+# `gardener.refresh_flag` from the album page and the startup warm-up. Reading it
+# is still free; the cost was paid when the flag was written. See the field's own
+# note for why a False can mean "we have not looked".
 #
 # Insertion order is the order the control offers them. Slugs are URL-visible and
 # outlive any wording change, so they are not derived from the labels.
@@ -185,6 +202,7 @@ _LIBRARY_FILTERS: dict[str, tuple[str, Callable[[Album], bool]]] = {
     "incomplete": ("Incomplete", _is_actionable_incomplete),
     "partial": ("Partially tagged", lambda a: a.partial_tag_count is not None),
     "no-artwork": ("No artwork", lambda a: not a.has_cover),
+    "update-available": ("Update available", lambda a: a.update_available),
 }
 
 # Longest search query the Library will act on (#180). Unlike `?filter=`'s slug,
@@ -546,10 +564,20 @@ def create_app(
         scan_runner.request_scan()  # sidecars written → refresh the snapshot
 
     reconcile_runner = ReconcileRunner(runner_fn=reconcile_runner_fn)
+
     # Auto-run reconcile once the initial library scan finishes — so MBID-tagged
     # (and ©cmt-URL-recoverable) orphans get sidecars on startup without needing
     # someone to open the inbox first.
-    scan_runner.set_on_first_complete(reconcile_runner.start)
+    # Two things want the first snapshot, so the slot holds both rather than
+    # either one quietly displacing the other: reconcile, and #287's warm-up of
+    # the update-available flags. Reconcile goes first — it can change an album's
+    # identity, and warming a flag onto an Album that reconcile is about to
+    # replace would be work thrown away.
+    def _on_first_scan() -> None:
+        reconcile_runner.start()
+        _start_flag_warm_up(scan_runner)
+
+    scan_runner.set_on_first_complete(_on_first_scan)
 
     project_root = Path(__file__).resolve().parent.parent.parent.parent
     templates_dir = project_root / "templates"
@@ -2077,6 +2105,38 @@ def _periodic_rescan_if_idle(
         log.info("Skipping periodic rescan: sync or reconcile in progress")
         return
     scan_runner.request_quiet_rescan()
+
+
+def _start_flag_warm_up(scan_runner: ScanRunner) -> None:
+    """Rebuild the update-available flags once the library snapshot exists (#287).
+
+    The flags live in process memory, so a restart leaves the Library's "Update
+    available" filter reading zero until something looks at each album again.
+    `gardener.warm_from_cache` refills it from stored MusicBrainz payloads and
+    the files on disk, spending **no** MusicBrainz requests.
+
+    Its own thread, not the scan thread that triggers it: this is minutes of
+    file reads on a large library, and blocking there would hold up the scan
+    completion every other startup task is waiting behind. Not an asyncio task
+    either — it must never run on the event loop, and there is nothing to await
+    it for.
+
+    Daemon, and deliberately not cancelled at shutdown: it reads, records a
+    hint, and persists nothing, so being killed mid-pass loses only work that
+    the next startup redoes.
+    """
+
+    def _run() -> None:
+        try:
+            gardener.warm_from_cache(scan_runner.albums())
+        except Exception:
+            # Boundary catch: one unforeseen failure in a background hint must
+            # not take down the thread silently. Loud, because nobody is
+            # watching — the visible symptom would otherwise be a filter that
+            # is simply emptier than it should be, which reads as "no updates".
+            log.exception("update-available warm-up failed")
+
+    threading.Thread(target=_run, name="harmonist-flag-warmup", daemon=True).start()
 
 
 def _refreshed_from_disk(request: Request, album: Album) -> Album:
@@ -3686,6 +3746,17 @@ def _register_routes(app: FastAPI) -> None:
         # differs, track by track. It stays where it earns its keep: behind the
         # Needs MBID suggestion card, deciding whether to link at all.
         comparison, tracks = _album_comparison(album.path, release, album.folders)
+        # Opening an album is a look at exactly the question the Library filter
+        # asks, against a release already in hand — so answer it here too and
+        # record it on the snapshot's Album (#287). That is what lets the filter
+        # be useful before the background pass exists (#270): browsing fills it
+        # in, and a re-tag taken from this very page clears the flag on the next
+        # visit, because the plan then comes back empty.
+        #
+        # Costs one read per file on top of the comparison, which is affordable
+        # on a page the user asked for and is exactly why the Library's own
+        # render cannot do this for every tile.
+        gardener.refresh_flag(album, release)
         ctx = _ctx(
             request,
             album=album,

--- a/templates/partials/library_page.html
+++ b/templates/partials/library_page.html
@@ -39,9 +39,9 @@
      hx-get="/library?{{ library_query(page, limit, filter, q) }}"
      hx-trigger="library-refresh from:body, tasks-changed from:body"
      hx-target="#library-rows" hx-swap="innerHTML">
-{# Search (#180). The filters below find albums that are *wrong*; this finds the
-   album you have in mind, which at library scale is the more common errand and
-   the one paging cannot help with.
+{# Search (#180). The filters below find albums that are *wrong*, or that have an
+   update waiting (#287); this finds the album you have in mind, which at library
+   scale is the more common errand and the one paging cannot help with.
 
    `hx-preserve` on the input, and it is load-bearing: this whole partial is
    replaced on every `tasks-changed` and `library-refresh`, so without it a scan

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -1,0 +1,367 @@
+"""Tests for the update-available detector (#287).
+
+The verdict is *"would a re-tag change an owned tag?"*, derived from the files on
+disk against the release MusicBrainz last gave us. These pin the four answers
+that are easy to get subtly wrong — no update, an update, an update that was
+taken back upstream, and a structural change — plus the two properties the
+feature rests on: the warm-up costs no MusicBrainz requests, and a flag survives
+a rescan of an album nothing touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import shutil
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from harmonist import activity_store, gardener, mb_cache, mb_lookup, scanner, tagger
+from harmonist import sidecar as sc
+from harmonist.models import Album, Sidecar
+from harmonist.web.scan_runner import ScanRunner
+
+SINE_M4A = Path(__file__).parent / "fixtures" / "sine.m4a"
+
+
+def _release(title: str = "Test Album", *, tracks: int = 1) -> dict:
+    """A minimal release the tagger can write from, in musicbrainzngs' shape."""
+    return {
+        "id": "rel-aaa",
+        "title": title,
+        "status": "Official",
+        "artist-credit": [
+            {"artist": {"id": "art-aaa", "name": "Test Artist", "sort-name": "Artist, Test"}}
+        ],
+        "release-group": {"id": "rg-aaa", "primary-type": "Album"},
+        "medium-list": [
+            {
+                "position": "1",
+                "format": "Digital Media",
+                "track-list": [
+                    {
+                        "id": f"rt-{i:03d}",
+                        "position": str(i),
+                        "title": f"Track {i}",
+                        "recording": {"id": f"rec-{i:03d}", "title": f"Track {i}"},
+                    }
+                    for i in range(1, tracks + 1)
+                ],
+            }
+        ],
+    }
+
+
+def _album_dir(root: Path, *, tracks: int = 1) -> Path:
+    d = root / "Test Artist" / "Test Album"
+    d.mkdir(parents=True)
+    for i in range(1, tracks + 1):
+        shutil.copy(SINE_M4A, d / f"{i:02d} Track {i}.m4a")
+    return d
+
+
+def _tagged(root: Path, release: dict, *, tracks: int = 1) -> Album:
+    """An album tagged from `release`, as the scanner sees it afterwards."""
+    d = _album_dir(root, tracks=tracks)
+    tagger.tag_album(d, release)
+    sc.write(d, Sidecar(mb_release_id=release["id"], tagged_at=datetime.now(UTC)))
+    return next(a for a in scanner.scan(root) if a.path == d)
+
+
+def test_an_album_carrying_what_musicbrainz_says_has_no_update(tmp_path):
+    """The baseline the whole filter depends on. If a freshly tagged album read
+    as having an update, every album in the library would, and the filter would
+    be a list of everything."""
+    release = _release()
+    album = _tagged(tmp_path, release)
+
+    assert gardener.would_change(album, release) is False
+
+
+def test_an_edit_upstream_is_an_update(tmp_path):
+    """The case the feature exists for: MusicBrainz moved, the files didn't."""
+    album = _tagged(tmp_path, _release())
+
+    assert gardener.would_change(album, _release("Test Album (remastered)")) is True
+
+
+def test_an_edit_that_was_taken_back_upstream_leaves_nothing_outstanding(tmp_path):
+    """A → B → A. The flag is derived from disk-vs-MusicBrainz, so a reverted
+    edit clears itself; a verdict taken from "the payload changed since we last
+    looked" would flag this album and keep flagging it, because something did
+    change every time we asked."""
+    original = _release()
+    album = _tagged(tmp_path, original)
+
+    assert gardener.refresh_flag(album, _release("Test Album (remastered)")) is True
+    assert gardener.refresh_flag(album, original) is False
+    assert album.update_available is False
+
+
+def test_the_release_growing_a_track_is_an_update_not_an_error(tmp_path):
+    """`plan_album` refuses an album whose file count no longer matches the
+    tracklist. That refusal IS the finding — a structural change is the loudest
+    thing MusicBrainz can do to an album — and treating it as a failure would
+    hide exactly the case the user most needs to see."""
+    album = _tagged(tmp_path, _release())
+
+    assert gardener.would_change(album, _release(tracks=2)) is True
+
+
+def test_an_unreadable_file_leaves_the_flag_as_it_was(tmp_path):
+    """ "I could not tell" is not "nothing to take". A network mount blinking
+    must not quietly empty the filter — the previous answer stands until
+    something can read the files again."""
+    release = _release()
+    album = _tagged(tmp_path, release)
+    gardener.refresh_flag(album, _release("Test Album (remastered)"))
+    assert album.update_available is True
+
+    (album.path / "01 Track 1.m4a").write_bytes(b"not an m4a at all")
+
+    assert gardener.refresh_flag(album, release) is True  # unchanged, not cleared
+
+
+def test_the_warm_up_rebuilds_flags_without_asking_musicbrainz(tmp_path, monkeypatch):
+    """The restart story. Both inputs to the verdict outlive the process — the
+    payload in `mb_release_cache`, the tags on disk — so the flags come back for
+    free. Any live fetch here would be a rate-limited request spent per album on
+    something a restart triggers.
+
+    The stored row is deliberately **stale**, because that is the state a
+    restart actually finds it in: the TTL is an hour and the process has been
+    down all night. A warm-up built on `fetch_release` would look correct
+    against a fresh row and go to the network for every album in the field.
+    """
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    # What MusicBrainz last told us, stored as `fetch_release` would have.
+    activity_store.store_release(
+        "rel-aaa",
+        "+".join(sorted(mb_lookup.RELEASE_INCLUDES)),
+        _release("Test Album (remastered)"),
+    )
+    conn = activity_store._ensure()
+    conn.execute(
+        "UPDATE mb_release_cache SET fetched_at = ?",
+        ((datetime.now(UTC) - timedelta(days=7)).isoformat(),),
+    )
+    conn.commit()
+
+    def _no_requests(*a: object, **k: object) -> dict:
+        raise AssertionError("the warm-up fetched from MusicBrainz")
+
+    monkeypatch.setattr(mb_lookup, "fetch_release", _no_requests)
+
+    assert gardener.warm_from_cache([album], pause=timedelta(0)) == 1
+    assert album.update_available is True
+
+
+def test_a_second_warm_up_changes_nothing(tmp_path, monkeypatch):
+    """Idempotency, which under a background pass is what stops a nightly job
+    becoming a nightly stream of noise. Running it twice reaches the same verdict
+    and adds nothing — no second flag, no feed entry, no write of any kind, since
+    the whole operation is a read and an in-memory assignment."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    activity_store.store_release(
+        "rel-aaa",
+        "+".join(sorted(mb_lookup.RELEASE_INCLUDES)),
+        _release("Test Album (remastered)"),
+    )
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda *a, **k: pytest.fail("warm-up went to MusicBrainz")
+    )
+
+    first = gardener.warm_from_cache([album], pause=timedelta(0))
+    events_after_first = len(activity_store.recent(50))
+
+    assert gardener.warm_from_cache([album], pause=timedelta(0)) == first == 1
+    assert album.update_available is True
+    assert len(activity_store.recent(50)) == events_after_first
+
+
+def test_the_warm_up_leaves_an_album_musicbrainz_was_never_asked_about(tmp_path):
+    """No stored payload means no baseline, which is not the same as "no update".
+    The album stays unflagged rather than being guessed at either way."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+
+    assert gardener.warm_from_cache([album], pause=timedelta(0)) == 0
+    assert album.update_available is False
+
+
+def test_the_warm_up_skips_an_album_with_no_release_of_its_own(tmp_path):
+    """An unlinked album has nothing to compare against — and `stored_release`
+    must not be handed a None mbid to look up."""
+    activity_store.init(tmp_path / "activity.db")
+    d = _album_dir(tmp_path)
+    album = next(a for a in scanner.scan(tmp_path) if a.path == d)
+    assert album.sidecar is None
+
+    assert gardener.warm_from_cache([album], pause=timedelta(0)) == 0
+
+
+async def _scan_via_runner(runner: ScanRunner) -> None:
+    runner.attach_loop()
+    for _ in range(300):
+        if runner.has_completed():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("background scan never completed")
+
+
+def test_the_flag_survives_a_rescan_of_an_untouched_album(tmp_path):
+    """The flag lives on the Album the snapshot holds, and a rescan rebuilds that
+    snapshot — so this is what makes it usable at all rather than something that
+    evaporates on the next hourly sweep. `resolve_dir` returns the cached Album
+    on a signature hit and `merge_by_identity` passes a single-directory album
+    straight through, so an album nothing touched is the same object with its
+    flag intact.
+    """
+    _tagged(tmp_path, _release())
+    runner = ScanRunner(tmp_path)
+    asyncio.run(_scan_via_runner(runner))
+    runner.albums()[0].update_available = True
+
+    rescanned = runner.scan_now()  # the same walk the hourly rescan makes
+
+    assert rescanned[0].update_available is True
+
+
+def test_a_retag_clears_the_flag_by_rebuilding_the_album(tmp_path):
+    """The other half of that: an album whose files changed is rebuilt from
+    scratch, so taking the update drops the flag with no bookkeeping. This is why
+    nothing has to remember to clear it."""
+    release = _release()
+    album_dir = _tagged(tmp_path, release).path
+    runner = ScanRunner(tmp_path)
+    asyncio.run(_scan_via_runner(runner))
+    runner.albums()[0].update_available = True
+
+    tagger.tag_album(album_dir, _release("Test Album (remastered)"))
+
+    assert runner.scan_now()[0].update_available is False
+
+
+# ---------------------------------------------------------------------------
+# Through the web layer (#287's actual errand)
+# ---------------------------------------------------------------------------
+#
+# These need the ScanRunner engaged, and that is not incidental: the flag lives
+# on the Album the snapshot holds, so a route can only record it somewhere
+# durable when there IS a snapshot. Without the runner every request rescans
+# and builds fresh Albums, which is what `_albums` does in the plain `client`
+# fixture — a flag set by one request would be gone by the next, and a test
+# there would be asserting about a configuration production never runs in.
+
+
+@pytest.fixture
+def engaged(tmp_path):
+    """A TestClient whose app reads a persistent library snapshot, as production
+    does. Returns `(client, runner)`."""
+    from harmonist.config import BandcampConfig, Config, PathsConfig, ServerConfig, TestConfig
+
+    music = tmp_path / "music"
+    music.mkdir(parents=True)
+    (tmp_path / "config").mkdir(parents=True)
+    cfg = Config(
+        paths=PathsConfig(config_dir=tmp_path / "config", music_dir=music),
+        bandcamp=BandcampConfig(),
+        server=ServerConfig(),
+        test=TestConfig(mode="fixture"),
+    )
+    activity_store.init(tmp_path / "activity.db")
+    yield cfg, lambda: _engage(cfg)
+
+
+def _engage(cfg):
+    from fastapi.testclient import TestClient
+
+    from harmonist.web.main import create_app
+
+    app = create_app(cfg)
+    runner: ScanRunner = app.state.scan_runner
+    asyncio.run(_scan_via_runner(runner))
+    # HX-Request for the CSRF middleware, exactly as the other web fixtures do.
+    return TestClient(app, headers={"HX-Request": "true"}), runner
+
+
+def test_opening_an_album_records_that_it_has_an_update(engaged, monkeypatch):
+    """The whole of this increment's usefulness before the background pass
+    exists (#270): the comparison the album page already runs answers the
+    filter's question too, so browsing fills the filter in."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda *a, **k: _release("Test Album (remastered)")
+    )
+    client, runner = engage()
+    assert runner.albums()[0].update_available is False
+
+    r = client.get(f"/library/{runner.albums()[0].id}/compare")
+
+    assert r.status_code == 200
+    assert runner.albums()[0].update_available is True
+
+
+def test_the_library_filter_narrows_to_albums_with_an_update(engaged, monkeypatch):
+    """And the filter is what makes that reachable without opening fifty pages."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    # A second album whose TITLE differs, because a tile renders the album title
+    # from the tags — two fixtures tagged from the same release are indis-
+    # tinguishable in the HTML, and the "not in" half of this test would then
+    # hold no matter what the filter did.
+    other = _release("Untouched Album") | {"id": "rel-bbb"}
+    d = cfg.paths.music_dir / "Test Artist" / "Untouched"
+    d.mkdir(parents=True)
+    shutil.copy(SINE_M4A, d / "01 Track 1.m4a")
+    tagger.tag_album(d, other)
+    sc.write(d, Sidecar(mb_release_id="rel-bbb", tagged_at=datetime.now(UTC)))
+    client, runner = engage()
+    next(a for a in runner.albums() if a.title == "Test Album").update_available = True
+
+    body = client.get("/library?filter=update-available").text
+
+    assert "Test Album" in body
+    assert "Untouched Album" not in body
+
+
+def test_the_filter_chip_is_dead_until_something_has_an_update(engaged):
+    """A chip worth 0 says so before it is picked, rather than answering with an
+    empty grid — the same promise the other three filters make, and the reason
+    the count is computed on every render. So the chip is a disabled span with
+    no link until an album is actually flagged, and a link the moment one is."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    client, runner = engage()
+
+    body = client.get("/library").text
+    assert "Update available" in body  # offered
+    assert "filter=update-available" not in body  # but not selectable
+
+    runner.albums()[0].update_available = True
+
+    assert "filter=update-available" in client.get("/library").text
+
+
+@pytest.mark.parametrize("mbid", ["rel-aaa"])
+def test_stored_release_reads_the_store_and_never_the_network(tmp_path, monkeypatch, mbid):
+    """`stored_release` is the warm-up's whole budget guarantee, so it is worth
+    pinning apart from its caller: a miss returns None rather than fetching."""
+    activity_store.init(tmp_path / "activity.db")
+    monkeypatch.setattr(
+        mb_lookup,
+        "fetch_release",
+        lambda *a, **k: pytest.fail("stored_release went to MusicBrainz"),
+    )
+
+    assert mb_cache.stored_release(mbid) is None
+
+    stored = _release()
+    activity_store.store_release(mbid, "+".join(sorted(mb_lookup.RELEASE_INCLUDES)), stored)
+
+    assert mb_cache.stored_release(mbid) == copy.deepcopy(stored)


### PR DESCRIPTION
Adds the Library's **Update available** filter: the albums whose MusicBrainz release has moved on since their files were tagged. Until now the only way to discover one was to open its page and look, so at library scale upstream corrections landed where nobody saw them.

This is #287 done ahead of the background pass (#270), because it does not need it — browsing fills the filter in, and the startup warm-up fills in everything MusicBrainz has already been asked about.

## The verdict

A dry run of the tagger (#266) — disk versus the release MusicBrainz last gave us — not the album page's `compare.*` engine, which is display-shaped and would judge on fields a re-tag cannot write while missing most of what one would.

Deriving from the plan rather than from *"the payload changed since we last looked"* is what makes it behave in the two awkward cases:

- an **unchanged** release whose files never took the previous update stays flagged (a payload comparison would clear it);
- an edit **reverted** upstream (A → B → A) clears itself (a payload comparison would flag it, and keep flagging it, because something did change every time we asked).

A structural change — the file count no longer matching the tracklist — counts as an update rather than an error: `plan_album`'s refusal *is* the finding.

## Nothing is persisted

No sidecar field, no table, no lifecycle, so the album's state stays derived and there is nothing for review-gate item 3 to object to. The flag lives on the in-memory `Album`, which gets both halves of the behaviour for free: a rescan of an untouched album keeps it (`resolve_dir` returns the cached Album on a signature hit, `merge_by_identity` passes a one-part album through), and a re-tag rebuilds the album and drops the flag with no bookkeeping.

After a restart the flags rebuild from stored release payloads plus the tags on disk, at a cost of **zero MusicBrainz requests** — the rate-limited half of the detector is exactly the half a rebuild does not need. The stored row's age is irrelevant to it, which is the point: a warm-up built on `fetch_release` would look correct against a fresh row and go to the network for every album in the field.

The filter therefore reports only what Harmonist has had reason to look at. That under-reporting is by design — it can miss an album, but it can never invite the user to act on an update that is not there — and it is documented as such in `docs/usage.md`. #270 fills in the rest.

## `formats.READ_ERRORS`

An `except OSError` around a tag read looks thorough and misses the common case: `MutagenError` is **not** an `OSError`, so a truncated or non-audio file raises `MP4StreamInfoError`, which inherits straight from `Exception`, and sails past the catch. The set is now named once inside the package where mutagen stops, so the gap is not rediscovered per caller.

## Testing

`test/test_gardener.py`, at two rungs. The web-rung tests engage the `ScanRunner`, which is not incidental — without it every request rescans and builds fresh `Album`s, so a flag set by one request would be gone by the next and the test would be asserting about a configuration production never runs in.

Six mutation checks were run. Two of them survived, and both tests were wrong:

- the no-requests test seeded a *fresh* cache row, so a `fetch_release`-based warm-up passed it while going to the network for every real album. It now ages the row seven days.
- the narrowing test asserted `"Untouched" not in body` while both fixture albums rendered the same tag-derived title, so that half could never fail.

Fixes #287