### PR TITLE
Say when an operation took too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+- **Harmonist now says in its log when something took too long** (#300) — a
+  MusicBrainz fetch, reading one album's tags, or a whole album comparison. One
+  line naming what was slow, how slow, and which album, and nothing at all when
+  things are normal. Until now a page that took ninety seconds and a page that
+  never finished left exactly the same trace: none. These lines stay in the log
+  and deliberately do **not** appear in the Activity feed, which is for what
+  Harmonist did rather than how long it took.
+
 ### Fixed
 
 - **The Tags comparison on an album's page now covers every album tag Harmonist

--- a/docs/design.md
+++ b/docs/design.md
@@ -1314,6 +1314,14 @@ at INFO), and `scanner._warn_once` complains about an unbuildable directory only
 when its signature has changed since the last complaint, so "I tried to fix it
 and it's still wrong" is still reported while "still broken, unchanged" is not.
 
+A third guard is different in kind: `extra={"_diagnostic": True}` keeps a record
+out of the feed **entirely**, rather than rate-limiting it. For measurements —
+`timing.warn_if_slow`, which warns when an operation crosses a threshold — the
+level is right for the log and wrong for the feed: nothing failed, nothing was
+lost, and there is nothing to act on. The distinction is worth holding onto when
+adding any new WARNING: the mirror's rule is *every warning is news the user
+should see*, which is true of a failure and false of a stopwatch.
+
 #### The per-album refresh
 
 The album page re-reads *its own* album's directories before rendering

--- a/src/harmonist/activity.py
+++ b/src/harmonist/activity.py
@@ -152,6 +152,18 @@ class _ActivityLogHandler(logging.Handler):
     def emit(self, rec: logging.LogRecord) -> None:
         if getattr(rec, "_activity", False):
             return  # already recorded via record(); don't loop it back
+        if getattr(rec, "_diagnostic", False):
+            # A measurement, not news. The feed is what Harmonist DID — actions
+            # and the failures that interrupted them — and a line saying an
+            # album took twelve seconds to read is neither: nothing went wrong,
+            # nothing was lost, and there is nothing for the user to act on.
+            #
+            # Load-bearing, not tidiness. `timing.warn_if_slow` (#300) fires on
+            # a threshold, so under exactly the conditions worth investigating
+            # (#299) it fires on every album page view — and the feed would fill
+            # with rows about its own slowness. That is #272's shape: a notice
+            # reporting a recurring condition rather than a change.
+            return
         try:
             msg = rec.getMessage()
         except Exception:

--- a/src/harmonist/mb_cache.py
+++ b/src/harmonist/mb_cache.py
@@ -48,7 +48,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from . import activity_store, mb_lookup
+from . import activity_store, mb_lookup, timing
 from .models import Release
 
 log = logging.getLogger(__name__)
@@ -67,6 +67,16 @@ _ttl = timedelta(hours=1)
 # refreshes the stored row, which keeps the gardener's baseline current. Calling
 # `mb_lookup` directly would bypass the fetch and the recording both.
 FRESH = timedelta(0)
+
+# When a live fetch is slow enough to be worth a line in the log (#300).
+#
+# Comfortably above the floor rather than near it: musicbrainzngs paces requests
+# at one per second (`MB_RATE_LIMIT_SECONDS`), so a *healthy* fetch can spend a
+# second waiting its turn before the network is touched at all. A threshold near
+# that would warn on every album and the log would be noise inside a day. Five
+# seconds means something else is happening — a queue behind other callers, or a
+# request that has stalled.
+_SLOW_FETCH = timedelta(seconds=5)
 
 
 def configure(ttl: timedelta) -> None:
@@ -116,7 +126,8 @@ def fetch_release(mbid: str, *, max_age: timedelta | None = None) -> Release:
     cached = activity_store.cached_release(mbid, inc)
     if cached is not None and _fresh(cached, _ttl if max_age is None else max_age):
         return cached.payload
-    release = mb_lookup.fetch_release(mbid)
+    with timing.warn_if_slow("MusicBrainz release fetch", _SLOW_FETCH, mbid=mbid):
+        release = mb_lookup.fetch_release(mbid)
     # Stored under the id the release ACTUALLY has, which after a merge is not
     # the one asked for (#268). Keying the row by the requested id would cache
     # the surviving release under a dead MBID — served to nobody, and leaving

