### PR TITLE
Write the release type the way Picard writes it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Harmonist wrote **MusicBrainz Album Type** capitalised (`Album`) where Picard
+  writes it lowercase (`album`), so nearly every album in a library adopted from
+  Picard disagreed with Harmonist on that one field permanently — showing up as a
+  re-tag that never settled, and, once the Update available filter arrived, as
+  most of the library apparently needing an update (#290). Both this and
+  **Album Status** now match Picard. Albums Harmonist tagged itself will show one
+  corrective update.
+
 ### Added
 
 - The Library has an **Update available** filter (#287), gathering albums whose

--- a/docs/design.md
+++ b/docs/design.md
@@ -814,8 +814,10 @@ Per-album (same on every track):
 - `----:com.apple.iTunes:MusicBrainz Album Id` — release MBID
 - `----:com.apple.iTunes:MusicBrainz Album Artist Id` — release-artist MBID(s)
 - `----:com.apple.iTunes:MusicBrainz Release Group Id`
-- `----:com.apple.iTunes:MusicBrainz Album Type`
-- `----:com.apple.iTunes:MusicBrainz Album Status`
+- `----:com.apple.iTunes:MusicBrainz Album Type` — **lower-cased** (`album`, not
+  `Album`), matching Picard. Primary type only; secondary types are not written.
+- `----:com.apple.iTunes:MusicBrainz Album Status` — **lower-cased** (`official`),
+  matching Picard.
 - `----:com.apple.iTunes:MusicBrainz Album Release Country`
 
 Per-track:

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -991,8 +991,19 @@ def _build_tagset(
         script=(release.get("text-representation") or {}).get("script") or None,
         mb_album_artist_ids=_artist_ids(release.get("artist-credit")),
         mb_release_group_id=rg.get("id"),
-        mb_album_type=rg.get("primary-type"),
-        # Picard writes the status lower-cased (e.g. "official", not "Official").
+        # Picard lower-cases BOTH of these — "album", not "Album"; "official",
+        # not "Official" — so Harmonist does too, or an adopted library differs
+        # from us on a field forever (#290). It differed on the type for exactly
+        # that reason: the status was normalised here and the type was not, and
+        # the gap is invisible because both fields look right in isolation.
+        #
+        # Cost of getting it wrong is not one bad row: `mb_album_type` is
+        # Identity under the significance map (design §"Identity"), so the
+        # gardener would route ~90% of an adopted library to the Inbox on its
+        # first night over a capital letter — #283's failure mode on a second
+        # field. Any future field taken from a MusicBrainz vocabulary belongs in
+        # this pair, not beside it.
+        mb_album_type=(rg.get("primary-type") or "").lower() or None,
         mb_album_status=(release.get("status") or "").lower() or None,
         mb_album_country=release.get("country"),
         mb_track_id=(track.get("recording") or {}).get("id"),

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -365,3 +365,25 @@ def test_stored_release_reads_the_store_and_never_the_network(tmp_path, monkeypa
     activity_store.store_release(mbid, "+".join(sorted(mb_lookup.RELEASE_INCLUDES)), stored)
 
     assert mb_cache.stored_release(mbid) == copy.deepcopy(stored)
+
+
+def test_a_picard_tagged_album_does_not_flag_on_the_release_type(tmp_path):
+    """Picard writes `MusicBrainz Album Type` lowercase, as it does the status.
+    Harmonist wrote the status the same way and the type verbatim from
+    MusicBrainz, so every Picard-tagged album in an adopted library differed on
+    that one field forever — ~90% of a real library, and `mb_album_type` is
+    classified Identity, so the gardener would have sent all of it to the Inbox
+    on its first night (#290).
+    """
+    from mutagen.mp4 import MP4
+
+    from harmonist.tagger import ATOM_MB_ALBUM_TYPE
+
+    release = _release()
+    album = _tagged(tmp_path, release)
+    # What Picard leaves on disk, which is what an adopted library carries.
+    f = MP4(album.path / "01 Track 1.m4a")
+    f[ATOM_MB_ALBUM_TYPE] = [b"album"]
+    f.save()
+
+    assert gardener.would_change(album, release) is False

--- a/test/test_picard_spec.py
+++ b/test/test_picard_spec.py
@@ -165,8 +165,11 @@ def test_album_level_mbid_atoms_match_picard_names(tmp_path):
     assert _atom_str(audio, ATOM_MB_ALBUM_ID) == "11111111-2222-3333-4444-555555555555"
     assert _atom_strs(audio, ATOM_MB_ALBUM_ARTIST_ID) == ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"]
     assert _atom_str(audio, ATOM_MB_RELEASE_GROUP_ID) == "abcdef01-2345-6789-abcd-ef0123456789"
-    assert _atom_str(audio, ATOM_MB_ALBUM_TYPE) == "Album"
-    assert _atom_str(audio, ATOM_MB_ALBUM_STATUS) == "official"  # Picard lower-cases status
+    # Picard lower-cases both of these vocabulary fields, so we do too — an
+    # adopted library carries "album"/"official" and would otherwise differ from
+    # Harmonist on the type forever (#290).
+    assert _atom_str(audio, ATOM_MB_ALBUM_TYPE) == "album"
+    assert _atom_str(audio, ATOM_MB_ALBUM_STATUS) == "official"
     assert _atom_str(audio, ATOM_MB_ALBUM_COUNTRY) == "GB"
 
 

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -407,8 +407,9 @@ def test_tag_album_writes_all_album_atoms(album_with_tracks):
     assert _atom_str(track1, ATOM_MB_ALBUM_ID) == "rel-aaa"
     assert _atom_strs(track1, ATOM_MB_ALBUM_ARTIST_ID) == ["art-aaa"]
     assert _atom_str(track1, ATOM_MB_RELEASE_GROUP_ID) == "rg-aaa"
-    assert _atom_str(track1, ATOM_MB_ALBUM_TYPE) == "Album"
-    assert _atom_str(track1, ATOM_MB_ALBUM_STATUS) == "official"  # Picard lower-cases status
+    # Both lower-cased, matching Picard — see #290.
+    assert _atom_str(track1, ATOM_MB_ALBUM_TYPE) == "album"
+    assert _atom_str(track1, ATOM_MB_ALBUM_STATUS) == "official"
     assert _atom_str(track1, ATOM_MB_ALBUM_COUNTRY) == "GB"
     assert _atom_str(track1, ATOM_LABEL) == "Test Label"
     assert _atom_str(track1, ATOM_CATALOG) == "CAT-001"


### PR DESCRIPTION
Picard lower-cases both MusicBrainz vocabulary fields it writes — `album`, `official`. Harmonist normalised the **status** and took the **type** verbatim from MusicBrainz, so it wrote `Album` where an adopted library carries `album`, and the two disagreed on that field forever.

```python
mb_album_type=rg.get("primary-type"),                            # verbatim → "Album"
mb_album_status=(release.get("status") or "").lower() or None,   # lowered  → "official"
```

## Scale

A 25-album sample of a real adopted library:

| field | values found |
|---|---|
| `MusicBrainz Album Type` | **18 × `album`**, 2 × `Album` (exactly the two Harmonist tagged itself) |
| `MusicBrainz Album Status` | **21 × `official`**, 0 capitalised |

So: most of an adopted library, permanently. And it never settled — #266's write-skip could not fire on those albums, so every re-tag rewrote every file to change one letter.

## Why it mattered more than a wrong row

`mb_album_type` is **Identity** under the significance map (`docs/design.md`), the highest level, which routes to the Inbox. #32's first unattended pass over an adopted library would therefore have sent nearly all of it there over a capital letter. That is precisely the failure #283 was filed to prevent — *"`album` would differ on every pass forever … #267's IDENTITY verdict would put the whole library in the Inbox on the gardener's first night"* — arriving on a second field.

Found because #287's new **Update available** filter listed *Aphex Twin — Selected Ambient Works, Volume II* while the album page showed every field matching. The page compares nine fields and this is not one of them; that gap is #291.

## Verified against the album that surfaced it

Before, against the live release — 27 files, two fields:

```
mb_album_type   'album' -> 'Album'
original_date   None    -> '1994-03-07'
```

After: `['original_date']` only. The remaining difference is a genuine enrichment MusicBrainz has and the files do not.

## What moves with the contract

- `test_picard_spec.py` and `test_tagger.py` both pinned `"Album"`; both now pin `"album"`, with the reason attached.
- `docs/design.md`'s atom list states the lower-casing explicitly for **both** fields — the gap was never that either looked wrong alone, it was that nothing said they were a pair. The note also records that only the primary type is written.
- New red-first test in `test_gardener.py`: an album carrying Picard's lowercase type must not read as having an update. It failed on its assertion before the fix.

Albums Harmonist tagged itself will show one corrective update, which is the intended direction.

Fixes #290