### PR TITLE
Let the warm-up say what it is doing, and get out of the way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+- The background pass that fills the **Update available** filter after a restart
+  now **reports itself in the log** — when it starts, how far it has got, and how
+  long it took (#299). It also **paces itself against the machine it is on**,
+  resting in proportion to what each album costs rather than by a fixed amount,
+  so on a slower NAS it gets out of the way of whatever you are doing rather than
+  competing with it. Previously it ran silently, which made a slow page during
+  that window indistinguishable from a stuck one.
 - **Harmonist now says in its log when something took too long** (#300) — a
   MusicBrainz fetch, reading one album's tags, or a whole album comparison. One
   line naming what was slow, how slow, and which album, and nothing at all when

--- a/src/harmonist/gardener.py
+++ b/src/harmonist/gardener.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Iterable
+from collections.abc import Sequence
 from datetime import timedelta
 
 from . import album_files, formats, mb_cache, tagger
@@ -55,11 +55,29 @@ from .models import Album, AlbumState, Release
 
 log = logging.getLogger(__name__)
 
-# How long the warm-up rests between albums. It is bounded by disk rather than
-# by MusicBrainz's 1 req/s, so this is not a rate limit — it is politeness to a
-# NAS that is also serving Plex, and to the library scan this runs behind.
-# Small enough that a 2,000-album library warms in a few minutes.
-WARM_PAUSE = timedelta(milliseconds=50)
+# What fraction of the time the warm-up is allowed to be working. The rest of
+# each album's share is spent asleep, so the pass takes roughly 1/duty times as
+# long as the work itself and leaves the remainder to whatever else the machine
+# is doing — a request being served, Plex transcoding, the library scan.
+#
+# A ratio rather than a fixed pause (#299). The original rested 50 ms between
+# albums, which is most of the time on a laptop and a rounding error on a NAS —
+# backwards, since the slow machine is the one that most needs this out of the
+# way. Resting in proportion to what each album cost self-tunes to the machine
+# with nothing to measure and nothing to configure.
+#
+# A quarter is deliberately unambitious. The warm-up's only job is that the
+# Library's Update available filter is not empty after a restart, and being
+# late to that is invisible — the filter under-reports by design and browsing
+# fills it in. Being slow is free here; being in the way is not.
+WARM_DUTY = 0.25
+
+# How often a running pass says where it has got to. Long enough not to fill the
+# log on a healthy install, short enough that a stalled pass is obvious.
+_PROGRESS_EVERY = timedelta(seconds=30)
+
+# The longest single rest, so one pathological album cannot park the pass.
+_MAX_REST = timedelta(seconds=2)
 
 
 def plan_for(album: Album, release: Release) -> tagger.AlbumPlan:
@@ -147,7 +165,7 @@ def refresh_flag(album: Album, release: Release) -> tagger.AlbumPlan | None:
     return plan
 
 
-def warm_from_cache(albums: Iterable[Album], *, pause: timedelta = WARM_PAUSE) -> int:
+def warm_from_cache(albums: Sequence[Album], *, duty: float = WARM_DUTY) -> int:
     """Rebuild the update-available flags from stored releases. Returns how many
     albums were flagged.
 
@@ -169,9 +187,18 @@ def warm_from_cache(albums: Iterable[Album], *, pause: timedelta = WARM_PAUSE) -
 
     Blocking I/O (one read per file, per `plan_album`), so call it from a worker
     thread, never the event loop.
+
+    **Paced by duty cycle, and audible while it runs** (#299). It shipped doing
+    neither, and the two failures compounded: on a NAS it took the CPU for
+    however long a whole library takes to parse, while saying nothing at all
+    until it finished — so an album page that crawled during that window looked
+    identical to one that had hung, with no way to tell which from the log.
     """
+    started = time.monotonic()
+    log.info("update-available warm-up: checking %d albums", len(albums))
     flagged = 0
     looked = 0
+    reported = started
     for album in albums:
         sc = album.sidecar
         if sc is None or not sc.mb_release_id:
@@ -180,17 +207,42 @@ def warm_from_cache(albums: Iterable[Album], *, pause: timedelta = WARM_PAUSE) -
         if release is None:
             continue  # never fetched, or fetched under a different `inc`
         looked += 1
+        at = time.monotonic()
         refresh_flag(album, release)
         # The verdict is the flag, not the return value — a None comes back both
         # for an unreadable album (not flagged) and for one whose tracklist no
         # longer fits (flagged), so counting the return would undercount.
         if album.update_available:
             flagged += 1
-        if pause > timedelta(0):
-            time.sleep(pause.total_seconds())
+        _rest(time.monotonic() - at, duty)
+        if time.monotonic() - reported >= _PROGRESS_EVERY.total_seconds():
+            reported = time.monotonic()
+            log.info(
+                "update-available warm-up: %d albums looked at, %d with an update", looked, flagged
+            )
     log.info(
-        "update-available warm-up: %d of %d albums with a stored release have an update",
+        "update-available warm-up: done in %.0fs — %d of %d albums with a stored release "
+        "have an update",
+        time.monotonic() - started,
         flagged,
         looked,
     )
     return flagged
+
+
+def _rest(worked: float, duty: float) -> None:
+    """Sleep long enough that the pass only ever uses `duty` of the machine.
+
+    A fixed pause was the original, and it is the wrong shape: 50 ms between
+    albums is most of the time on a laptop and a rounding error on a NAS, which
+    is exactly backwards — the slow machine is the one that needs the pass to
+    get out of the way. Resting in proportion to what each album actually cost
+    self-tunes with no measurement, no configuration and nothing shared with the
+    request path to coordinate through.
+
+    Capped, so one pathological album — a hundred tracks on a failing disk —
+    cannot stall the whole pass behind a single long sleep.
+    """
+    if duty <= 0 or duty >= 1:
+        return  # 0 disables pacing (tests); 1 means "no rest", same thing here
+    time.sleep(min(worked * (1 / duty - 1), _MAX_REST.total_seconds()))

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -168,7 +168,7 @@ def test_the_warm_up_rebuilds_flags_without_asking_musicbrainz(tmp_path, monkeyp
 
     monkeypatch.setattr(mb_lookup, "fetch_release", _no_requests)
 
-    assert gardener.warm_from_cache([album], pause=timedelta(0)) == 1
+    assert gardener.warm_from_cache([album], duty=0) == 1
     assert album.update_available is True
 
 
@@ -188,10 +188,10 @@ def test_a_second_warm_up_changes_nothing(tmp_path, monkeypatch):
         mb_lookup, "fetch_release", lambda *a, **k: pytest.fail("warm-up went to MusicBrainz")
     )
 
-    first = gardener.warm_from_cache([album], pause=timedelta(0))
+    first = gardener.warm_from_cache([album], duty=0)
     events_after_first = len(activity_store.recent(50))
 
-    assert gardener.warm_from_cache([album], pause=timedelta(0)) == first == 1
+    assert gardener.warm_from_cache([album], duty=0) == first == 1
     assert album.update_available is True
     assert len(activity_store.recent(50)) == events_after_first
 
@@ -202,7 +202,7 @@ def test_the_warm_up_leaves_an_album_musicbrainz_was_never_asked_about(tmp_path)
     activity_store.init(tmp_path / "activity.db")
     album = _tagged(tmp_path, _release())
 
-    assert gardener.warm_from_cache([album], pause=timedelta(0)) == 0
+    assert gardener.warm_from_cache([album], duty=0) == 0
     assert album.update_available is False
 
 
@@ -214,7 +214,7 @@ def test_the_warm_up_skips_an_album_with_no_release_of_its_own(tmp_path):
     album = next(a for a in scanner.scan(tmp_path) if a.path == d)
     assert album.sidecar is None
 
-    assert gardener.warm_from_cache([album], pause=timedelta(0)) == 0
+    assert gardener.warm_from_cache([album], duty=0) == 0
 
 
 async def _scan_via_runner(runner: ScanRunner) -> None:
@@ -484,3 +484,63 @@ def test_an_album_with_nothing_waiting_says_nothing(engaged, monkeypatch):
     body = client.get(f"/library/{runner.albums()[0].id}/compare").text
 
     assert "Update available" not in body
+
+
+# ---------------------------------------------------------------------------
+# Pacing and audibility (#299)
+# ---------------------------------------------------------------------------
+
+
+def test_the_warm_up_says_it_started_and_says_it_finished(tmp_path, caplog):
+    """It shipped logging one line, at the end. On a NAS that made a pass taking
+    minutes indistinguishable from no pass at all — and from a hang, which is
+    exactly the ambiguity that left #299 with two competing explanations and no
+    way to choose between them."""
+    import logging
+
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+
+    with caplog.at_level(logging.INFO, logger="harmonist.gardener"):
+        gardener.warm_from_cache([album], duty=0)
+
+    lines = [r.getMessage() for r in caplog.records]
+    assert any("checking 1 albums" in m for m in lines)
+    assert any("done in" in m for m in lines)
+
+
+def test_the_rest_is_proportional_to_the_work(monkeypatch):
+    """A fixed pause is the wrong shape: 50 ms is most of the time on a laptop
+    and a rounding error on a NAS, which is backwards — the slow machine is the
+    one that most needs the pass out of its way. Resting in proportion to what
+    the album actually cost self-tunes with nothing to measure."""
+    slept: list[float] = []
+    monkeypatch.setattr(gardener.time, "sleep", slept.append)
+
+    gardener._rest(worked=0.1, duty=0.25)  # a quarter duty → rest three times as long
+
+    assert slept == [pytest.approx(0.3)]
+
+
+def test_one_pathological_album_cannot_park_the_pass(monkeypatch):
+    """Proportional rest has a tail: a hundred-track album on a failing disk
+    would otherwise buy itself a rest measured in minutes, during which the pass
+    does nothing at all and its progress lines say nothing new."""
+    slept: list[float] = []
+    monkeypatch.setattr(gardener.time, "sleep", slept.append)
+
+    gardener._rest(worked=600.0, duty=0.25)
+
+    assert slept == [gardener._MAX_REST.total_seconds()]
+
+
+def test_pacing_can_be_switched_off_entirely(monkeypatch):
+    """`duty=0` is what the tests above run at, so it has to mean *no sleep at
+    all* rather than a very short one — a test suite that really slept would be
+    paying the pass's politeness on every run."""
+    slept: list[float] = []
+    monkeypatch.setattr(gardener.time, "sleep", slept.append)
+
+    gardener._rest(worked=1.0, duty=0)
+
+    assert slept == []


### PR DESCRIPTION
The update-available warm-up shipped doing neither, and the two failures compounded. On a NAS it took the machine for however long a whole library takes to parse, while saying nothing at all until it finished — so an album page that crawled during that window looked exactly like one that had hung, and the log could not tell them apart. That is why #299 had two competing explanations and no way to choose between them.

## Audible

A line when it starts, naming how many albums it will check. Progress every 30 seconds. A finish line with the elapsed time.

```
INFO harmonist.gardener: update-available warm-up: checking 14 albums
INFO harmonist.gardener: update-available warm-up: done in 0s — 0 of 0 albums with a stored release have an update
```

A long job that is silent is indistinguishable from no job at all, and from a stuck one.

## Paced by duty cycle, not a fixed pause

It rested 50 ms between albums. That is most of the time on a laptop and a rounding error on a NAS — **backwards**, since the slow machine is the one that most needs the pass out of its way.

Now it rests in proportion to what each album actually cost: at a quarter duty, an album that took 200 ms buys 600 ms of rest. That self-tunes to the machine with nothing to measure, nothing to configure, and nothing shared with the request path to coordinate through. Capped, so one pathological album — a hundred tracks on a failing disk — cannot park the pass behind a single long sleep.

**A quarter is deliberately unambitious.** The warm-up's only job is that the Library's Update available filter is not empty after a restart, and being late to that is invisible: the filter under-reports by design and browsing fills it in. Being slow is free here; being in the way is not.

## Three decisions

**Kept at startup**, rather than deferred to first use as the issue floated. Filling the filter lazily would leave it empty exactly when someone first looks at it — that is the symptom, not the fix.

**Not wrapped in `timing.warn_if_slow` (#300).** A threshold warning inside a per-album loop fires once per album, which is the noise the error-handling rules warn about in loops. Progress lines are the right shape for a long job; thresholds are the right shape for a single operation.

**The start line's wording came from reading a real run.** It was "starting over 14 albums", which reads as *restarting*. No test would ever have caught that.

## Testing

Four new tests: the start and finish lines exist, rest is proportional to work, the cap holds for a pathological album, and `duty=0` means no sleep at all (so the suite does not pay the pass's politeness on every run).

Mutation-checked: reverting to a fixed pause fails both pacing tests; removing the start line fails the audibility test.

Fixes #299