--- a/src/harmonist/timing.py
+++ b/src/harmonist/timing.py
@@ -1,0 +1,94 @@
+"""Saying when an operation took too long (#300).
+
+Harmonist has had no way to report slowness. Every operation either succeeded
+silently or failed loudly, so a page that took ninety seconds and a page that
+never returned produced exactly the same log: nothing at all.
+
+That is not a cosmetic gap. #299 is an album page that stalls after a restart on
+a NAS the developer is not sitting in front of, and it has two entirely
+different explanations — a background pass competing for the CPU, or a
+rate-limited MusicBrainz fetch — with no way to tell them apart after the fact.
+The log is the only channel for anything that happens while nobody is watching,
+and "slow" is exactly the kind of thing it was silent about.
+
+So: a guard that says nothing when things are fine, and one WARNING line when
+they are not.
+
+**WARNING, not ERROR.** Nothing was lost and nothing stopped working; this is
+the "recovered / degraded" level. **Silent under the threshold**, so a healthy
+install pays one `time.monotonic()` and adds no noise.
+
+Deliberately standalone. It does NOT import `audit`, whose `key=value`
+formatting this mirrors, because `audit` pulls in the SQLite activity store and
+a logging helper has no business dragging a database behind it. The convention
+is shared; the code is six lines and is not.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import timedelta
+
+log = logging.getLogger(__name__)
+
+
+@contextmanager
+def warn_if_slow(what: str, threshold: timedelta, **context: object) -> Iterator[None]:
+    """Log one WARNING if the block takes `threshold` or longer. Otherwise silent.
+
+    `context` becomes `key=value` pairs on the line, matching the audit log's
+    convention, so the warning names *which* album or release was slow rather
+    than reporting that something, somewhere, was. A line nobody can act on is
+    barely better than no line.
+
+    **Wrap a whole pass, never one iteration of a loop.** Twenty-seven warnings
+    for one slow album is the noise the error-handling rules warn about; one
+    warning naming the album is the signal. Where the worst item matters, the
+    caller should find it and pass it as context.
+
+    Reports a slow block that **raised**, too. The exception is somebody else's
+    to log, but how long it took before failing is a fact worth having — a
+    MusicBrainz call that fails after thirty seconds and one that fails at once
+    are different problems.
+
+    Thresholds are constants at their call sites, not settings. They are the
+    period of a backstop nobody should have to reason about, and a user has
+    nothing to tune them against (the same argument `_RESCAN_INTERVAL` makes).
+    """
+    started = time.monotonic()
+    try:
+        yield
+    finally:
+        elapsed = time.monotonic() - started
+        if elapsed >= threshold.total_seconds():
+            log.warning(
+                "%s took %.1fs (over %.1fs)%s",
+                what,
+                elapsed,
+                threshold.total_seconds(),
+                f" {_detail(context)}" if context else "",
+                # Keep it out of the user-facing Activity feed. `activity`
+                # mirrors every WARNING from a `harmonist.*` logger into the
+                # feed so background failures are visible — a good rule that
+                # assumed every warning is news. This one is a measurement:
+                # nothing went wrong and there is nothing to act on. Without
+                # the flag, the conditions most worth investigating are exactly
+                # the ones that would bury the feed in rows about themselves.
+                extra={"_diagnostic": True},
+            )
+
+
+def _detail(fields: dict[str, object]) -> str:
+    return " ".join(f"{key}={_fmt(value)}" for key, value in fields.items())
+
+
+def _fmt(value: object) -> str:
+    """One context value, quoted when it contains whitespace — album paths do,
+    and an unquoted one would split the line into unparseable fragments."""
+    if value is None:
+        return "-"
+    s = str(value)
+    return f'"{s}"' if (not s or any(c.isspace() for c in s)) else s

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -52,6 +52,7 @@ from harmonist import (
     redownloads,
     scanner,
     tag_history,
+    timing,
 )
 from harmonist import config as config_mod
 from harmonist import sidecar as sidecar_mod
@@ -204,6 +205,17 @@ _LIBRARY_FILTERS: dict[str, tuple[str, Callable[[Album], bool]]] = {
     "no-artwork": ("No artwork", lambda a: not a.has_cover),
     "update-available": ("Update available", lambda a: a.update_available),
 }
+
+# When reading one album's tags is slow enough to say so (#300). Generous: this
+# is every file in the album opened and parsed, so a long album on a modest NAS
+# is legitimately a second or two, and #299 is the case where it is minutes.
+_SLOW_ALBUM_READ = timedelta(seconds=10)
+
+# When the whole disk-vs-MusicBrainz comparison is slow enough to say so. The
+# most valuable of the three, and the reason it exists as well as the two
+# beneath it: a page can be slow with no single phase crossing its own
+# threshold, and this is the line that says so anyway.
+_SLOW_COMPARE = timedelta(seconds=15)
 
 # Longest search query the Library will act on (#180). Unlike `?filter=`'s slug,
 # `q` is free text, and it is reflected into every URL this page builds — seventeen
@@ -882,10 +894,15 @@ def _album_tracks(
     """
     audio = album_files.for_paths(paths) if paths else album_files.audio_files(album_dir)
     video = album_files.videos_for_paths(paths) if paths else album_files.video_files(album_dir)
