### PR TITLE
Go and ask MusicBrainz, instead of waiting to be asked

### DIFF
--- a/.claude/skills/musicbrainz-query/SKILL.md
+++ b/.claude/skills/musicbrainz-query/SKILL.md
@@ -49,7 +49,13 @@ before it exists.
   payload writes metadata Harmonist has already been told was superseded;
 - **the user pressed something meaning "look again".** Recheck, the album page's
   re-read control. Serving those a stored answer makes the button a silent
-  no-op with nothing on screen to say why.
+  no-op with nothing on screen to say why;
+- **going and looking IS the operation.** `gardener.sweep`, the background
+  update check, whose entire job is to find out whether MusicBrainz has moved.
+  A stored answer would make it a no-op that costs nothing and reports nothing.
+  This is the only read-only caller in that position, and it is not a licence
+  for the next one: the test is whether the caller exists *to refresh the
+  baseline*, not whether fresher data would be nicer.
 
 Everything that merely displays or compares may take the stored answer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Harmonist can **check your library against MusicBrainz in the background**, so
+  the **Update available** filter finds albums nobody has opened (#270). Off by
+  default — set `level = "review"` under `[gardener]`. It never writes to your
+  files.
+
 ## [1.12.0] - 2026-08-28
 
 ### Added

--- a/docs/design.md
+++ b/docs/design.md
@@ -1058,7 +1058,7 @@ src/harmonist/
     reconcile_runner.py Reconciliation pass over the library (rate-limited MB)
     scan_runner.py      Cache-backed library scan + status
     dir_watcher.py      watchfiles watcher → rescan when the music dir settles
-    periodic.py         Generic interval task → the hourly library rescan
+    periodic.py         Generic interval task → the hourly rescan + update check
 ```
 
 Templates and static assets live at the **project root** (`/templates`,
@@ -1100,6 +1100,9 @@ user_agent = "Harmonist/0.1 ( harmonist@girtby.net )"
 [server]
 host = "0.0.0.0"
 port = 8000
+
+[gardener]
+level = "off"      # off | review  (#273 adds enrich)
 
 [test]
 mode = "fixture"   # fixture | cassette | live
@@ -1321,6 +1324,56 @@ level is right for the log and wrong for the feed: nothing failed, nothing was
 lost, and there is nothing to act on. The distinction is worth holding onto when
 adding any new WARNING: the mirror's rule is *every warning is news the user
 should see*, which is true of a failure and false of a stopwatch.
+
+#### The background update check
+
+The second caller of that timer, and the scheduled half of the metadata
+gardener (#270): `gardener.sweep`, on a worker thread, asking MusicBrainz about
+the albums whose release payload is stalest and setting `update_available` from
+what comes back. It is what makes the Library's **Update available** filter
+report on albums nobody has opened, rather than only on the ones a human has
+already looked at.
+
+**Off unless asked for** (`[gardener] level`, `off` by default). The pass writes
+nothing to anybody's files, so the default is not protecting the library — it is
+protecting the MusicBrainz budget, which is a volunteer service and one request
+per second for everything Harmonist does. `review` is the only other level
+today; #273 adds `enrich`, the level at which some of what the pass finds gets
+applied on its own.
+
+**Detect-only is the classifier's answer, not a phase.** `owned.AUTO_APPLY` is
+empty, so every change needs a person; until #271 gives a finding somewhere to
+live there is nothing for an unattended pass to hand one to. The consequence
+worth stating is that this pass *cannot damage a library* — the strongest thing
+that can be said about a background job that runs while nobody is watching.
+
+**The early exit is the idempotency invariant, mechanically.** The stored
+payload is read before the fetch and an unchanged one ends that album there: no
+file reads, no plan, nothing recorded. A second pass over a library MusicBrainz
+has not touched costs its requests and nothing else. Note the asymmetry that
+makes this correct — an unchanged payload *skips* an album, it never *clears*
+its flag, because "MusicBrainz has not moved" and "the files have nothing
+outstanding" are different facts and an album whose update was never applied
+still has one.
+
+**The queue is dated off the cache**, `mb_cache.fetch_times()`, so scheduling
+needs no state of its own: `fetched_at` already says when each release was last
+read, never-fetched sorts first, and an album asked about inside
+`gardener.RECHECK_AFTER` is skipped. Two cases escape that clock and would
+otherwise cost a request per pass forever, because neither leaves a refreshed
+row under the id the sidecar names — a **merged** release, whose row lands under
+the id MusicBrainz redirected to (§5), and a **deleted** one, which stores
+nothing at all because a negative is never cached. `gardener._asked` remembers
+the ids this process has spent a request on, which closes both.
+
+**It stands aside** for a sync, a reconcile pass, or a library that has not been
+scanned yet, and refuses to start on top of a pass still running. One reason
+between them: the rate limit is a single shared queue and anything the user set
+in motion is waiting on it, while the check's albums have waited a week and can
+wait another hour. And when MusicBrainz keeps failing it gives up for the pass
+rather than spending a request per album to learn the same thing each time — a
+404 is an answer and does not count towards that, or a library with five
+deleted releases would abort every pass at the fifth.
 
 #### The per-album refresh
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,6 +87,9 @@ cache_ttl_seconds = 3600          # re-serve a fetched release for this long
 
 [library]
 watch_settle_seconds = 5          # quiet time before a watched change rescans
+
+[gardener]
+level = "off"                     # "off" | "review" — background update checks
 ```
 
 Harmonist watches the music dir and rescans when files change under it, but
@@ -107,6 +110,16 @@ fetches and re-serves it for `cache_ttl_seconds` rather than asking again. An
 album's page shows when its release was last read, with a **read again** link
 beside it, so you can always force a fresh look after editing MusicBrainz — and
 re-tagging and **Recheck** never use the cache. Set it to `0` to always fetch.
+
+`[gardener] level` decides whether Harmonist checks your library against
+MusicBrainz on its own. It ships **`off`**, and the only other setting today is
+**`review`**: a small, paced background pass that asks MusicBrainz about the
+albums it has looked at least recently and updates the Library's **Update
+available** filter from the answers. It never writes to your files — applying an
+update is still something you press a button for. Turning it on means Harmonist
+asks MusicBrainz about roughly a hundred albums an hour while it is idle, so
+every album is re-checked about weekly; it stands aside for any sync, reconcile
+or scan rather than competing with them for the one-request-per-second budget.
 
 Bandcamp sync needs a `cookies.txt` (exported from a logged-in browser) — paste
 or upload it via the in-app **Set up Bandcamp sync** prompt.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -217,6 +217,15 @@ you tagged it — each with its count:
   Harmonist met it hasn't been compared yet, so it won't be here even if there is
   something waiting. The filter under-reports rather than inventing work.
 
+  You can have Harmonist go and look instead of waiting to be asked. Set
+  `level = "review"` under `[gardener]` in `harmonist.toml` and a small
+  background pass works through the library, checking the albums it has looked
+  at least recently against MusicBrainz — roughly a hundred an hour while
+  nothing else is happening, so every album comes round about weekly. It only
+  ever *looks*: taking an update is still a button you press. It waits for any
+  sync, reconcile or scan to finish rather than competing with them, and it is
+  off until you turn it on.
+
 Search and the filters compose: searching inside a filter narrows within it, and
 the chip counts follow the search, so each one tells you what it would actually
 show. When both are on, the box says which filter it's searching inside, and an

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -965,6 +965,54 @@ def store_release(mbid: str, inc: str, payload: Mapping[str, Any]) -> None:
         )
 
 
