### PR TITLE
Order the Tags panel so a column reads as one subject

### DIFF
--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -468,7 +468,7 @@ def _as_display(raw: object) -> str | None:
 
 
 def _rows(fields: Sequence[Owned]) -> tuple[tuple[str, str, str | None, Kind], ...]:
-    """`(label, disk key, mb attr, kind)` for each owned field, in `Owned` order."""
+    """`(label, disk key, mb attr, kind)` for each owned field, in the given order."""
     return tuple((LABELS[f], f.value, f.value, _KINDS[f]) for f in fields)
 
 
@@ -492,8 +492,68 @@ def _rows(fields: Sequence[Owned]) -> tuple[tuple[str, str, str | None, Kind], .
 _NOT_COMPARED: frozenset[Owned] = frozenset({Owned.MB_ALBUM_ID})
 
 
+#: The order the panel shows its rows in (#307).
+#:
+#: The grid fills row-major, two label/value pairs per row (#295), so this
+#: sequence decides which COLUMN each field lands in — and `Owned` order, which
+#: the panel used until now, was never chosen for that. It put the artist fields
+#: in both columns and the release fields in both, so reading down either one
+#: gave three subjects interleaved: Album, Album artist sort, Release group,
+#: Release status.
+#:
+#: Paired up here instead: the release block down one column, the artist block
+#: down the other, and then the pairs that belong together side by side — Date
+#: with Original date, Label with Cat. no., Barcode with ASIN.
+#:
+#: **A sort key, not a replacement.** `_ALBUM_FIELDS` is derived rather than
+#: listed precisely so a field added to `Owned` is compared from the day it
+#: exists (#295), and a second hand-written list is exactly what let the panel
+#: omit twenty-one fields. So a field missing from here sorts to the END and is
+#: still shown; it never disappears. `test_display_order_cannot_drop_a_field`
+#: holds that.
+#:
+#: Below 60rem the panel is one column and this sequence is what it reads top to
+#: bottom, where the interleaving is the other way round: Album, Album artist,
+#: Release group, Album artist sort. Accepted deliberately — one order cannot be
+#: grouped for one column and for two, and the wide layout is the one being read
+#: on the machine someone tags from.
+_DISPLAY_ORDER: tuple[Owned, ...] = (
+    # Row 1-3: what the release IS, beside who it is BY.
+    Owned.ALBUM,
+    Owned.ALBUM_ARTIST,
+    Owned.MB_RELEASE_GROUP_ID,
+    Owned.ALBUM_ARTIST_SORT,
+    Owned.MB_ALBUM_TYPE,
+    Owned.MB_ALBUM_ARTIST_IDS,
+    # Row 4-5: which edition, and when.
+    Owned.MB_ALBUM_STATUS,
+    Owned.MB_ALBUM_COUNTRY,
+    Owned.DATE,
+    Owned.ORIGINAL_DATE,
+    # Row 6-8: the release's paperwork.
+    Owned.LABEL,
+    Owned.CATALOG_NUMBER,
+    Owned.BARCODE,
+    Owned.ASIN,
+    Owned.DISC_TOTAL,
+    Owned.SCRIPT,
+)
+
+
+def _in_display_order(fields: Sequence[Owned]) -> list[Owned]:
+    """`fields` sorted by `_DISPLAY_ORDER`, with anything unlisted at the end.
+
+    Stable, so unlisted fields keep their `Owned` order among themselves — a
+    field added to `Owned` and forgotten here appears in the panel, at the
+    bottom, rather than vanishing from it.
+    """
+    last = len(_DISPLAY_ORDER)
+    order = {f: i for i, f in enumerate(_DISPLAY_ORDER)}
+    return sorted(fields, key=lambda f: order.get(f, last))
+
+
 #: The album panel's rows: every album-scoped tag Harmonist writes bar the one
-#: above, then the two it only displays.
+#: above, in the display order above, then the two it only displays.
 #:
 #: **Derived, not listed.** It used to be a hand-written tuple of nine, and the
 #: gap between it and `Owned` grew to twenty-one fields without anyone noticing
@@ -503,7 +563,7 @@ _NOT_COMPARED: frozenset[Owned] = frozenset({Owned.MB_ALBUM_ID})
 #: re-tag would write (#295). Deriving it means a field added to `Owned` is
 #: compared from the day it exists.
 _ALBUM_FIELDS: tuple[tuple[str, str, str | None, Kind], ...] = (
-    _rows([f for f in ALBUM_FIELDS if f not in _NOT_COMPARED]) + _DISPLAY_ONLY
+    _rows(_in_display_order([f for f in ALBUM_FIELDS if f not in _NOT_COMPARED])) + _DISPLAY_ONLY
 )
 
 

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -30,7 +30,7 @@ from harmonist.compare import (
     disk_tracklist,
     tracklist,
 )
-from harmonist.formats.owned import Owned
+from harmonist.formats.owned import ALBUM_FIELDS, Owned
 from harmonist.formats.types import TagSet, TrackTags
 
 
@@ -887,3 +887,49 @@ def test_only_id_rows_carry_a_musicbrainz_entity():
         "Album artist IDs": "artist",
         "Release group": "release-group",
     }