-    return (
-        [(_rel_to(f, album_dir), formats.read_tags(f)) for f in audio],
-        [(_rel_to(f, album_dir), formats.read_video_tags(f)) for f in video],
-    )
+    # The whole pass, not each file: one line naming a slow album is the signal,
+    # twenty-seven lines naming its tracks is the noise (#300).
+    with timing.warn_if_slow(
+        "album tag read", _SLOW_ALBUM_READ, album=album_dir, files=len(audio) + len(video)
+    ):
+        return (
+            [(_rel_to(f, album_dir), formats.read_tags(f)) for f in audio],
+            [(_rel_to(f, album_dir), formats.read_video_tags(f)) for f in video],
+        )
 
 
 def _in_track_order(
@@ -3695,10 +3712,27 @@ def _register_routes(app: FastAPI) -> None:
                 '<p class="text-2xs text-muted italic mt-2">'
                 "No MusicBrainz release to compare against.</p>"
             )
+        # Around the whole thing (#300). The MusicBrainz fetch and the tag read
+        # carry their own guards, but this is the one that catches a page that
+        # was slow without any single phase crossing its threshold — which is
+        # the shape of #299, where the page stalls and nothing says why.
+        with timing.warn_if_slow(
+            "album comparison", _SLOW_COMPARE, album=album.path, mbid=sc.mb_release_id
+        ):
+            return _compare_response(request, album, sc.mb_release_id, reread=reread)
+
+    def _compare_response(request: Request, album: Album, mbid: str, *, reread: bool) -> Response:
+        """The body of `library_compare`, split out only so the timing guard
+        above can wrap it — every `return` in here is a way the comparison can
+        end, and a guard that covered some of them would report the fast paths
+        and stay silent on whichever one was slow.
+
+        Takes the release id rather than the sidecar: the caller has already
+        established it is present, and passing the narrowed value states that
+        precondition in the signature instead of leaving it as something the
+        two functions have to agree about silently."""
         try:
-            release = mb_cache.fetch_release(
-                sc.mb_release_id, max_age=mb_cache.FRESH if reread else None
-            )
+            release = mb_cache.fetch_release(mbid, max_age=mb_cache.FRESH if reread else None)
         except mb_lookup.ReleaseGoneError:
             # A 404 is an ANSWER, not a failure: the release has been deleted
             # from MusicBrainz, and no amount of retrying will bring it back.
