### PR TITLE
Scope the re-tag box to the fields nothing else shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,9 @@ versions follow [semantic versioning](https://semver.org).
   it has already fetched — no MusicBrainz traffic — and keeps it current as you
   browse; re-tagging an album takes it off the list.
 - An album with an update waiting now **says what the update is**, on its own
-  page under the Tags comparison (#291) — field by field, before and after, in
-  the same form the History entry takes once you've applied it. The comparison
-  above it shows nine headline fields, so an album could previously be listed as
-  having an update and still read as matching on every row shown.
+  page under the Tags comparison (#291, #297) — the per-track tags the tracklist
+  has no column for, such as an ISRC or a recording ID MusicBrainz has filled in,
+  field by field and in the same form the History entry takes once applied.
 - Harmonist now **rescans your library once an hour** as a backstop (#151), for
   the cases where its file watcher isn't working and can't tell you so — a
   library mounted over the network, where the watcher is blind, or a watcher

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -201,12 +201,13 @@ you tagged it — each with its count:
   corrected, a release date fixed, a track retitled. Re-tag from the album's page
   to take it, and the album drops off the list.
 
-  The album's own page says *what* the update is, under the Tags comparison —
-  each field with its before and after, laid out the way the History entry will
-  be once you've applied it. The comparison above it covers every album-level tag
-  Harmonist writes, so the two agree; the list below adds the per-track fields —
-  ISRCs, recording IDs, track titles — which the comparison shows in the tracklist
-  rather than the field table.
+  The album's own page says *what* the update is. The Tags comparison covers
+  every album-level tag Harmonist writes, and the tracklist covers each track's
+  number, title, artist and length — between them, most of an update is visible
+  where you would look for it anyway. What is left goes in a short list under the
+  comparison: the per-track tags no column has room for — sort names, ISRCs, the
+  MusicBrainz ID of each recording — each with its before and after, laid out the
+  way the History entry will be once you've applied it.
 
   Harmonist works this out from the MusicBrainz releases it has already fetched,
   so the filter costs no lookups and fills in as you browse — an album you open

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -814,6 +814,36 @@ _TRACK_FIELDS: tuple[tuple[str, str, str, Kind], ...] = (
 TRACK_COLUMNS: tuple[str, ...] = ("#", "Title", "Artist", "Length")
 
 
+#: The owned fields the album page already shows somewhere — every compared row
+#: of the panel, plus the tracklist's Title, Artist and number columns.
+#:
+#: Exists so the re-tag plan's box (#291) can be scoped to what has NO other
+#: surface here (#297). Until #295 the panel compared nine fields out of thirty
+#: and the box was the only place the rest appeared; now the panel compares them
+#: all, and a box repeating them says the same thing twice on the same screen.
+#:
+#: **Derived from the two rendering tables, not listed beside them**, for the
+#: reason `_ALBUM_FIELDS` is: a hand-kept copy drifts, and here the drift shows
+#: up as a row printed twice — the exact complaint #297 was filed about. Taken
+#: from `_ALBUM_FIELDS` rather than `ALBUM_FIELDS` so it tracks what the panel
+#: RENDERS rather than what the album scope contains; a row the panel drops
+#: falls back to the box by itself. The `mb_attr` guard is what keeps Genre and
+#: Comment out — they are displayed, but they are not owned fields and a plan
+#: can never carry them.
+#:
+#: `disc_num` is deliberately NOT in here even though the number column can show
+#: it. `_number` reads it as `disc or 1`, so a track gaining an explicit disc
+#: number it lacked renders identically on both sides and the column stays
+#: silent. A field this set claims wrongly is a change the page cannot report at
+#: all; one it omits is a row shown twice on a multi-disc renumbering. Those are
+#: not the same size of mistake.
+SHOWN_FIELDS: frozenset[str] = frozenset(
+    [disk_attr for _, disk_attr, mb_attr, _ in _ALBUM_FIELDS if mb_attr]
+    + [mb_attr for _, _, mb_attr, _ in _TRACK_FIELDS]
+    + [Owned.TRACK_NUM.value]
+)
+
+
 def tracklist(
     tracks: Sequence[tuple[str, TrackTags]],
     mb: Sequence[MBTrack],

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -3809,17 +3809,28 @@ def _register_routes(app: FastAPI) -> None:
             # that failed the write it was just asked for) — "read just now" is
             # then still true of the fetch that produced this response.
             mb_read_at=mb_cache.fetched_at(mbid) or datetime.now(UTC),
-            # What a re-tag would actually change, field by field (#291). Free:
-            # `refresh_flag` just built this plan to set the flag, so rendering
-            # it costs no further reads — and without it the page can show every
-            # field matching while the Library says an update is waiting, which
-            # is a dead end with no third place to look.
+            # What a re-tag would change in the fields nothing else on this page
+            # shows (#291, narrowed by #297). Free: `refresh_flag` just built
+            # this plan to set the flag, so rendering it costs no further reads.
             #
-            # The panel above compares nine curated fields; the plan covers all
-            # thirty Harmonist owns, which is exactly the gap. Rendered through
-            # `tag_history`, so it reads like the History entry it will become.
+            # Scoped rather than complete, and that is the whole point. The box
+            # was written when the panel compared nine album fields out of the
+            # thirty the plan covers; #295 widened the panel to all of them, so
+            # an unfiltered box restates every album-level difference directly
+            # underneath itself. What survives `SHOWN_FIELDS` is the per-track
+            # tags — ISRCs, recording ids, sort names — which the four-column
+            # tracklist has nowhere to put and which are otherwise invisible.
+            #
+            # Rendered through `tag_history`, so it reads like the History entry
+            # it will become.
             update_changes=(
-                tag_history.from_plan(plan, album.path, album_files.for_paths(album.folders))
+                tuple(
+                    c
+                    for c in tag_history.from_plan(
+                        plan, album.path, album_files.for_paths(album.folders)
+                    )
+                    if c.field not in compare.SHOWN_FIELDS
+                )
                 if plan is not None and plan.changes
                 else ()
             ),

--- a/templates/partials/library_compare.html
+++ b/templates/partials/library_compare.html
@@ -19,14 +19,21 @@
     {% include 'partials/_track_list.html' %}
 </section>
 
-{# Why this album is in the Library's "Update available" filter (#291).
+{# The part of a waiting re-tag that has nowhere else on this page to appear
+   (#291, scoped by #297).
 
-   The panel above compares nine curated album fields; the flag is derived from
-   all thirty Harmonist owns, plus the per-track ones. So the two could disagree
-   in a way that read as a bug and wasn't — an album listed as having an update
-   whose page showed every field matching, with no third place to look. This is
-   that third place, and it sits in the Tags section because that is where the
-   reader already is when the question occurs to them.
+   It began as the whole plan, because the panel above compared nine album
+   fields and the flag was derived from thirty — so an album could sit in the
+   Library's "Update available" filter and read as matching on every row shown.
+   #295 closed that gap from the other end: the panel now compares every
+   album-scoped tag Harmonist writes, and an unscoped box repeats each of those
+   differences immediately below itself.
+
+   What is left is the per-track tags. The tracklist is four fixed columns — #,
+   Title, Artist, Length — so an ISRC MusicBrainz has filled in, a recording id
+   a merge has moved, a sort name Picard never wrote, appear NOWHERE else. The
+   filtering is `compare.SHOWN_FIELDS`, applied in the view, so this partial
+   renders whatever survives rather than knowing the rule itself.
 
    Rendered through the SAME partial as a History entry's change list, from the
    same `tag_history.FieldChange` rows: what is waiting reads exactly like the
@@ -35,10 +42,11 @@
    and the partial's Undo blocks are guarded on those being truthy. #}
 {% if update_changes %}
 <div class="mt-4 pt-3 border-t border-line">
-    <h3 class="text-2xs font-bold text-ink uppercase tracking-widest">Update available</h3>
+    <h3 class="text-2xs font-bold text-ink uppercase tracking-widest">Track tags a re-tag would change</h3>
     <p class="text-2xs text-muted mt-1 mb-2">
-        MusicBrainz has information these files don't. Re-tagging would make the
-        changes below; nothing is changed until you do.
+        Per-track fields the tracklist has no column for — sort names, ISRCs and
+        the MusicBrainz ids of each recording. Re-tagging would make the changes
+        below; nothing is changed until you do.
     </p>
     {% with changes = update_changes %}
     {% include 'partials/_tag_changes.html' %}

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from harmonist import formats
 from harmonist.compare import (
+    SHOWN_FIELDS,
     TRACK_COLUMNS,
     Agreement,
     AlbumComparison,
@@ -29,6 +30,7 @@ from harmonist.compare import (
     disk_tracklist,
     tracklist,
 )
+from harmonist.formats.owned import Owned
 from harmonist.formats.types import TagSet, TrackTags
 
 
@@ -829,3 +831,31 @@ def test_a_field_outside_the_old_nine_is_compared(tmp_path):
     row = {f.label: f for f in differing}["Original date"]
     assert row.agreement is Agreement.DIFFERS
     assert (row.disk, row.mb) == ("2019-03-15", "1994-03-07")
+
+
+def test_shown_fields_names_exactly_the_tags_with_another_surface():
+    """What the album page renders somewhere, so the re-tag box can be scoped to
+    the complement (#297).
+
+    The complement is the interesting half, so it is what gets pinned — and as a
+    whole set, not a sample: `SHOWN_FIELDS` is derived, so a field added to
+    `Owned` lands OUTSIDE it by default and starts appearing in the box. That is
+    the right default, and it should still be a decision someone made rather than
+    one that happened to them.
+
+    These ten are the box's entire reason to exist. The tracklist is four fixed
+    columns — #, Title, Artist, Length — so an ISRC MusicBrainz has filled in or
+    a recording id a merge has moved has nowhere else on the page to appear.
+    """
+    assert {f.value for f in Owned} - SHOWN_FIELDS == {
+        "artist_sort",
+        "artists",
+        "track_total",
+        "disc_num",
+        "disc_subtitle",
+        "media",
+        "mb_track_id",
+        "mb_release_track_id",
+        "mb_artist_ids",
+        "isrcs",
+    }

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -449,33 +449,58 @@ def test_reach_counts_every_file_not_just_the_changed_ones(tmp_path):
 
 
 def test_the_album_page_explains_an_update_the_comparison_cannot_show(engaged, monkeypatch):
-    """The bug this closes: `original_date` and `mb_album_type` are not among the
-    nine fields `compare._ALBUM_FIELDS` shows, so an album could be listed under
-    Update available and read as fully matching when opened, with no third place
-    to look."""
+    """The bug this closes: a re-tag can change tags the page has no other place
+    for. An ISRC is the everyday one — MusicBrainz fills them in constantly, and
+    the tracklist's four columns (#, Title, Artist, Length) have nowhere to put
+    it — so without this box the album sits under Update available and reads as
+    matching on every row shown."""
     cfg, engage = engaged
     _tagged(cfg.paths.music_dir, _release())
-    moved = _release() | {
-        "release-group": {
-            "id": "rg-aaa",
-            "primary-type": "Album",
-            "first-release-date": "1994-03-07",
-        }
-    }
-    monkeypatch.setattr(mb_lookup, "fetch_release", lambda *a, **k: moved)
+    filled_in = copy.deepcopy(_release())
+    track = filled_in["medium-list"][0]["track-list"][0]
+    track["recording"]["isrc-list"] = ["GBAYE0000123"]
+    monkeypatch.setattr(mb_lookup, "fetch_release", lambda *a, **k: filled_in)
     client, runner = engage()
 
     body = client.get(f"/library/{runner.albums()[0].id}/compare").text
 
-    assert "Update available" in body
-    assert "Original date" in body  # the field the Tags panel never shows
-    assert "1994-03-07" in body
+    assert "Track tags a re-tag would change" in body
+    assert "ISRC" in body
+    assert "GBAYE0000123" in body
+
+
+def test_an_album_scoped_update_is_not_stated_twice(engaged, monkeypatch):
+    """#297. The box was written when the Tags panel compared nine album fields
+    out of the thirty a plan covers. #295 widened the panel to all of them, so a
+    single album-level difference now renders in the comparison AND again in the
+    box directly beneath it — the same row, twice, on a page where one field
+    differs.
+
+    The comparison keeps it; the box drops out entirely rather than showing an
+    empty heading."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    catalogued = copy.deepcopy(_release())
+    catalogued["label-info-list"] = [
+        {"label": {"name": "Warp"}, "catalog-number": "WARPCD-999"},
+    ]
+    monkeypatch.setattr(mb_lookup, "fetch_release", lambda *a, **k: catalogued)
+    client, runner = engage()
+
+    body = client.get(f"/library/{runner.albums()[0].id}/compare").text
+
+    # The comparison still reports it — this is a real difference, not a
+    # suppressed one, and the flag it sets stays explained.
+    assert runner.albums()[0].update_available is True
+    assert body.count("Cat. no.") == 1
+    assert body.count("WARPCD-999") == 1
+    assert "Track tags a re-tag would change" not in body
 
 
 def test_an_album_with_nothing_waiting_says_nothing(engaged, monkeypatch):
-    """No empty "Update available" heading on an album that is up to date — the
-    section has to be absent, not present-and-blank, or every album grows a box
-    telling the reader there is nothing to tell them."""
+    """No empty heading on an album that is up to date — the section has to be
+    absent, not present-and-blank, or every album grows a box telling the reader
+    there is nothing to tell them."""
     cfg, engage = engaged
     _tagged(cfg.paths.music_dir, _release())
     monkeypatch.setattr(mb_lookup, "fetch_release", lambda *a, **k: _release())
@@ -483,7 +508,7 @@ def test_an_album_with_nothing_waiting_says_nothing(engaged, monkeypatch):
 
     body = client.get(f"/library/{runner.albums()[0].id}/compare").text
 
-    assert "Update available" not in body
+    assert "Track tags a re-tag would change" not in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
#291 added the "Update available" box because the Tags comparison showed nine album fields while the update flag was derived from thirty — so an album could sit in the Library's Update available filter and read as matching on every row its page displayed. The box was the third place to look.

#295 then widened the comparison to every album-scoped tag Harmonist writes, which removed most of that reason about four hours later. On an album with one album-level difference the page now states it twice, and the second telling adds nothing: both are rendered from the same plan against the same `tagsets_for` values and cannot disagree.

What the box is still the only surface for is the per-track owned fields. The tracklist is four fixed columns — #, Title, Artist, Length — so an ISRC MusicBrainz has filled in, a recording id a merge has moved, a sort name Picard never wrote, appear nowhere else on the page.

## What changed

`compare.SHOWN_FIELDS` names what the album page already renders — every compared row of the panel, plus the tracklist's Title, Artist and number columns — and the view drops those rows from the box. Derived from the two rendering tables rather than listed beside them, for the reason `_ALBUM_FIELDS` is: a hand-kept copy drifts, and the drift here shows up as a row printed twice, which is the complaint itself.

The heading is retitled to say what it covers, since it is no longer everything.

## Judgment calls

**`disc_num` is deliberately left out of `SHOWN_FIELDS`**, even though the number column can show it. `_number` reads it as `disc or 1`, so a track gaining an explicit disc number it lacked renders identically on both sides and the column stays silent. A field the set claims wrongly is a change the page cannot report at all; one it omits is a row shown twice on a multi-disc renumbering. Those are not the same size of mistake.

**The changelog entry for #291 is amended rather than joined by a second one** — that feature has not shipped, so the notes describe where it landed rather than narrating a box nobody saw being narrowed.

## Testing

Web-route rung: the box's contents are rendered HTML, which `TestClient` can see. Two mutation checks were run — the filter removed, and the filter widened to hide everything — each going red on the intended test. `test_shown_fields_names_exactly_the_tags_with_another_surface` pins the complement as a whole set, so a field added to `Owned` (which lands outside it by default) is a decision someone makes rather than one that happens.

Fixes #297