+def release_fetch_times(inc: str) -> dict[str, datetime]:
+    """When each cached release under `inc` was last read from MusicBrainz.
+
+    The gardener's scheduling clock (#270): a pass asks about the albums whose
+    payload is stalest, which means reading every row's timestamp and none of
+    their payloads. `cached_release` in a loop would answer the same question
+    and `json.loads` a whole release per album to do it — the one cost this
+    query exists to avoid, and invisible in a test, because the answer is
+    identical either way.
+
+    An unindexed scan of `WHERE inc = ?` on purpose. The table has one row per
+    release the install has ever fetched, this runs once per pass rather than
+    once per album, and an index on `inc` would be an index over a handful of
+    distinct values — all cost, no selectivity.
+
+    **An empty dict on failure, like `cached_release`'s None.** It means "no
+    row is known to be recent", so every album reads as due and the pass spends
+    requests it might not have needed — the same safe direction a cache miss
+    takes. It can never mean "nothing to do", which is the answer that would be
+    wrong to guess at. Loud anyway: a pass silently re-asking about the whole
+    library every night is exactly the budget leak the cache exists to stop.
+    """
+    try:
+        conn = _ensure()
+        with _LOCK:
+            rows = conn.execute(
+                "SELECT mbid, fetched_at FROM mb_release_cache WHERE inc = ?", (inc,)
+            ).fetchall()
+    except sqlite3.Error:
+        log.exception(
+            "activity_store release_fetch_times() failed — the background update "
+            "check will treat every album as due and re-ask MusicBrainz about all "
+            "of them",
+            extra=_QUIET_MIRROR,
+        )
+        return {}
+    times: dict[str, datetime] = {}
+    for mbid, stamp in rows:
+        try:
+            times[mbid] = datetime.fromisoformat(stamp)
+        except (ValueError, TypeError):
+            # A timestamp that cannot be read leaves its album out of the map,
+            # so it reads as never-fetched and gets asked about. Same direction
+            # as an unparseable payload in `cached_release`: go and look.
+            log.warning("activity_store: unreadable fetched_at for %s", mbid, extra=_QUIET_MIRROR)
+    return times
+
+
 # There is deliberately no `forget_release`. Three things would want one and
 # none of them survives contact:
 #

--- a/src/harmonist/config.py
+++ b/src/harmonist/config.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, field_validator
 
 TestMode = Literal["fixture", "cassette", "live"]
 CoverArtSize = Literal["250", "500", "1200", "original"]
+GardenerLevel = Literal["off", "review"]
 
 
 class PathsConfig(BaseModel):
@@ -93,6 +94,30 @@ class LibraryConfig(BaseModel):
     watch_settle_seconds: float = 5.0
 
 
+class GardenerConfig(BaseModel):
+    """How much of the metadata gardener (#32) is allowed to run by itself.
+
+    Levels are ordered by how much Harmonist is trusted to do while nobody is
+    watching, which is the only ordering a setting like this needs to be
+    intelligible: `off` does nothing at all, `review` looks and reports but
+    **never writes to a file**, and #273 adds `enrich` above them for applying
+    the safe half of a change on its own.
+
+    A named level rather than a boolean, even though only two exist today. The
+    third is already designed, and an `enabled = true` that later has to become
+    `level = "review"` breaks a config file on somebody's NAS during an upgrade
+    for no reason but our convenience.
+
+    **`off` by default.** `review` writes nothing either, so the default is not
+    protecting the user's files — it is protecting the MusicBrainz budget. The
+    pass spends a rate-limited request per album per cycle against a volunteer
+    service, and starting to do that to somebody's install because they
+    upgraded is not a decision this project gets to make for them.
+    """
+
+    level: GardenerLevel = "off"
+
+
 class TestConfig(BaseModel):
     mode: TestMode = "fixture"
     unignore_item_ids: list[int] = Field(default_factory=list)
@@ -107,6 +132,7 @@ class Config(BaseModel):
     cover_art: CoverArtConfig = Field(default_factory=CoverArtConfig)
     artwork_store: ArtworkStoreConfig = Field(default_factory=ArtworkStoreConfig)
     library: LibraryConfig = Field(default_factory=LibraryConfig)
+    gardener: GardenerConfig = Field(default_factory=GardenerConfig)
     test: TestConfig = Field(default_factory=TestConfig)
     log_level: str = "info"
     demo_mode: bool = False
@@ -170,6 +196,7 @@ def _apply_env_overrides(data: dict[str, Any]) -> dict[str, Any]:
     auth = data.setdefault("auth", {})
     cover_art = data.setdefault("cover_art", {})
     library = data.setdefault("library", {})
+    gardener = data.setdefault("gardener", {})
     test = data.setdefault("test", {})
 
     if v := env.get("HARMONIST_MUSIC_DIR"):
@@ -199,6 +226,13 @@ def _apply_env_overrides(data: dict[str, Any]) -> dict[str, Any]:
         cover_art["size"] = v
     if v := env.get("HARMONIST_WATCH_SETTLE_SECONDS"):
         library["watch_settle_seconds"] = float(v)
+    if v := env.get("HARMONIST_GARDENER_LEVEL"):
+        # Passed through unvalidated so pydantic rejects a typo at startup with
+        # the level names in the message. Coercing an unknown value to "off"
+        # here would give someone who meant to turn the pass on a container
+        # that starts cleanly and does nothing, with no way to tell from the
+        # outside which of the two they got.
+        gardener["level"] = v.strip()
     if v := env.get("HARMONIST_DEMO_MODE"):
         data["demo_mode"] = v.strip() not in ("", "0", "false", "False", "no")
     return data

--- a/src/harmonist/gardener.py
+++ b/src/harmonist/gardener.py
@@ -5,6 +5,12 @@ The detector half of #32's metadata gardener, and the whole of what #287's
 re-tag against the release MusicBrainz currently holds change any owned tag?* —
 and records the answer on the in-memory `Album`.
 