+
+
+def test_the_panel_pairs_release_fields_against_artist_fields():
+    """#307. The grid fills row-major, two label/value pairs per row, so the
+    field sequence decides which COLUMN each row lands in — and `Owned` order,
+    which this used until now, was never chosen for that. It split the artist
+    fields across both columns and the release fields across both, so reading
+    down either one gave three subjects interleaved.
+
+    Pinned as the whole sequence, because the property being asserted is about
+    ADJACENCY: it lives in the pairs, and sampling two of them cannot see a
+    third that has drifted into the wrong column.
+    """
+    fields = album_fields([("1.flac", TrackTags(album="Obreel"))], _tagset(album="Obreel"))
+
+    assert [f.label for f in fields] == [
+        "Album",           "Album artist",
+        "Release group",   "Album artist sort",
+        "Release type",    "Album artist IDs",
+        "Release status",  "Country",
+        "Date",            "Original date",
+        "Label",           "Cat. no.",
+        "Barcode",         "ASIN",
+        "Disc total",      "Script",
+        "Genre",           "Comment",
+    ]  # fmt: skip
+
+
+def test_display_order_cannot_drop_a_field():
+    """The order is a sort key, not a second list of what to show.
+
+    That distinction is the whole safety property. A hand-written list of rows
+    is exactly what let this panel omit twenty-one fields (#295), and it is
+    still hand-written here — so a field nobody remembered to place has to end
+    up at the BOTTOM of the panel, never absent from it.
+
+    `mb_album_id` is a real album field that `_DISPLAY_ORDER` genuinely does not
+    name, so this asserts against the live gap rather than a fabricated one.
+    """
+    from harmonist.compare import _DISPLAY_ORDER, _in_display_order
+
+    assert Owned.MB_ALBUM_ID not in _DISPLAY_ORDER
+
+    placed = _in_display_order(list(ALBUM_FIELDS))
+    assert set(placed) == set(ALBUM_FIELDS)  # nothing lost
+    assert placed[-1] is Owned.MB_ALBUM_ID  # and the unplaced one is last


### PR DESCRIPTION
#295 laid this panel out as two label/value pairs per row, filling the grid row-major. The row order came from `Owned`, which was never chosen for a two-column grid and reads badly in one — reading down the left column gave three subjects interleaved, with the artist fields split across both columns and the release fields split across both:

```
ALBUM
ALBUM ARTIST SORT
RELEASE GROUP
RELEASE STATUS
DATE
SCRIPT
```

## What it looks like now

```
ALBUM           Rawhide        ALBUM ARTIST       The Blues Brothers
RELEASE GROUP   Rawhide        ALBUM ARTIST SORT  —
RELEASE TYPE    album          ALBUM ARTIST IDS   The Blues Brothers
RELEASE STATUS  official       COUNTRY            US
DATE            2024-01-01     ORIGINAL DATE      —
LABEL           Demo Records   CAT. NO.           DEMO-001
BARCODE         —              ASIN               —
DISC TOTAL      1              SCRIPT             —
GENRE           —              COMMENT            —
```

The release block runs down one column and the artist block down the other, and the remaining pairs fall together where they belong — Date beside Original date, Label beside Cat. no., Barcode beside ASIN — which `Owned` order did not manage either.

## A sort key, not a second list

`_ALBUM_FIELDS` is derived rather than listed precisely so a field added to `Owned` is compared from the day it exists, and a hand-written list of rows is exactly what let this panel omit twenty-one fields (#295).

So `_in_display_order` **sorts** the derived set: a field nobody remembered to place lands at the bottom of the panel and is still shown, never dropped. That is the whole safety property, so it is pinned by a test against the *live* gap — `mb_album_id`, which #298 left out of the panel and which this order genuinely does not name — rather than a fabricated one.

The label sequence is asserted whole rather than sampled. What is being claimed is about **adjacency**: it lives in the pairs, and checking two of them cannot see a third that has drifted into the wrong column.

## Known trade-off

Below 60rem the panel is a single column and this sequence is what it reads top to bottom, where the interleaving is now the other way round: Album, Album artist, Release group, Album artist sort. Accepted deliberately — one order cannot be grouped for one column and for two, and the wide layout is the one being read on the machine someone tags from.

## Testing

Two mutation checks, both red: two fields swapped back into the wrong columns, and an unplaced field dropped instead of appended. Also checked by eye in demo mode at 1440px — a column-order change is not proven by a string assertion alone.

No changelog entry: this reorders a layout that has not been released, so there is nothing for an upgrading user to learn. Same reasoning as #301, which tidied the label column of the same panel.

Fixes #307