@@ -3717,7 +3751,7 @@ def _register_routes(app: FastAPI) -> None:
             log.warning(
                 "album %s names release %s, which MusicBrainz no longer has",
                 album.path,
-                sc.mb_release_id,
+                mbid,
             )
             comparison, tracks = _album_disk_view(album.path, album.folders)
             return _templates(request).TemplateResponse(
@@ -3774,7 +3808,7 @@ def _register_routes(app: FastAPI) -> None:
             # Falls back to now only when the row is somehow missing (a store
             # that failed the write it was just asked for) — "read just now" is
             # then still true of the fetch that produced this response.
-            mb_read_at=mb_cache.fetched_at(sc.mb_release_id) or datetime.now(UTC),
+            mb_read_at=mb_cache.fetched_at(mbid) or datetime.now(UTC),
             # What a re-tag would actually change, field by field (#291). Free:
             # `refresh_flag` just built this plan to set the flag, so rendering
             # it costs no further reads — and without it the page can show every

--- a/test/test_timing.py
+++ b/test/test_timing.py
@@ -1,0 +1,138 @@
+"""Tests for the slow-operation guard (#300).
+
+The guard's whole value is that it is silent when things are fine and says
+exactly one useful thing when they are not, so both halves are pinned here — a
+guard that warned on every call would be turned off within a week, and one that
+stayed quiet when something was slow would be the gap it was built to close.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from harmonist import timing
+
+
+def test_a_fast_block_says_nothing(caplog):
+    """The common case, and the one that decides whether this is bearable. An
+    install where nothing is wrong must produce no timing output at all."""
+    with (
+        caplog.at_level(logging.DEBUG, logger="harmonist.timing"),
+        timing.warn_if_slow("read tags", timedelta(seconds=30)),
+    ):
+        pass
+
+    assert caplog.records == []
+
+
+def test_a_slow_block_warns_once(caplog):
+    with (
+        caplog.at_level(logging.WARNING, logger="harmonist.timing"),
+        timing.warn_if_slow("read tags", timedelta(0)),
+    ):
+        pass
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
+    assert "read tags took" in caplog.records[0].getMessage()
+
+
+def test_the_warning_names_what_was_slow(caplog):
+    """ "Something was slow" is not actionable on a library of thousands. The
+    line has to say which album, or nobody can do anything with it."""
+    with (
+        caplog.at_level(logging.WARNING, logger="harmonist.timing"),
+        timing.warn_if_slow(
+            "read tags", timedelta(0), album=Path("/music/Aphex Twin/SAW II"), tracks=27
+        ),
+    ):
+        pass
+
+    message = caplog.records[0].getMessage()
+    assert 'album="/music/Aphex Twin/SAW II"' in message  # quoted: it has a space
+    assert "tracks=27" in message
+
+
+def test_a_value_with_no_whitespace_is_not_quoted(caplog):
+    """Quoting everything would make the common case harder to read; quoting
+    nothing would split an album path across fields. Only what needs it."""
+    with (
+        caplog.at_level(logging.WARNING, logger="harmonist.timing"),
+        timing.warn_if_slow("fetch release", timedelta(0), mbid="rel-aaa"),
+    ):
+        pass
+
+    assert "mbid=rel-aaa" in caplog.records[0].getMessage()
+
+
+def test_a_slow_failure_is_reported_and_the_exception_still_propagates(caplog):
+    """How long something took before failing is a fact worth having — a
+    MusicBrainz call that fails after thirty seconds and one that fails at once
+    are different problems. The guard must not swallow the failure to say so."""
+    with (
+        caplog.at_level(logging.WARNING, logger="harmonist.timing"),
+        pytest.raises(ValueError, match="boom"),
+        timing.warn_if_slow("fetch release", timedelta(0), mbid="rel-aaa"),
+    ):
+        raise ValueError("boom")
+
+    assert len(caplog.records) == 1
+    assert "fetch release took" in caplog.records[0].getMessage()
+
+
+def test_a_fast_failure_says_nothing_extra(caplog):
+    """The exception is somebody else's to log. A guard that also spoke up on
+    every fast failure would double every error in the log."""
+    with (
+        caplog.at_level(logging.DEBUG, logger="harmonist.timing"),
+        pytest.raises(ValueError),
+        timing.warn_if_slow("fetch release", timedelta(seconds=30)),
+    ):
+        raise ValueError("boom")
+
+    assert caplog.records == []
+
+
+def test_a_slow_warning_does_not_reach_the_activity_feed():
+    """The feed is what Harmonist DID — actions, and the failures that
+    interrupted them. `activity` mirrors every WARNING from a `harmonist.*`
+    logger into it so background failures are visible, which is right and which
+    assumed every warning is news.
+
+    A timing line is a measurement: nothing went wrong, nothing was lost, and
+    there is nothing to act on. And it fires on a threshold, so under exactly
+    the conditions worth investigating (#299) it fires on every album page view
+    — the feed would fill with rows about its own slowness. Found because this
+    warning mirrored into the feed on the first run.
+    """
+    from harmonist import activity, activity_store
+
+    activity.install_log_handler()
+    activity_store.init(":memory:")
+    before = len(activity_store.recent(50))
+
+    with timing.warn_if_slow("read tags", timedelta(0), album="/music/A/B"):
+        pass
+
+    assert len(activity_store.recent(50)) == before
+
+
+def test_a_real_warning_still_reaches_the_activity_feed():
+    """The exemption must be narrow. If it silenced the mirror generally, every
+    background failure would stop being visible — which is what the mirror is
+    for."""
+    import logging as _logging
+
+    from harmonist import activity, activity_store
+
+    activity.install_log_handler()
+    activity_store.init(":memory:")
+    before = len(activity_store.recent(50))
+
+    _logging.getLogger("harmonist.test").warning("a real background failure")
+
+    assert len(activity_store.recent(50)) == before + 1


### PR DESCRIPTION
Harmonist had no way to report slowness. Every operation either succeeded silently or failed loudly, so a page that took ninety seconds and a page that never returned produced exactly the same log: **nothing**.

That is what makes #299 undiagnosable — an album page that stalls after a restart, on a NAS nobody is sitting in front of, with two entirely different explanations (a background pass competing for the CPU, or a rate-limited MusicBrainz fetch) and no way to tell them apart after the fact.

## The guard

`timing.warn_if_slow` is a context manager that logs **one WARNING** when a block crosses a threshold and says nothing otherwise, so a healthy install pays one `time.monotonic()` and adds no noise.

Context kwargs become `key=value` pairs, matching the audit log's convention, so the line names *which* album was slow — "something was slow" is not actionable on a library of thousands.

It reports a slow block that **raised**, too: the exception is somebody else's to log, but a MusicBrainz call that fails after thirty seconds and one that fails at once are different problems.

## Three call sites

The MusicBrainz fetch, one album's tag read, and the whole comparison. The last is the one that earns its place: a page can be slow with no single phase crossing its own threshold, and that is the shape of #299.

**The MusicBrainz threshold is five seconds, deliberately not near the floor.** musicbrainzngs paces at 1 req/s, so a *healthy* fetch can spend a second waiting its turn; a threshold near that would warn on every album and the log would be noise inside a day.

**`refresh_flag` is deliberately not wrapped.** On the album page it is already inside the comparison's guard, and in the warm-up it is a per-album loop where a threshold warning fires once per album — the noise the error-handling rules warn about in loops. The warm-up needs start and progress lines instead, which is #299.

## The find this cost

The first test run failed `assert 2 == 1` — two log records where one was expected. The second was `harmonist.activity`: **the feed mirrors every WARNING from a `harmonist.*` logger**, so every timing warning was becoming a user-facing Activity entry.

That is not a test problem. The mirror's rule — *every warning is news the user should see* — is right for a failure and wrong for a stopwatch. And this fires on a **threshold**, so under exactly the conditions worth investigating the feed would fill with rows about its own slowness. That is #272's shape: a notice reporting a recurring condition rather than a change.

So `extra={"_diagnostic": True}` keeps a measurement in the log and out of the feed, tested **both ways** — a timing warning does not reach the feed, and a genuine background warning still does, so the exemption stays narrow. Mutation-checked: removing the exemption fails the first test.

`docs/design.md` already documented the mirror's failure mode and its two guards against *repetition*; this is a third of a different kind (do not mirror at all, rather than do not repeat), so it is recorded beside them. Worth holding onto when adding any new WARNING.

## Testing

Eight tests: silent under threshold, warns once over it, names what was slow, quotes only values that need it, reports a slow failure without swallowing the exception, stays quiet on a fast failure, and the two feed-mirroring cases above.

Fixes #300