+Three callers ask it, and they differ only in where the release comes from: the
+album page, from the cache as it renders; `warm_from_cache`, from every stored
+payload after a restart, spending no requests; and `sweep` (#270), from a fresh
+fetch on a timer, which is the only one that can find an update nobody has gone
+looking for. `sweep` writes nothing to anybody's files — see its docstring.
+
 ## Why this and not the album page's comparison
 
 `compare.album_fields` / `compare.tracklist` are display-shaped: their per-track
@@ -45,12 +51,14 @@ lifetime, and it lives in `activity.db` (#271). This is only the flag.
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from collections.abc import Sequence
-from datetime import timedelta
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 
-from . import album_files, formats, mb_cache, tagger
+from . import album_files, formats, mb_cache, mb_lookup, tagger
 from .models import Album, AlbumState, Release
 
 log = logging.getLogger(__name__)
@@ -246,3 +254,257 @@ def _rest(worked: float, duty: float) -> None:
     if duty <= 0 or duty >= 1:
         return  # 0 disables pacing (tests); 1 means "no rest", same thing here
     time.sleep(min(worked * (1 / duty - 1), _MAX_REST.total_seconds()))
+
+
+# --- The background pass (#270) ---------------------------------------------
+
+#: How long an album's release payload may go unasked-about before the pass asks
+#: MusicBrainz again. A week rather than a night: edits arrive on the scale of
+#: months for most releases, so noticing one six days late costs nothing, while
+#: asking six times too often costs six times the budget for the same answer.
+RECHECK_AFTER = timedelta(days=7)
+
+#: The most albums one pass will ask about. At the 1 req/s MusicBrainz floor
+#: this is the pass's *duration* as much as its size — a hundred albums is under
+#: two minutes — which is what keeps it off the shared rate limiter while
+#: somebody is using the app.
+#:
+#: With the interval it is also the sweep rate: a hundred an hour is 2,400 a
+#: day, so a library big enough to matter still completes a cycle well inside
+#: `RECHECK_AFTER`. #273 turns both into settings for anyone whose does not.
+ALBUMS_PER_PASS = 100
+
+#: How many MusicBrainz failures in a row end a pass early. MusicBrainz being
+#: down looks exactly like this, and grinding through the rest of the queue to
+#: fail at each one spends a request apiece and buries the first failure — the
+#: only one that says anything — under ninety-nine identical ones.
+_GIVE_UP_AFTER = 5
+
+#: Sorts before every real timestamp, so "never asked" is the stalest thing
+#: there is and an album nobody has ever looked at goes to the front of the
+#: queue. Those are the albums the flag is silent about (see
+#: `Album.update_available`), which makes them the ones a pass is worth most on.
+_NEVER = datetime.min.replace(tzinfo=UTC)
+
+#: When this process last ASKED about a release id, as distinct from when a
+#: payload was last stored under one (`mb_cache.fetch_times`). Normally the same
+#: fact; two cases separate them, and in both the album is asked about on every
+#: pass forever without this:
+#:
+#: * a **merged** release — the fetch follows MusicBrainz's redirect and the row
+#:   lands under the id it gave back (#268), so the id the sidecar names never
+#:   gets a fresher row;
+#: * a **deleted** release — the fetch raises and nothing is stored at all,
+#:   which is right (a negative is never cached), but leaves the same gap on an
+#:   album whose remedy is a human decision that re-asking brings no closer.
+#:
+#: In memory, because it paces a pass rather than describing the library:
+#: losing it on a restart costs one extra request for each affected album and
+#: nothing else. One entry per distinct release id asked about, so it is bounded
+#: by the size of the library — the same order as the album list itself.
+_asked: dict[str, datetime] = {}
+
+
+@dataclass(frozen=True)
+class PassResult:
+    """What one pass did — the log line reads off this, and so will #274's
+    digest."""
+
+    #: Releases fetched from MusicBrainz. The pass's whole budget cost.
+    asked: int
+    #: Of those, the ones whose files were then read — because the payload had
+    #: moved, or because there was nothing stored to compare it against. The gap
+    #: between this and `asked` is the early exit doing its job.
+    examined: int
+    #: Of those, the ones that turned out to have an update outstanding.
+    flagged: int
+    #: Releases MusicBrainz no longer has (#194/#210).
+    gone: int
+    #: Fetches that failed — a network error, a 503. Not an answer either way.
+    failed: int
+    #: Whether the pass stopped early because MusicBrainz kept failing. Read by
+    #: the closing log line, so a short pass says why it was short rather than
+    #: leaving a small number of albums looking like a quiet night.
+    gave_up: bool = False
+
+
+def sweep(
+    albums: Sequence[Album],
+    *,
+    limit: int = ALBUMS_PER_PASS,
+    recheck_after: timedelta = RECHECK_AFTER,
+) -> PassResult:
+    """Ask MusicBrainz about the albums whose release we have looked at least
+    recently, and update their flags from what comes back.
+
+    The scheduled half of #32, and **detect-only**: it fetches, compares and
+    sets `album.update_available`, and writes nothing to anybody's files. That
+    is not a stage of a plan, it is what the classifier currently permits —
+    `owned.AUTO_APPLY` is empty, so every change needs a person, and until #271
+    gives a finding somewhere to live there is nothing for this to hand one to.
+    Two things fall out of that: the pass cannot damage a library, and its whole
+    value is that the Library's Update available filter stops depending on
+    somebody having happened to open the album (#287, #293).
+
+    **The early exit is the design.** The stored payload is read BEFORE the
+    fetch, and an unchanged one ends the album there — no file reads, no plan,
+    nothing recorded. So a second pass over a library MusicBrainz has not
+    touched costs its requests and nothing else, which is #32's idempotency
+    invariant enforced by construction rather than by care.
+
+    An unchanged payload never *clears* a flag, only skips it. The two are easy
+    to conflate and the difference is a bug: an album whose files never took the
+    previous update still has one outstanding, however long MusicBrainz has sat
+    still (see this module's header).
+
+    `max_age=FRESH`, which no other read-only caller passes. Serving this the
+    cached row would make the pass a no-op that costs nothing and reports
+    nothing — going and looking IS the operation, and the refreshed row it
+    leaves behind is what dates the next pass's queue.
+
+    Blocking on both the network and the disk, so call it from a worker thread,
+    never the event loop.
+    """
+    now = datetime.now(UTC)
+    due = _due(albums, recheck_after=recheck_after, now=now)
+    log.info("update check: %d album(s) due, asking MusicBrainz about up to %d", len(due), limit)
+    asked = examined = flagged = gone = failed = 0
+    consecutive = 0
+    gave_up = False
+    reported = time.monotonic()
+    for mbid, group in due[:limit]:
+        # Read the baseline BEFORE the fetch: `fetch_release` replaces the row
+        # on its way back, so afterwards there is nothing left to compare with.
+        before = mb_cache.stored_release(mbid)
+        # Recorded whatever happens next, including a failure. This is "we spent
+        # a request on this id", which is the thing that must not repeat every
+        # pass — and the ids it protects are exactly the ones a fetch does not
+        # leave a row for.
+        _asked[mbid] = datetime.now(UTC)
+        asked += 1
+        try:
+            release = mb_cache.fetch_release(mbid, max_age=mb_cache.FRESH)
+        except mb_lookup.ReleaseGoneError:
+            # An answer, not a failure — so it does not count towards giving up.
+            # INFO rather than WARNING on purpose: a release deleted last year is
+            # still deleted tonight, and a mirrored WARNING would post that
+            # non-news to the Activity feed every pass forever. The album page
+            # already says so whenever the user looks (#194/#210), and #271 is
+            # what turns it into something waiting for them.
+            log.info("update check: MusicBrainz no longer has release %s", mbid)
+            gone += 1
+            consecutive = 0
+            continue
+        except mb_lookup.MBError:
+            failed += 1
+            consecutive += 1
+            # Kept out of the Activity feed (`_diagnostic`): nothing was lost,
+            # the next pass retries, and a MusicBrainz wobble is not the user's
+            # to act on. The log still has it, with the traceback.
+            log.warning(
+                "update check: could not fetch release %s",
+                mbid,
+                exc_info=True,
+                extra={"_diagnostic": True},
+            )
+            if consecutive >= _GIVE_UP_AFTER:
+                # This one IS mirrored. A pass that gave up leaves the flags
+                # stale for a week, and that is a thing the user can only find
+                # out from us.
+                log.warning(
+                    "update check: giving up this pass after %d MusicBrainz failures in a row",
+                    consecutive,
+                )
+                gave_up = True
+                break
+            continue
+        consecutive = 0
+        if before is not None and _same_release(before, release):
+            continue  # MusicBrainz has said nothing new; read no files
+        examined += len(group)
+        for album in group:
+            refresh_flag(album, release)
+            if album.update_available:
+                flagged += 1
+        if time.monotonic() - reported >= _PROGRESS_EVERY.total_seconds():
+            reported = time.monotonic()
+            log.info("update check: %d asked, %d with something new", asked, examined)
+    result = PassResult(
+        asked=asked, examined=examined, flagged=flagged, gone=gone, failed=failed, gave_up=gave_up
+    )
+    log.info(
+        "update check: %s — asked about %d release(s), %d had moved, %d album(s) "
+        "have an update, %d gone from MusicBrainz, %d fetch(es) failed",
+        "gave up early" if result.gave_up else "done",
+        result.asked,
+        result.examined,
+        result.flagged,
+        result.gone,
+        result.failed,
+    )
+    return result
+
+
+def _due(
+    albums: Sequence[Album], *, recheck_after: timedelta, now: datetime
+) -> list[tuple[str, list[Album]]]:
+    """The releases worth asking about, stalest first, grouped by release id.
+
+    **Grouped**, because two albums can name the same release — a duplicate rip
+    in two folders (#243), or one album split across directories that resolved
+    apart. One fetch answers for all of them, and asking twice would spend a
+    second rate-limited request on a payload we already have in hand.
+    """
+    times = mb_cache.fetch_times()
+    by_release: dict[str, list[Album]] = {}
+    for album in albums:
+        sc = album.sidecar
+        if sc is None or not sc.mb_release_id:
+            continue  # nothing to ask about; not an error
+        by_release.setdefault(sc.mb_release_id, []).append(album)
+    due: list[tuple[datetime, str, list[Album]]] = []
+    for mbid, group in by_release.items():
+        last = _last_look(mbid, times)
+        # A stamp in the FUTURE — a NAS clock corrected backwards by NTP — reads
+        # as due rather than as fresh for however long the clock is out, so the
+        # worst a bad clock can do here is cost a request. Same reading
+        # `mb_cache._fresh` takes.
+        if last is not None and timedelta(0) <= now - last < recheck_after:
+            continue
+        due.append((last or _NEVER, mbid, group))
+    due.sort(key=lambda item: item[0])
+    return [(mbid, group) for _, mbid, group in due]
+
+
+def _last_look(mbid: str, times: dict[str, datetime]) -> datetime | None:
+    """When this release was last looked at, by either measure, or None if it
+    never has been. See `_asked` for why there are two."""
+    seen = [t for t in (times.get(mbid), _asked.get(mbid)) if t is not None]
+    return max(seen) if seen else None
+
+
+def _same_release(before: Release, after: Release) -> bool:
+    """Whether MusicBrainz has anything to say that it had not already said.
+
+    Compared as the JSON the store would write rather than as dicts, because
+    that is precisely the question — *would re-storing this change the row?* —
+    and it is immune to the one way a dict comparison here can lie. A payload
+    that has round-tripped through `json.dumps` has had any tuple flattened to a
+    list, so a fresh payload carrying one would compare unequal to its own
+    stored copy forever. Nothing would break: the pass would simply read every
+    album's files every night for no reason, and no assertion about the *answer*
+    would ever notice.
+
+    An unserialisable payload answers "not the same", which sends the album to
+    the plan — the direction that costs file reads rather than the one that
+    silently skips an album that might have an update outstanding.
+    """
+    try:
+        return json.dumps(before, sort_keys=True) == json.dumps(after, sort_keys=True)
+    except (TypeError, ValueError):
+        log.warning(
+            "update check: could not compare release payloads; reading the files instead",
+            exc_info=True,
+            extra={"_diagnostic": True},
+        )
+        return False

--- a/src/harmonist/mb_cache.py
+++ b/src/harmonist/mb_cache.py
@@ -188,3 +188,20 @@ def fetched_at(mbid: str) -> datetime | None:
     """
     cached = activity_store.cached_release(mbid, _key(mb_lookup.RELEASE_INCLUDES))
     return None if cached is None else cached.fetched_at
+
+
+def fetch_times() -> dict[str, datetime]:
+    """`fetched_at` for every release this install has fetched, in one query.
+
+    What the background pass schedules off (#270): it wants the stalest albums
+    first, which is a question about the whole table rather than about one
+    album, and asking `fetched_at` per album would parse a release payload each
+    time to reach a timestamp beside it.
+
+    Keyed by the id the release ACTUALLY has, because that is how the rows are
+    keyed (#268) — so an album whose release has been merged away has no entry
+    here even though it has been fetched, and reads as never-asked. That is the
+    caller's problem to solve rather than this function's to hide: see
+    `gardener._asked`.
+    """
+    return activity_store.release_fetch_times(_key(mb_lookup.RELEASE_INCLUDES))

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -231,6 +231,18 @@ _LIBRARY_QUERY_MAX = 100
 # isn't there either: an unchanged library is a stat per file and no tag reads.
 _RESCAN_INTERVAL = timedelta(hours=1)
 
+# How often the gardener's update check runs when it is switched on (#270).
+# Also a constant for now, and for a different reason from the rescan's: it is
+# half of a rate — with `gardener.ALBUMS_PER_PASS` it says how fast the library
+# is swept — and the two are no use apart. #273 makes the pair a setting
+# together, alongside the trust level.
+#
+# Deliberately the same hour as the rescan rather than a nightly slot: the pass
+# is short, capped, and skipped whenever anything else is working, so spreading
+# it thinly across the day keeps it out of the way better than concentrating it
+# at 3am would — and there is no hour at which a NAS is reliably idle.
+_UPDATE_CHECK_INTERVAL = timedelta(hours=1)
+
 # The header that tells `/library` to name the resolved view in the address bar
 # (#180). The search form cannot spell its own `hx-push-url`: it does not know the
 # query until the reader types it, and the page size and filter it must carry come
@@ -663,16 +675,37 @@ def create_app(
                 stop_event=watch_stop,
             )
         )
+        # And ask MusicBrainz what it has been doing (#270) — off unless the
+        # user turned it on, because it spends the rate-limited budget while
+        # nobody is watching. The task isn't created at all when it is off, so
+        # the default install has no extra timer, not a timer that does nothing.
+        check_task = (
+            asyncio.create_task(
+                periodic.run_periodically(
+                    _UPDATE_CHECK_INTERVAL,
+                    lambda: _update_check_if_idle(sync_runner, reconcile_runner, scan_runner),
+                    name="update check",
+                    stop_event=watch_stop,
+                )
+            )
+            if cfg.gardener.level != "off"
+            else None
+        )
         try:
             yield
         finally:
             watch_stop.set()
             watch_task.cancel()
             rescan_task.cancel()
+            if check_task is not None:
+                check_task.cancel()
             with suppress(asyncio.CancelledError):
                 await watch_task
             with suppress(asyncio.CancelledError):
                 await rescan_task
+            if check_task is not None:
+                with suppress(asyncio.CancelledError):
+                    await check_task
 
     app = FastAPI(title="Harmonist", lifespan=lifespan)
     app.state.cfg = cfg
@@ -2122,6 +2155,62 @@ def _periodic_rescan_if_idle(
         log.info("Skipping periodic rescan: sync or reconcile in progress")
         return
     scan_runner.request_quiet_rescan()
+
+
+# Held for the duration of a pass, so a slow one cannot be started again on top
+# of itself. A pass is capped at a hundred albums and normally takes two
+# minutes, but a MusicBrainz that answers slowly rather than failing can stretch
+# it past the hour — and two passes at once would ask about the same albums
+# twice and spend twice the budget doing it.
+_update_check_lock = threading.Lock()
+
+
+def _update_check_if_idle(
+    sync_runner: SyncRunner, reconcile_runner: ReconcileRunner, scan_runner: ScanRunner
+) -> None:
+    """One gardener pass (#270), unless something with a better claim is running.
+
+    Three things get out of the way, for one reason between them: the
+    MusicBrainz rate limit is a single shared queue, and anything the user set
+    in motion is waiting on it. A sync or a reconcile pass is spending it
+    already, and the check is in no hurry — its albums have been unasked-about
+    for a week and one more hour changes nothing. It skips the tick rather than
+    deferring it, like the periodic rescan does, because the next one comes
+    round soon and nothing is waiting on this one.
+
+    The third is the first scan: the pass reads `scan_runner.albums()`, which is
+    empty until then, so an early tick would report a library of nothing.
+
+    **Its own thread.** The pass blocks on the network for a second per album
+    and then on the disk, which are the two things that must never happen on the
+    event loop. Daemon, and not cancelled at shutdown: it records a hint and
+    persists nothing but the cache rows it fills on the way, so being killed
+    part-way through loses only work the next pass redoes.
+    """
+    if sync_runner.is_running or reconcile_runner.is_running:
+        log.info("Skipping update check: sync or reconcile in progress")
+        return
+    if not scan_runner.has_completed():
+        log.info("Skipping update check: the library has not been scanned yet")
+        return
+    if not _update_check_lock.acquire(blocking=False):
+        log.warning("Skipping update check: the previous pass is still running")
+        return
+
+    def _run() -> None:
+        try:
+            gardener.sweep(scan_runner.albums())
+        except Exception:
+            # Boundary catch: the pass already absorbs the failures it expects
+            # — a fetch that errors, a file it cannot read — so anything
+            # arriving here is a defect rather than a bad night. Loud, and
+            # loud every time: at 3am the log is the only channel, and a pass
+            # that has been dying quietly for a month is worth repeating.
+            log.exception("update check failed")
+        finally:
+            _update_check_lock.release()
+
+    threading.Thread(target=_run, name="harmonist-update-check", daemon=True).start()
 
 
 def _start_flag_warm_up(scan_runner: ScanRunner) -> None:

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import shutil
+import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -26,10 +27,10 @@ from harmonist.web.scan_runner import ScanRunner
 SINE_M4A = Path(__file__).parent / "fixtures" / "sine.m4a"
 
 
-def _release(title: str = "Test Album", *, tracks: int = 1) -> dict:
+def _release(title: str = "Test Album", *, tracks: int = 1, mbid: str = "rel-aaa") -> dict:
     """A minimal release the tagger can write from, in musicbrainzngs' shape."""
     return {
-        "id": "rel-aaa",
+        "id": mbid,
         "title": title,
         "status": "Official",
         "artist-credit": [
@@ -54,8 +55,8 @@ def _release(title: str = "Test Album", *, tracks: int = 1) -> dict:
     }
 
 
-def _album_dir(root: Path, *, tracks: int = 1) -> Path:
-    d = root / "Test Artist" / "Test Album"
+def _album_dir(root: Path, *, tracks: int = 1, name: str = "Test Album") -> Path:
+    d = root / "Test Artist" / name
     d.mkdir(parents=True)
     for i in range(1, tracks + 1):
         shutil.copy(SINE_M4A, d / f"{i:02d} Track {i}.m4a")
@@ -75,9 +76,9 @@ def _flag(album: Album, release: dict) -> bool:
     return album.update_available
 
 
-def _tagged(root: Path, release: dict, *, tracks: int = 1) -> Album:
+def _tagged(root: Path, release: dict, *, tracks: int = 1, name: str = "Test Album") -> Album:
     """An album tagged from `release`, as the scanner sees it afterwards."""
-    d = _album_dir(root, tracks=tracks)
+    d = _album_dir(root, tracks=tracks, name=name)
     tagger.tag_album(d, release)
     sc.write(d, Sidecar(mb_release_id=release["id"], tagged_at=datetime.now(UTC)))
     return next(a for a in scanner.scan(root) if a.path == d)
@@ -569,3 +570,439 @@ def test_pacing_can_be_switched_off_entirely(monkeypatch):
     gardener._rest(worked=1.0, duty=0)
 
     assert slept == []
+
+
+# --- The background pass (#270) ---------------------------------------------
+#
+# The pass is detect-only, so what these have to pin is not what it writes — it
+# writes nothing — but what it SPENDS and what it skips. Every assertion about
+# the number of MusicBrainz requests is load-bearing for that reason: the flags
+# come out identical whether the pass asked once or a hundred times, so nothing
+# else in the suite can notice a budget leak.
+
+
+@pytest.fixture(autouse=True)
+def _forget_what_was_asked():
+    """`gardener._asked` is module-level pacing state that outlives a test.
+
+    A leak would make a later pass skip an album for reasons that test never set
+    up — and it would do it by making the pass *quieter*, which is the direction
+    an assertion about call counts reads as success.
+    """
+    gardener._asked.clear()
+    yield
+    gardener._asked.clear()
+
+
+def _inc() -> str:
+    return "+".join(sorted(mb_lookup.RELEASE_INCLUDES))
+
+
+def _store(release: dict, *, age: timedelta = timedelta(0)) -> None:
+    """Record `release` as `fetch_release` would have done, `age` ago."""
+    activity_store.store_release(str(release["id"]), _inc(), release)
+    conn = activity_store._ensure()
+    conn.execute(
+        "UPDATE mb_release_cache SET fetched_at = ? WHERE mbid = ?",
+        ((datetime.now(UTC) - age).isoformat(), str(release["id"])),
+    )
+    conn.commit()
+
+
+def _serving(monkeypatch, *releases: dict) -> list[str]:
+    """Answer MusicBrainz from `releases`, and return the list of ids asked for.
+
+    Patched on `mb_lookup` rather than on `mb_cache`, so the cache's own
+    behaviour — which row it reads, which row it writes back, and under which id
+    — is part of what these tests exercise rather than something stubbed past.
+
+    An id nothing answers for raises `ReleaseGoneError`, which is what
+    MusicBrainz does for a release that has been deleted.
+    """
+    by_id = {str(r["id"]): r for r in releases}
+    asked: list[str] = []
+
+    def _fetch(mbid: str) -> dict:
+        asked.append(mbid)
+        if mbid not in by_id:
+            raise mb_lookup.ReleaseGoneError(f"MusicBrainz no longer has release {mbid}")
+        return copy.deepcopy(by_id[mbid])
+
+    monkeypatch.setattr(mb_lookup, "fetch_release", _fetch)
+    return asked
+
+
+def _stale() -> timedelta:
+    """Old enough that the pass considers an album due."""
+    return gardener.RECHECK_AFTER + timedelta(days=1)
+
+
+def test_a_pass_finds_an_update_nobody_went_looking_for(tmp_path, monkeypatch):
+    """The reason the pass exists. Every other route to the flag needs a human —
+    opening the album, or a payload some earlier human's visit left behind — so
+    an album nobody has touched since MusicBrainz edited it stays silent forever
+    without this."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    _store(_release(), age=_stale())
+    asked = _serving(monkeypatch, _release("Test Album (remastered)"))
+
+    result = gardener.sweep([album])
+
+    assert asked == ["rel-aaa"]
+    assert album.update_available is True
+    assert (result.examined, result.flagged) == (1, 1)
+
+
+def test_an_unchanged_release_never_reaches_the_files(tmp_path, monkeypatch):
+    """The early exit, which is what makes a nightly pass over an unchanged
+    library cost its requests and nothing else. Asserted as *no plan was built*
+    rather than as "the flag came out the same", because the flag comes out the
+    same either way — reading every album's files every night would be invisible
+    to any assertion about the answer."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    _store(_release(), age=_stale())
+    _serving(monkeypatch, _release())
+    monkeypatch.setattr(
+        tagger, "plan_album", lambda *a, **k: pytest.fail("the pass read the files")
+    )
+
+    assert gardener.sweep([album]).examined == 0
+
+
+def test_an_unchanged_release_does_not_clear_a_flag_already_raised(tmp_path, monkeypatch):
+    """The trap the early exit sets. "MusicBrainz has not moved since we last
+    looked" and "the files have nothing outstanding" are different facts, and an
+    album whose update was never applied keeps it however long MusicBrainz sits
+    still. Skipping the album is right; clearing it would empty the filter of
+    exactly the albums the user has yet to act on."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    moved = _release("Test Album (remastered)")
+    _store(moved, age=_stale())
+    gardener.refresh_flag(album, moved)
+    assert album.update_available is True
+
+    _serving(monkeypatch, moved)
+    gardener.sweep([album])
+
+    assert album.update_available is True
+
+
+def test_the_pass_writes_nothing_to_the_files(tmp_path, monkeypatch):
+    """Detect-only, stated as a property rather than as a claim in a docstring.
+    `owned.AUTO_APPLY` is empty, so there is nothing the classifier permits the
+    pass to apply — and this is the assertion that fails the day someone widens
+    it without meaning to."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    before = {p: p.read_bytes() for p in sorted(album.path.iterdir())}
+    _store(_release(), age=_stale())
+    _serving(monkeypatch, _release("Test Album (remastered)"))
+
+    gardener.sweep([album])
+
+    assert album.update_available is True  # it found the change ...
+    assert {p: p.read_bytes() for p in sorted(album.path.iterdir())} == before  # ... and left it
+
+
+def test_a_second_pass_over_an_unchanged_library_does_nothing_at_all(tmp_path, monkeypatch):
+    """Idempotency, stated end to end: the pass runs twice and the second one
+    asks nothing, reads nothing and changes nothing. This is the outer of the
+    two mechanisms — the recheck window, which keeps the album out of the queue
+    entirely; the early exit behind it has its own test, and never gets a turn
+    here. Under a timer that fires every hour forever, this is the property that
+    decides whether the feature is quiet or unbearable."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    _store(_release(), age=_stale())
+    asked = _serving(monkeypatch, _release("Test Album (remastered)"))
+
+    first = gardener.sweep([album])
+    second = gardener.sweep([album])
+
+    assert (first.asked, first.examined) == (1, 1)
+    assert (second.asked, second.examined) == (0, 0)
+    assert asked == ["rel-aaa"]
+    assert album.update_available is True  # the first pass's answer still stands
+
+
+def test_an_album_asked_about_recently_is_not_asked_again(tmp_path, monkeypatch):
+    """What stops an hourly timer being an hourly request per album. The clock
+    is the cache row's own `fetched_at`, so this needs no state of its own — and
+    a library the pass has just swept costs nothing until the window is up."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    _store(_release(), age=gardener.RECHECK_AFTER - timedelta(hours=1))
+    asked = _serving(monkeypatch, _release())
+
+    assert gardener.sweep([album]).asked == 0
+    assert asked == []
+
+
+def test_an_album_musicbrainz_was_never_asked_about_goes_first(tmp_path, monkeypatch):
+    """Never-fetched sorts before every real timestamp, which puts the albums
+    the flag is silent about at the front of the queue. Those are the ones a
+    pass is worth most on: the warm-up cannot speak for them, so until the pass
+    reaches one, "no update" is a guess rather than an answer."""
+    activity_store.init(tmp_path / "activity.db")
+    seen = _tagged(tmp_path, _release(mbid="rel-seen"), name="Seen")
+    never = _tagged(tmp_path, _release(mbid="rel-never"), name="Never")
+    _store(_release(mbid="rel-seen"), age=_stale())
+    asked = _serving(monkeypatch, _release(mbid="rel-seen"), _release(mbid="rel-never"))
+
+    gardener.sweep([seen, never], limit=1)
+
+    assert asked == ["rel-never"]
+
+
+def test_the_stalest_album_goes_first_when_the_cap_bites(tmp_path, monkeypatch):
+    """The cap is what bounds one pass; the ordering is what stops the cap
+    starving the same albums forever. Least-recently-asked first means every
+    album reaches the front eventually, which a stable library order would not
+    give — it would sweep the first N albums nightly and never reach the rest."""
+    activity_store.init(tmp_path / "activity.db")
+    recent = _tagged(tmp_path, _release(mbid="rel-recent"), name="Recent")
+    ancient = _tagged(tmp_path, _release(mbid="rel-ancient"), name="Ancient")
+    _store(_release(mbid="rel-recent"), age=_stale())
+    _store(_release(mbid="rel-ancient"), age=_stale() * 2)
+    asked = _serving(monkeypatch, _release(mbid="rel-recent"), _release(mbid="rel-ancient"))
+
+    gardener.sweep([recent, ancient], limit=1)
+
+    assert asked == ["rel-ancient"]
+
+
+def test_two_albums_on_one_release_cost_one_request(tmp_path, monkeypatch):
+    """A duplicate rip in two folders (#243) names one release twice. One fetch
+    answers for both, and asking again would spend a second rate-limited request
+    on a payload already in hand — invisible in the result, which is correct
+    either way."""
+    activity_store.init(tmp_path / "activity.db")
+    one = _tagged(tmp_path, _release(), name="Test Album")
+    two = _tagged(tmp_path, _release(), name="Test Album (copy)")
+    _store(_release(), age=_stale())
+    asked = _serving(monkeypatch, _release("Test Album (remastered)"))
+
+    result = gardener.sweep([one, two])
+
+    assert asked == ["rel-aaa"]
+    assert (one.update_available, two.update_available) == (True, True)
+    assert result.examined == 2
+
+
+def test_a_deleted_release_is_not_asked_about_again_next_pass(tmp_path, monkeypatch):
+    """A 404 stores nothing — a negative is never cached — so the cache clock
+    says "never asked" forever and the album would come back to the front of the
+    queue on every pass. Its remedy is a human decision (#194/#210) that
+    re-asking brings no closer, so the pass remembers having asked."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    asked = _serving(monkeypatch)  # nothing answers: MusicBrainz has deleted it
+
+    first = gardener.sweep([album])
+    second = gardener.sweep([album])
+
+    assert first.gone == 1
+    assert asked == ["rel-aaa"]  # asked once, across both passes
+    assert second.asked == 0
+
+
+def test_a_merged_release_is_not_asked_about_again_next_pass(tmp_path, monkeypatch):
+    """MusicBrainz redirects a merged id, so the row lands under the id it gave
+    back (#268) and nothing ever refreshes the one the sidecar names. Same leak
+    as the deleted case and a more common one — without the memory, every merged
+    album in the library costs a request on every pass, forever."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    _store(_release(), age=_stale())
+    merged = _release(mbid="rel-merged-target")
+    asked: list[str] = []
+
+    def _redirects(mbid: str) -> dict:
+        """What a merge looks like from here: the id asked for is answered by a
+        release carrying a different one."""
+        asked.append(mbid)
+        return copy.deepcopy(merged)
+
+    monkeypatch.setattr(mb_lookup, "fetch_release", _redirects)
+
+    gardener.sweep([album])
+    gardener.sweep([album])
+
+    assert asked == ["rel-aaa"]
+    assert album.update_available is True  # the id in the files no longer matches
+
+
+def test_a_musicbrainz_outage_stops_the_pass_rather_than_grinding_through_it(tmp_path, monkeypatch):
+    """When MusicBrainz is down every album fails identically. Continuing spends
+    a rate-limited request per album to learn the same thing each time, and
+    buries the first failure — the only one that says anything — under the rest.
+    The next pass retries from the top."""
+    activity_store.init(tmp_path / "activity.db")
+    albums = []
+    for i in range(gardener._GIVE_UP_AFTER + 3):
+        albums.append(_tagged(tmp_path, _release(mbid=f"rel-{i:03d}"), name=f"Album {i}"))
+    asked: list[str] = []
+
+    def _down(mbid: str) -> dict:
+        asked.append(mbid)
+        raise mb_lookup.MBError("MusicBrainz is not answering")
+
+    monkeypatch.setattr(mb_lookup, "fetch_release", _down)
+
+    result = gardener.sweep(albums)
+
+    assert result.gave_up is True
+    assert len(asked) == gardener._GIVE_UP_AFTER
+    assert result.failed == gardener._GIVE_UP_AFTER
+
+
+def test_a_deleted_release_does_not_count_towards_giving_up(tmp_path, monkeypatch):
+    """A 404 is an answer, not a failure. A library with five albums MusicBrainz
+    has deleted — which is a library that has been adopted, not a broken one —
+    would otherwise abort every pass at the fifth and never reach the rest."""
+    activity_store.init(tmp_path / "activity.db")
+    albums = [
+        _tagged(tmp_path, _release(mbid=f"rel-{i:03d}"), name=f"Album {i}")
+        for i in range(gardener._GIVE_UP_AFTER + 2)
+    ]
+    asked = _serving(monkeypatch)  # nothing answers for any of them
+
+    result = gardener.sweep(albums)
+
+    assert result.gave_up is False
+    assert result.gone == len(albums)
+    assert len(asked) == len(albums)
+
+
+def test_an_album_with_no_release_of_its_own_is_never_asked_about(tmp_path, monkeypatch):
+    """An unlinked album has no id to ask with. The pass must skip it rather
+    than hand a None to the cache — the same guard the warm-up carries."""
+    activity_store.init(tmp_path / "activity.db")
+    d = _album_dir(tmp_path)
+    album = next(a for a in scanner.scan(tmp_path) if a.path == d)
+    assert album.sidecar is None
+    asked = _serving(monkeypatch)
+
+    assert gardener.sweep([album]).asked == 0
+    assert asked == []
+
+
+def _stub_runner(*, running: bool = False, scanned: bool = True):
+    """Enough of a runner for the tick's guards to read."""
+
+    class _Stub:
+        is_running = running
+
+        def has_completed(self) -> bool:
+            return scanned
+
+        def albums(self) -> list:
+            return []
+
+    return _Stub()
+
+
+def _sweep_signal(monkeypatch) -> threading.Event:
+    """Set when the tick actually starts a pass."""
+    done = threading.Event()
+
+    def _sweep(albums, **kwargs):
+        done.set()
+        return gardener.PassResult(asked=0, examined=0, flagged=0, gone=0, failed=0)
+
+    monkeypatch.setattr(gardener, "sweep", _sweep)
+    return done
+
+
+def test_a_tick_starts_a_pass_when_nothing_else_is_working(monkeypatch):
+    """The positive case the three guards below are exceptions to — without it
+    they would all pass against a tick that never runs anything at all."""
+    from harmonist.web import main as web_main
+
+    done = _sweep_signal(monkeypatch)
+
+    web_main._update_check_if_idle(_stub_runner(), _stub_runner(), _stub_runner())
+
+    assert done.wait(5) is True
+
+
+@pytest.mark.parametrize(
+    ("sync", "reconcile", "scanned"),
+    [(True, False, True), (False, True, True), (False, False, False)],
+)
+def test_a_tick_stands_aside_for_work_with_a_better_claim(monkeypatch, sync, reconcile, scanned):
+    """A sync and a reconcile pass are already spending the one shared
+    MusicBrainz rate limit, on something the user set in motion; the check's
+    albums have waited a week and can wait another hour. Before the first scan
+    there is no library to look at — `albums()` is empty, so a tick then would
+    report a library of nothing."""
+    from harmonist.web import main as web_main
+
+    done = _sweep_signal(monkeypatch)
+
+    web_main._update_check_if_idle(
+        _stub_runner(running=sync),
+        _stub_runner(running=reconcile),
+        _stub_runner(scanned=scanned),
+    )
+
+    assert done.wait(0.25) is False
+
+
+def test_a_pass_still_running_is_not_started_on_top_of_itself(monkeypatch):
+    """A pass is capped and normally takes two minutes, but a MusicBrainz that
+    answers slowly rather than failing can stretch one past the hour. Two at
+    once would ask about the same albums twice and pay twice for the answer."""
+    from harmonist.web import main as web_main
+
+    done = _sweep_signal(monkeypatch)
+    web_main._update_check_lock.acquire()
+    try:
+        web_main._update_check_if_idle(_stub_runner(), _stub_runner(), _stub_runner())
+        assert done.wait(0.25) is False
+    finally:
+        web_main._update_check_lock.release()
+
+
+def _timer_names(cfg, monkeypatch) -> list[str]:
+    """The periodic tasks the lifespan actually engages."""
+    from fastapi.testclient import TestClient
+
+    from harmonist.web import main as web_main
+
+    names: list[str] = []
+
+    async def _record(interval, action, *, name, stop_event=None):
+        names.append(name)
+        if stop_event is not None:
+            await stop_event.wait()
+
+    monkeypatch.setattr(web_main.periodic, "run_periodically", _record)
+    with TestClient(web_main.create_app(cfg), headers={"HX-Request": "true"}):
+        pass
+    return names
+
+
+def test_the_update_check_does_not_run_unless_it_was_turned_on(engaged, monkeypatch):
+    """The default. `review` writes nothing to anybody's files, so this is not
+    protecting the library — it is protecting a volunteer service from an
+    install that started asking it a hundred questions an hour because somebody
+    upgraded. No task is created at all, rather than a task that does nothing."""
+    cfg, _ = engaged
+
+    assert "update check" not in _timer_names(cfg, monkeypatch)
+
+
+def test_turning_it_on_engages_the_timer(engaged, monkeypatch):
+    """The other half: an install that asked for the pass gets one, on the same
+    generic timer the hourly rescan runs on rather than a second pattern beside
+    it (#151)."""
+    from harmonist.config import GardenerConfig
+
+    cfg, _ = engaged
+    cfg = cfg.model_copy(update={"gardener": GardenerConfig(level="review")})
+
+    assert "update check" in _timer_names(cfg, monkeypatch)


### PR DESCRIPTION
The **Update available** filter could only ever report on albums a human had
already opened: the flag is derived from a stored release payload, and nothing
put one there unless somebody went looking. So the albums most likely to have
drifted — the ones nobody has touched in years — were exactly the ones it stayed
silent about.

This is the scheduled half of #32: `gardener.sweep`, on the same
`run_periodically` timer the hourly rescan uses, taking the albums whose release
we have looked at least recently, asking MusicBrainz at its one-per-second
floor, and setting the flag from what comes back.

## Detect-only, and not as a phase

It writes nothing to anybody's files. `owned.AUTO_APPLY` is empty, so every
change still needs a person, and until #271 gives a finding somewhere to live
there is nothing for an unattended pass to hand one to. The consequence worth
stating is that this pass **cannot damage a library**, which is the strongest
thing that can be said about a job that runs while nobody is watching.
`test_the_pass_writes_nothing_to_the_files` pins it.

## The early exit is the design

The stored payload is read *before* the fetch, and an unchanged one ends that
album there — no file reads, no plan, nothing recorded. A second pass over a
library MusicBrainz has not touched costs its requests and nothing else, which
is #32's idempotency invariant enforced by construction rather than by care.

Note the asymmetry that makes it correct: an unchanged payload **skips** an
album, it never **clears** its flag. "MusicBrainz has not moved" and "the files
have nothing outstanding" are different facts, and an album whose update was
never applied still has one however long MusicBrainz sits still.

## Two leaks in the scheduling clock, found and closed

The queue is dated off #127's own `fetched_at` (`mb_cache.fetch_times()`), so
scheduling needs no state of its own. Two cases escape that clock, and both
would have cost a request per album on every pass forever:

- a **merged** release — the fetch follows the redirect and the row lands under
  the id MusicBrainz gave back (#268), so the id the sidecar names never gets a
  fresher row;
- a **deleted** release — the fetch raises and nothing is stored at all, which
  is right (a negative is never cached), but leaves the same gap on an album
  whose remedy is a human decision that re-asking brings no closer.

`gardener._asked` remembers which ids this process has spent a request on, which
closes both. In memory, because it paces a pass rather than describing the
library.

## Off by default

`[gardener] level`, `"off" | "review"` — a named level rather than a boolean,
because #273's third level is already designed and an `enabled = true` that
later has to become `level = "review"` breaks a config file on somebody's NAS
for no reason but our convenience.

`review` writes nothing either, so the default is not protecting the library —
it is protecting a volunteer service from an install that started asking it a
hundred questions an hour because somebody upgraded.

## Standing aside

A sync, a reconcile pass, a library not yet scanned, or a pass still running
from last hour: all skip the tick. One reason between them — the rate limit is a
single shared queue and anything the user set in motion is waiting on it, while
the check's albums have waited a week and can wait another hour. When
MusicBrainz keeps failing the pass gives up rather than spending a request per
album to learn the same thing each time; a 404 is an *answer* and does not count
towards that, or a library with five deleted releases would abort every pass at
the fifth.

## Testing

21 new tests. All were written after the code, so all 17 mutation checks were
run — each went red on exactly the intended test, and `gardener.py` and
`main.py` diffed byte-identical afterwards.

The request-count assertions are the load-bearing ones: the flags come out
identical whether the pass asked once or a hundred times, so nothing else in the
suite could notice a budget leak.

## Follow-ups this unblocks

- **#293** (badge the Library tile) said its honest sequencing was "after #270",
  because a badge's silence is a stronger claim than a filter's and the flag
  under-reports until something sweeps. That is now available.
- **#273** should extend `level` with `enrich` rather than add a key, and take
  over `_UPDATE_CHECK_INTERVAL` and `gardener.ALBUMS_PER_PASS`, which are
  constants for now.

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
