### PR TITLE
Write albumartists, the album-level twin of the artists tag

### DIFF
--- a/.claude/skills/source-control/SKILL.md
+++ b/.claude/skills/source-control/SKILL.md
@@ -32,6 +32,14 @@ None of the following is authorization. Each has been used as one:
 - **They approved a push earlier in the session.** Approval doesn't carry
   forward. One go-ahead covers the operation asked about and nothing beyond it —
   a follow-up fix an hour later is a fresh ask.
+- **The approval is still open, but the branch has grown since.** The nastiest
+  one, because nothing about it feels like a second push: they said "push and
+  open the PR", you hadn't pushed yet, and in between they asked for one more
+  thing. The go-ahead described a branch that no longer exists. An approval
+  covers the commits it was given for; commits added after it need a fresh ask,
+  and "you were going to push anyway" is not that ask. #309's PR went out
+  carrying a commit for #261 on the strength of an approval given before #261
+  was mentioned.
 
 1.10.0 was pushed, tagged and published to GHCR without asking, on the second
 and third reasons above. Nothing broke, which is exactly why it's written down:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- Harmonist now writes **`albumartists`**, the album-level list of artist names
+  Picard writes alongside `albumartist`. On a collaboration the joined phrase —
+  *zakè & rhubiqs* — leaves a player guessing where one name ends and the next
+  begins, so the album files under a single composite artist; Navidrome and Plex
+  read the list instead. Written on the next tagging or re-tag (#322).
+  **Albums tagged by an earlier version don't carry it**, so they will report an
+  update available until re-tagged; a library Picard has tagged already has the
+  tag and is unaffected.
 - An album with a MusicBrainz update waiting carries an **Update** badge on its
   Library tile (#293).
 - Harmonist can **check your library against MusicBrainz in the background**, so

--- a/docs/design.md
+++ b/docs/design.md
@@ -896,13 +896,41 @@ Everything not in the set is left exactly as found: the comment carrying a recov
 `Owned` is split by **scope** — whether a field's value depends on which track it is:
 
 - **Album** — `mb_album_id`, `album`, `album_artist`, `album_artist_sort`, `mb_album_artist_ids`, `mb_release_group_id`, `mb_album_type`, `mb_album_status`, `mb_album_country`, `date`, `original_date`, `script`, `label`, `catalog_number`, `barcode`, `asin`, `disc_total`.
-- **Track** — `title`, `artist`, `artist_sort`, `artists`, `track_num`, `track_total`, `disc_num`, `media`, `mb_track_id`, `mb_release_track_id`, `mb_artist_ids`, `isrcs`.
+- **Track** — `title`, `artist`, `artist_sort`, `artists`, `track_num`, `track_total`, `disc_num`, `disc_subtitle`, `media`, `mb_track_id`, `mb_release_track_id`, `mb_artist_ids`, `isrcs`.
 
 `media`, `disc_subtitle`, `disc_num` and `track_total` are derived from the *medium*, so they are track-scoped even though they look album-level: on a 2-disc release, or a CD+DVD set, they genuinely differ between tracks. The scope drives the tagging audit records (#86), which record an album-level change once per album rather than once per track.
 
 The `Owned` member values are exactly the `TagSet` attribute names, and a test asserts the two sets match. That guards drift in both directions: a new `TagSet` field nobody classified would be written but never cleared, and an `Owned` member with no field behind it would clear a tag Harmonist never writes.
 
 **Artwork is deliberately not in the set.** Embedded cover art is not a tag here — `tagger.tag_album` passes `cover=None` when the tracks carry differing per-track images precisely so `write_tags` leaves them alone, and clearing artwork with the owned set would make that protection a no-op. Per-track artwork is a third category that fits neither scope, which neither MusicBrainz nor Picard really models; it is handled in the tagger. See #131.
+
+### The tags Harmonist does *not* write
+
+`Owned` says what is written; this says what is deliberately left out, which the code cannot. Measured against [Picard's own tag documentation](https://picard-docs.musicbrainz.org/en/latest/variables/tags_basic.html), Harmonist's 30 owned fields land as 31 of the 38 **basic** tags and none of the ~19 **advanced** (relationship-derived) ones.
+
+The table is the standing answer to "why doesn't Harmonist write X" — so it is kept to the *reason*, and never restates the covered set, which would rot the moment `Owned` changed.
+
+| Picard tag(s) | Verdict | Why |
+| --- | --- | --- |
+| `albumartists` | Planned (#322) | The album-level twin of `artists`, from a credit already in hand. |
+| `compilation` | Planned (#323) | The Various Artists flag; without it players shatter a VA album per track artist. |
+| `genre` | Deferred (#12) | Read-only today: a genre tagged elsewhere is displayed and never clobbered. Needs the `genres` include and a policy on genre-vs-folksonomy-tag. |
+| `composer`, `composersort`, `lyricist`, `writer`, `arranger`, `conductor`, `performer:*`, `producer`, `engineer`, `mixer`, `djmixer`, `remixer`, `director`, `work`, `musicbrainz_workid`, `musicbrainz_composerid`, `language`, `license`, `website` | Undecided | The entire advanced set is one `RELEASE_INCLUDES` change away, in the same single request — but that tuple **is the `mb_cache` key** (§4), so adding to it invalidates every cached release and re-fetches the library at one rate-limited request per album. `Owned` roughly doubles, landing on the comparison (#106), the audit records (#86) and undo (#157); ID3 needs the `TMCL`/`TIPL` multi-value frames, which no backend writes. Relationships also churn in MusicBrainz far more than release facts, so #32's pass would report updates constantly. Worth splitting: composer/lyricist/work is the classical and soundtrack case; the credits half is a much larger surface for much less benefit. |
+| `comment` | Never | Claimed as **user space**. It carries a recovered Bandcamp URL and is excluded from every backend's owned mapping so a re-tag preserves it. Picard puts the release disambiguation here; Harmonist shows that on the album page instead. |
+| `originalalbum`, `originalartist`, `musicbrainz_originalalbumid`, `musicbrainz_originalartistid` | Undecided, leaning no | Needs the release group's *release list*, which the release fetch doesn't carry — one extra lookup per release group, against the call budget. `original_date` already carries the part users sort on. |
+| `lyrics`, `syncedlyrics` | Out of scope here | MusicBrainz serves no lyrics, only relationships to lyric sites. A second provider is a scope question about what Harmonist is, not a tag mapping. |
+| `bpm`, `key` | No source | AcousticBrainz is shut down. Would require local audio analysis, which Harmonist does not otherwise do. |
+| `acoustid_id`, `acoustid_fingerprint`, `musicip_fingerprint`, `musicip_puid` | Never | Audio fingerprinting. An album is identified by its Bandcamp URL or its MBID, never by analysing the audio; MusicIP is long dead. |
+| `musicbrainz_discid` | Never | Derived from a physical CD's table of contents. Harmonist never sees a disc. |
+| `albumsort`, `titlesort` | Never | MusicBrainz has no sort title for a release or a track — only for artists, which *are* written. Picard leaves these empty too. |
+| `copyright`, `encodedby`, `encodersettings`, `originalfilename` | Never | Facts about the file or the rip, not about the release. Preserved as found. |
+| `podcast`, `podcasturl`, `show`, `showsort`, `itunes_cddb_1`, `gapless` | Never | Podcast, TV and iTunes-store plumbing. |
+| `showmovement`, `subtitle` | Rides on the row above | Classical movement handling, only meaningful with the work relationships. |
+| `releasedate` | Nothing to do | Maps to the same slot as `date` (`DATE` / `TDRC`), which *is* written. It exists in Picard so a script can retarget `date`. |
+
+One apparent gap that isn't: `originalyear` is written on Vorbis and MP4 but not MP3, because **ID3v2.4 has no frame for it** — `TDOR` carries the full original date and consumers derive the year.
+
+**Everything above is still preserved.** "Not written" is not "removed": anything outside `Owned` is left exactly as found, so a library tagged by Picard with composers and performers keeps them through a Harmonist re-tag.
 
 ### A second correct spelling of the album title
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -895,7 +895,7 @@ Everything not in the set is left exactly as found: the comment carrying a recov
 
 `Owned` is split by **scope** — whether a field's value depends on which track it is:
 
-- **Album** — `mb_album_id`, `album`, `album_artist`, `album_artist_sort`, `mb_album_artist_ids`, `mb_release_group_id`, `mb_album_type`, `mb_album_status`, `mb_album_country`, `date`, `original_date`, `script`, `label`, `catalog_number`, `barcode`, `asin`, `disc_total`.
+- **Album** — `mb_album_id`, `album`, `album_artist`, `album_artist_sort`, `album_artists`, `mb_album_artist_ids`, `mb_release_group_id`, `mb_album_type`, `mb_album_status`, `mb_album_country`, `date`, `original_date`, `script`, `label`, `catalog_number`, `barcode`, `asin`, `disc_total`.
 - **Track** — `title`, `artist`, `artist_sort`, `artists`, `track_num`, `track_total`, `disc_num`, `disc_subtitle`, `media`, `mb_track_id`, `mb_release_track_id`, `mb_artist_ids`, `isrcs`.
 
 `media`, `disc_subtitle`, `disc_num` and `track_total` are derived from the *medium*, so they are track-scoped even though they look album-level: on a 2-disc release, or a CD+DVD set, they genuinely differ between tracks. The scope drives the tagging audit records (#86), which record an album-level change once per album rather than once per track.
@@ -906,13 +906,12 @@ The `Owned` member values are exactly the `TagSet` attribute names, and a test a
 
 ### The tags Harmonist does *not* write
 
-`Owned` says what is written; this says what is deliberately left out, which the code cannot. Measured against [Picard's own tag documentation](https://picard-docs.musicbrainz.org/en/latest/variables/tags_basic.html), Harmonist's 30 owned fields land as 31 of the 38 **basic** tags and none of the ~19 **advanced** (relationship-derived) ones.
+`Owned` says what is written; this says what is deliberately left out, which the code cannot. Measured against [Picard's own tag documentation](https://picard-docs.musicbrainz.org/en/latest/variables/tags_basic.html), Harmonist's 31 owned fields land as 32 of the 38 **basic** tags and none of the ~19 **advanced** (relationship-derived) ones.
 
 The table is the standing answer to "why doesn't Harmonist write X" — so it is kept to the *reason*, and never restates the covered set, which would rot the moment `Owned` changed.
 
 | Picard tag(s) | Verdict | Why |
 | --- | --- | --- |
-| `albumartists` | Planned (#322) | The album-level twin of `artists`, from a credit already in hand. |
 | `compilation` | Planned (#323) | The Various Artists flag; without it players shatter a VA album per track artist. |
 | `genre` | Deferred (#12) | Read-only today: a genre tagged elsewhere is displayed and never clobbered. Needs the `genres` include and a policy on genre-vs-folksonomy-tag. |
 | `composer`, `composersort`, `lyricist`, `writer`, `arranger`, `conductor`, `performer:*`, `producer`, `engineer`, `mixer`, `djmixer`, `remixer`, `director`, `work`, `musicbrainz_workid`, `musicbrainz_composerid`, `language`, `license`, `website` | Undecided | The entire advanced set is one `RELEASE_INCLUDES` change away, in the same single request — but that tuple **is the `mb_cache` key** (§4), so adding to it invalidates every cached release and re-fetches the library at one rate-limited request per album. `Owned` roughly doubles, landing on the comparison (#106), the audit records (#86) and undo (#157); ID3 needs the `TMCL`/`TIPL` multi-value frames, which no backend writes. Relationships also churn in MusicBrainz far more than release facts, so #32's pass would report updates constantly. Worth splitting: composer/lyricist/work is the classical and soundtrack case; the credits half is a much larger surface for much less benefit. |

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -401,6 +401,7 @@ _KINDS: dict[str, Kind] = {
     Owned.ALBUM: Kind.TEXT,
     Owned.ALBUM_ARTIST: Kind.TEXT,
     Owned.ALBUM_ARTIST_SORT: Kind.TEXT,
+    Owned.ALBUM_ARTISTS: Kind.TEXT,
     Owned.MB_ALBUM_ARTIST_IDS: Kind.TEXT,
     Owned.MB_RELEASE_GROUP_ID: Kind.TEXT,
     Owned.MB_ALBUM_TYPE: Kind.SCALAR,
@@ -530,25 +531,30 @@ _NOT_COMPARED: frozenset[Owned] = frozenset({Owned.MB_ALBUM_ID})
 #: grouped for one column and for two, and the wide layout is the one being read
 #: on the machine someone tags from.
 _DISPLAY_ORDER: tuple[Owned, ...] = (
-    # Row 1-3: what the release IS, beside who it is BY.
+    # Row 1-4: what the release IS, beside who it is BY. `album_artists` sits
+    # directly under the singular phrase it unjoins (#322), and `script` — the
+    # writing system of the title above it — moved up from the paperwork block
+    # to keep the two columns square once the artist side grew to four.
     Owned.ALBUM,
     Owned.ALBUM_ARTIST,
     Owned.MB_RELEASE_GROUP_ID,
-    Owned.ALBUM_ARTIST_SORT,
+    Owned.ALBUM_ARTISTS,
     Owned.MB_ALBUM_TYPE,
+    Owned.ALBUM_ARTIST_SORT,
+    Owned.SCRIPT,
     Owned.MB_ALBUM_ARTIST_IDS,
-    # Row 4-5: which edition, and when.
+    # Row 5-6: which edition, and when.
     Owned.MB_ALBUM_STATUS,
     Owned.MB_ALBUM_COUNTRY,
     Owned.DATE,
     Owned.ORIGINAL_DATE,
-    # Row 6-8: the release's paperwork.
+    # Row 7-9: the release's paperwork. An odd field count leaves the last row
+    # half-full, which is the right place for the gap.
     Owned.LABEL,
     Owned.CATALOG_NUMBER,
     Owned.BARCODE,
     Owned.ASIN,
     Owned.DISC_TOTAL,
-    Owned.SCRIPT,
 )
 
 

--- a/src/harmonist/formats/_vorbis.py
+++ b/src/harmonist/formats/_vorbis.py
@@ -42,6 +42,7 @@ KEY_ALBUM_ARTIST = "ALBUMARTIST"
 KEY_ARTIST_SORT = "ARTISTSORT"
 KEY_ALBUM_ARTIST_SORT = "ALBUMARTISTSORT"
 KEY_ARTISTS = "ARTISTS"
+KEY_ALBUM_ARTISTS = "ALBUMARTISTS"
 KEY_DATE = "DATE"
 KEY_ORIGINAL_DATE = "ORIGINALDATE"
 KEY_ORIGINAL_YEAR = "ORIGINALYEAR"
@@ -72,6 +73,7 @@ OWNED_KEYS: dict[Owned, tuple[str, ...]] = {
     Owned.ALBUM: (KEY_ALBUM,),
     Owned.ALBUM_ARTIST: (KEY_ALBUM_ARTIST,),
     Owned.ALBUM_ARTIST_SORT: (KEY_ALBUM_ARTIST_SORT,),
+    Owned.ALBUM_ARTISTS: (KEY_ALBUM_ARTISTS,),
     Owned.MB_ALBUM_ARTIST_IDS: (KEY_ALBUM_ARTIST_ID,),
     Owned.MB_RELEASE_GROUP_ID: (KEY_RELEASE_GROUP_ID,),
     Owned.MB_ALBUM_TYPE: (KEY_RELEASE_TYPE,),
@@ -140,6 +142,7 @@ _SINGLE_KEYS: dict[Owned, str] = {
 
 #: Owned fields carried as several values under one key.
 _LIST_KEYS: dict[Owned, str] = {
+    Owned.ALBUM_ARTISTS: KEY_ALBUM_ARTISTS,
     Owned.MB_ALBUM_ARTIST_IDS: KEY_ALBUM_ARTIST_ID,
     Owned.ARTISTS: KEY_ARTISTS,
     Owned.MB_ARTIST_IDS: KEY_ARTIST_ID,
@@ -362,6 +365,7 @@ class VorbisTagger:
             Owned.ALBUM: one(KEY_ALBUM),
             Owned.ALBUM_ARTIST: one(KEY_ALBUM_ARTIST),
             Owned.ALBUM_ARTIST_SORT: one(KEY_ALBUM_ARTIST_SORT),
+            Owned.ALBUM_ARTISTS: many(KEY_ALBUM_ARTISTS),
             Owned.MB_ALBUM_ARTIST_IDS: many(KEY_ALBUM_ARTIST_ID),
             Owned.MB_RELEASE_GROUP_ID: one(KEY_RELEASE_GROUP_ID),
             Owned.MB_ALBUM_TYPE: one(KEY_RELEASE_TYPE),
@@ -450,6 +454,8 @@ class VorbisTagger:
             tags[KEY_ARTIST_SORT] = [tagset.artist_sort]
         if tagset.album_artist_sort:
             tags[KEY_ALBUM_ARTIST_SORT] = [tagset.album_artist_sort]
+        if tagset.album_artists:
+            tags[KEY_ALBUM_ARTISTS] = list(tagset.album_artists)
         if tagset.artists:
             tags[KEY_ARTISTS] = list(tagset.artists)
         if tagset.date:

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -47,6 +47,7 @@ ATOM_ASIN = f"{ATOM_PREFIX}ASIN"
 # Per-track ISRC(s) and multi-value artists, original date, script (freeform).
 ATOM_ISRC = f"{ATOM_PREFIX}ISRC"
 ATOM_ARTISTS = f"{ATOM_PREFIX}ARTISTS"
+ATOM_ALBUM_ARTISTS = f"{ATOM_PREFIX}ALBUMARTISTS"
 ATOM_ORIGINAL_DATE = f"{ATOM_PREFIX}ORIGINALDATE"
 ATOM_ORIGINAL_YEAR = f"{ATOM_PREFIX}ORIGINALYEAR"
 ATOM_SCRIPT = f"{ATOM_PREFIX}SCRIPT"
@@ -84,6 +85,7 @@ OWNED_ATOMS: dict[Owned, tuple[str, ...]] = {
     Owned.ALBUM: (ATOM_ALBUM,),
     Owned.ALBUM_ARTIST: (ATOM_ALBUM_ARTIST,),
     Owned.ALBUM_ARTIST_SORT: (ATOM_ALBUM_ARTIST_SORT,),
+    Owned.ALBUM_ARTISTS: (ATOM_ALBUM_ARTISTS,),
     Owned.MB_ALBUM_ARTIST_IDS: (ATOM_MB_ALBUM_ARTIST_ID,),
     Owned.MB_RELEASE_GROUP_ID: (ATOM_MB_RELEASE_GROUP_ID,),
     Owned.MB_ALBUM_TYPE: (ATOM_MB_ALBUM_TYPE,),
@@ -329,6 +331,7 @@ def _read_owned(audio: MP4) -> dict[str, Any]:
         Owned.ALBUM: _text_atom(audio, ATOM_ALBUM),
         Owned.ALBUM_ARTIST: _text_atom(audio, ATOM_ALBUM_ARTIST),
         Owned.ALBUM_ARTIST_SORT: _text_atom(audio, ATOM_ALBUM_ARTIST_SORT),
+        Owned.ALBUM_ARTISTS: _binary_atom_list(audio, ATOM_ALBUM_ARTISTS),
         Owned.MB_ALBUM_ARTIST_IDS: _binary_atom_list(audio, ATOM_MB_ALBUM_ARTIST_ID),
         Owned.MB_RELEASE_GROUP_ID: _binary_atom_str(audio, ATOM_MB_RELEASE_GROUP_ID),
         Owned.MB_ALBUM_TYPE: _binary_atom_str(audio, ATOM_MB_ALBUM_TYPE),
@@ -471,6 +474,7 @@ _BINARY_ATOMS: dict[Owned, str] = {
 
 #: Owned fields stored as multi-valued freeform atoms.
 _BINARY_LIST_ATOMS: dict[Owned, str] = {
+    Owned.ALBUM_ARTISTS: ATOM_ALBUM_ARTISTS,
     Owned.MB_ALBUM_ARTIST_IDS: ATOM_MB_ALBUM_ARTIST_ID,
     Owned.ARTISTS: ATOM_ARTISTS,
     Owned.MB_ARTIST_IDS: ATOM_MB_ARTIST_ID,
@@ -545,6 +549,8 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> dict[str, Any
         audio[ATOM_ARTIST_SORT] = [tagset.artist_sort]
     if tagset.album_artist_sort:
         audio[ATOM_ALBUM_ARTIST_SORT] = [tagset.album_artist_sort]
+    if tagset.album_artists:
+        audio[ATOM_ALBUM_ARTISTS] = [a.encode("utf-8") for a in tagset.album_artists]
     if tagset.artists:
         audio[ATOM_ARTISTS] = [a.encode("utf-8") for a in tagset.artists]
 

--- a/src/harmonist/formats/mp3.py
+++ b/src/harmonist/formats/mp3.py
@@ -64,6 +64,7 @@ TXXX_CATALOG = "CATALOGNUMBER"
 TXXX_BARCODE = "BARCODE"
 TXXX_ASIN = "ASIN"
 TXXX_ARTISTS = "ARTISTS"
+TXXX_ALBUM_ARTISTS = "ALBUMARTISTS"
 TXXX_SCRIPT = "SCRIPT"
 
 
@@ -81,6 +82,7 @@ OWNED_FRAMES: dict[Owned, tuple[str, ...]] = {
     Owned.ALBUM: ("TALB",),
     Owned.ALBUM_ARTIST: ("TPE2",),
     Owned.ALBUM_ARTIST_SORT: ("TSO2",),
+    Owned.ALBUM_ARTISTS: (f"TXXX:{TXXX_ALBUM_ARTISTS}",),
     Owned.MB_ALBUM_ARTIST_IDS: (f"TXXX:{TXXX_ALBUM_ARTIST_ID}",),
     Owned.MB_RELEASE_GROUP_ID: (f"TXXX:{TXXX_RELEASE_GROUP_ID}",),
     Owned.MB_ALBUM_TYPE: (f"TXXX:{TXXX_ALBUM_TYPE}",),
@@ -342,6 +344,7 @@ def _read_owned(tags: Any) -> dict[str, Any]:
         Owned.ALBUM: _text(tags, "TALB"),
         Owned.ALBUM_ARTIST: _text(tags, "TPE2"),
         Owned.ALBUM_ARTIST_SORT: _text(tags, "TSO2"),
+        Owned.ALBUM_ARTISTS: _txxx_list(tags, TXXX_ALBUM_ARTISTS),
         Owned.MB_ALBUM_ARTIST_IDS: _txxx_list(tags, TXXX_ALBUM_ARTIST_ID),
         Owned.MB_RELEASE_GROUP_ID: _txxx(tags, TXXX_RELEASE_GROUP_ID),
         Owned.MB_ALBUM_TYPE: _txxx(tags, TXXX_ALBUM_TYPE),
@@ -504,6 +507,7 @@ _TXXX_FIELDS: dict[Owned, str] = {
 
 #: Owned fields carried as several strings in one TXXX frame.
 _TXXX_LIST_FIELDS: dict[Owned, str] = {
+    Owned.ALBUM_ARTISTS: TXXX_ALBUM_ARTISTS,
     Owned.MB_ALBUM_ARTIST_IDS: TXXX_ALBUM_ARTIST_ID,
     Owned.ARTISTS: TXXX_ARTISTS,
     Owned.MB_ARTIST_IDS: TXXX_ARTIST_ID,
@@ -579,6 +583,8 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> dict[str, Any
         tags.setall("TSOP", [TSOP(encoding=Encoding.UTF8, text=[tagset.artist_sort])])
     if tagset.album_artist_sort:
         tags.setall("TSO2", [TSO2(encoding=Encoding.UTF8, text=[tagset.album_artist_sort])])
+    if tagset.album_artists:
+        _set_txxx(tags, TXXX_ALBUM_ARTISTS, tagset.album_artists)
     if tagset.artists:
         _set_txxx(tags, TXXX_ARTISTS, tagset.artists)
     if tagset.original_date:

--- a/src/harmonist/formats/owned.py
+++ b/src/harmonist/formats/owned.py
@@ -70,6 +70,7 @@ class Owned(StrEnum):
     ALBUM = "album"
     ALBUM_ARTIST = "album_artist"
     ALBUM_ARTIST_SORT = "album_artist_sort"
+    ALBUM_ARTISTS = "album_artists"
     MB_ALBUM_ARTIST_IDS = "mb_album_artist_ids"
     MB_RELEASE_GROUP_ID = "mb_release_group_id"
     MB_ALBUM_TYPE = "mb_album_type"
@@ -105,6 +106,10 @@ SCOPE: dict[Owned, Scope] = {
     Owned.ALBUM: Scope.ALBUM,
     Owned.ALBUM_ARTIST: Scope.ALBUM,
     Owned.ALBUM_ARTIST_SORT: Scope.ALBUM,
+    # Derived from the RELEASE credit, so unlike `artists` it cannot vary
+    # between tracks — a compilation's tracks differ in `artists` while every
+    # one of them names the same album artists.
+    Owned.ALBUM_ARTISTS: Scope.ALBUM,
     Owned.MB_ALBUM_ARTIST_IDS: Scope.ALBUM,
     Owned.MB_RELEASE_GROUP_ID: Scope.ALBUM,
     Owned.MB_ALBUM_TYPE: Scope.ALBUM,
@@ -215,6 +220,7 @@ SIGNIFICANCE: dict[str, Significance] = {
     # --- Identity: what the album, or one of its tracks, IS ---
     Owned.ALBUM: Significance.IDENTITY,
     Owned.ALBUM_ARTIST: Significance.IDENTITY,
+    Owned.ALBUM_ARTISTS: Significance.IDENTITY,
     Owned.ARTIST: Significance.IDENTITY,
     Owned.ARTISTS: Significance.IDENTITY,
     # Identity even though it reads like a descriptor: MusicBrainz re-typing a
@@ -355,6 +361,7 @@ LABELS: dict[str, str] = {
     Owned.ALBUM: "Album",
     Owned.ALBUM_ARTIST: "Album artist",
     Owned.ALBUM_ARTIST_SORT: "Album artist sort",
+    Owned.ALBUM_ARTISTS: "Album artists",
     Owned.MB_ALBUM_ARTIST_IDS: "Album artist IDs",
     Owned.MB_RELEASE_GROUP_ID: "Release group",
     Owned.MB_ALBUM_TYPE: "Release type",

--- a/src/harmonist/formats/types.py
+++ b/src/harmonist/formats/types.py
@@ -94,10 +94,18 @@ class TagSet:
     track_total: int
 
     # Sort names + multi-value artists (Picard: albumartistsort, artistsort,
-    # artists). Sort names drive correct alphabetisation in Plex/Navidrome
-    # ("The Beatles" under B); `artists` is the unjoined per-artist list.
+    # albumartists, artists). Sort names drive correct alphabetisation in
+    # Plex/Navidrome ("The Beatles" under B); the two list fields are the
+    # unjoined per-artist names.
+    #
+    # `album_artists` is `artists` one level up, and it exists for the same
+    # reason: `album_artist` is a single joined phrase — "zakè & rhubiqs" — so
+    # a player wanting to file a collaboration under BOTH artists has to guess
+    # where one name ends and the next begins. Navidrome and Plex read the
+    # album-level list to avoid that guess (#322).
     album_artist_sort: str | None = None
     artist_sort: str | None = None
+    album_artists: list[str] = field(default_factory=list)
     artists: list[str] = field(default_factory=list)
 
     # Original release date of the *work* (release-group first-release-date),

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -33,6 +33,7 @@ from .formats.m4a import (  # noqa: F401 — back-compat re-exports
     ATOM_ALBUM,
     ATOM_ALBUM_ARTIST,
     ATOM_ALBUM_ARTIST_SORT,
+    ATOM_ALBUM_ARTISTS,
     ATOM_ARTIST,
     ATOM_ARTIST_SORT,
     ATOM_ARTISTS,
@@ -986,6 +987,11 @@ def _build_tagset(
         track_total=track_total,
         album_artist_sort=_artist_sort_phrase(release.get("artist-credit")) or None,
         artist_sort=_artist_sort_phrase(track_artist_credit) or None,
+        # The release credit unjoined, so a two-artist collaboration files under
+        # both names instead of under one composite pseudo-artist (#322). Bare
+        # names by construction — `_artist_names` drops the join phrases, which
+        # is the guess this tag exists to remove.
+        album_artists=_artist_names(release.get("artist-credit")),
         artists=_artist_names(track_artist_credit),
         original_date=rg.get("first-release-date") or None,
         script=(release.get("text-representation") or {}).get("script") or None,

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -1324,19 +1324,25 @@ def test_the_panel_pairs_release_fields_against_artist_fields():
     Pinned as the whole sequence, because the property being asserted is about
     ADJACENCY: it lives in the pairs, and sampling two of them cannot see a
     third that has drifted into the wrong column.
+
+    `Album artists` (#322) made the artist column four long, so `Script` moved up
+    from the paperwork block to square the two — and left an odd number of album
+    fields, which is why `Genre` now pairs with `Disc total` and `Comment` ends
+    the grid alone.
     """
     fields = album_fields([("1.flac", TrackTags(album="Obreel"))], _tagset(album="Obreel"))
 
     assert [f.label for f in fields] == [
         "Album",           "Album artist",
-        "Release group",   "Album artist sort",
-        "Release type",    "Album artist IDs",
+        "Release group",   "Album artists",
+        "Release type",    "Album artist sort",
+        "Script",          "Album artist IDs",
         "Release status",  "Country",
         "Date",            "Original date",
         "Label",           "Cat. no.",
         "Barcode",         "ASIN",
-        "Disc total",      "Script",
-        "Genre",           "Comment",
+        "Disc total",      "Genre",
+        "Comment",
     ]  # fmt: skip
 
 

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -940,6 +940,7 @@ def _full_tagset() -> Any:
         track_total=18,
         album_artist_sort="Boards of Canada",
         artist_sort="Boards of Canada",
+        album_artists=["Boards of Canada"],
         artists=["Boards of Canada"],
         original_date="1998-04-20",
         script="Latn",

--- a/test/test_picard_spec.py
+++ b/test/test_picard_spec.py
@@ -20,6 +20,7 @@ from mutagen.mp4 import MP4
 
 from harmonist.tagger import (
     ATOM_ALBUM_ARTIST_SORT,
+    ATOM_ALBUM_ARTISTS,
     ATOM_ARTIST_SORT,
     ATOM_ARTISTS,
     ATOM_ASIN,
@@ -253,8 +254,9 @@ def test_disc_number_atom(tmp_path):
 
 
 def test_sort_artists_original_date_script_atoms(tmp_path):
-    """Picard: soaa/soar (sort names), ARTISTS (multi-value), ORIGINALDATE +
-    ORIGINALYEAR (release-group first release), SCRIPT (text-representation)."""
+    """Picard: soaa/soar (sort names), ARTISTS and ALBUMARTISTS (multi-value),
+    ORIGINALDATE + ORIGINALYEAR (release-group first release), SCRIPT
+    (text-representation)."""
     album_dir = _setup_album(tmp_path, 2)
     PicardCompatibleTagger().tag_album(album_dir, _fully_populated_release())
 
@@ -262,6 +264,7 @@ def test_sort_artists_original_date_script_atoms(tmp_path):
     assert t1["soaa"] == ["Reference Artist, The"]
     assert t1["soar"] == ["Reference Artist, The"]
     assert _atom_strs(t1, ATOM_ARTISTS) == ["Reference Artist"]
+    assert _atom_strs(t1, ATOM_ALBUM_ARTISTS) == ["Reference Artist"]
     assert _atom_str(t1, ATOM_ORIGINAL_DATE) == "1990-01-01"
     assert _atom_str(t1, ATOM_ORIGINAL_YEAR) == "1990"
     assert _atom_str(t1, ATOM_SCRIPT) == "Latn"
@@ -270,6 +273,11 @@ def test_sort_artists_original_date_script_atoms(tmp_path):
     t2 = MP4(album_dir / "02 Track 2.m4a")
     assert t2["soar"] == ["Guest feat. Host"]
     assert _atom_strs(t2, ATOM_ARTISTS) == ["Guest", "Host"]
+    # ALBUMARTISTS does NOT follow it: the album-level list comes from the
+    # RELEASE credit, so it is the same on every track however the tracks are
+    # credited (#322). Built from `artist-credit` on the track, this would read
+    # ["Guest", "Host"] and the album would file under its guest.
+    assert _atom_strs(t2, ATOM_ALBUM_ARTISTS) == ["Reference Artist"]
 
 
 # ---------- exhaustive atom inventory ----------
@@ -306,6 +314,7 @@ EXPECTED_PICARD_ATOMS_WE_WRITE = {
     # Sort names, multi-value artists, original date, script
     ATOM_ALBUM_ARTIST_SORT,
     ATOM_ARTIST_SORT,
+    ATOM_ALBUM_ARTISTS,
     ATOM_ARTISTS,
     ATOM_ORIGINAL_DATE,
     ATOM_ORIGINAL_YEAR,

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -505,6 +505,33 @@ def test_artist_phrases_keep_the_join_phrase(credit):
     assert tagger._artist_names(credit) == ["zakè", "rhubiqs"]
 
 
+def test_a_collaboration_names_both_album_artists_on_every_track():
+    """#322. `album_artist` is one joined phrase, so a player filing the album
+    under BOTH artists has to guess where "zakè" ends and "rhubiqs" begins —
+    the guess `artists` already removes at track level.
+
+    Asserted through `tagsets_for` rather than on a helper, because the claim is
+    that EVERY track carries the album-level list: it is derived from the release
+    credit, so it cannot vary between tracks, and a per-track derivation would
+    still pass a one-track assertion.
+    """
+    release = _release_2_tracks()
+    release["artist-credit"] = [
+        {"artist": {"id": "art-z", "name": "zakè", "sort-name": "zakè"}, "name": "zakè"},
+        " & ",
+        {"artist": {"id": "art-r", "name": "rhubiqs", "sort-name": "rhubiqs"}, "name": "rhubiqs"},
+    ]
+
+    tagsets = tagger.tagsets_for(release)
+
+    assert [t.album_artists for t in tagsets] == [["zakè", "rhubiqs"], ["zakè", "rhubiqs"]]
+    # The joined phrase is unchanged — the list is an addition, not a substitute.
+    assert {t.album_artist for t in tagsets} == {"zakè & rhubiqs"}
+    # Track 2 keeps its own credit in `artists`, which is what makes the two
+    # fields different questions rather than one written twice.
+    assert tagsets[1].artists == ["Featured Artist", "Other"]
+
+
 def test_tag_album_track_artist_credit_overrides_release(album_with_tracks):
     """Track 2 has its own artist-credit; should be used for ©ART and Artist Id atom."""
     album_dir = album_with_tracks(2)


### PR DESCRIPTION
`albumartist` is a single joined phrase — *zakè & rhubiqs* — so a player wanting to file a collaboration under **both** artists has to guess where one name ends and the next begins. That is the guess `artists` already removes at track level, and Navidrome and Plex read the album-level list for the same purpose. Until now a two-artist release filed under one composite pseudo-artist.

## What it does

`album_artists` is derived from the **release** credit, not the track's, so it is `Scope.ALBUM`: a compilation's tracks differ in `artists` while every one of them names the same album artists. Mapped per format as Picard does — `TXXX:ALBUMARTISTS` (ID3), `ALBUMARTISTS` (Vorbis), `----:com.apple.iTunes:ALBUMARTISTS` (MP4).

No parsing is involved in either direction. MusicBrainz returns the credit as a structured list; `_artist_phrase` composes the joined phrase from it and `_artist_names` walks the same list dropping the join phrases, preferring each entry's *credited-as* name — so a release crediting an artist under an alias writes that alias into both tags, consistent with the MBIDs beside them.

Being owned, it joins the tag-change records, the comparison panel and the undo for free. It also makes the panel's artist column four long, so `script` moves up from the paperwork block to keep the two columns square.

## Note for upgraders

Albums tagged by an earlier version don't carry the tag, so they will report an update available until re-tagged. A library Picard has tagged already has it and is unaffected. Called out in the changelog rather than suppressed.

## Tests

- `test_a_collaboration_names_both_album_artists_on_every_track` — through `tagsets_for`, so the album-level claim is made of every track rather than of one.
- `test_sort_artists_original_date_script_atoms` — track 2 has its own credit; `ARTISTS` follows it and `ALBUMARTISTS` does not.
- The `_full_tagset` round trip and the Picard atom inventory cover all three backends.

Mutation-checked both ways: deriving from the track credit reddens the two new tests, and dropping the write reddens 23 across the round-trip, idempotence and gardener suites.

Also carries one docs-only commit that predates the branch — the table in `design.md` recording which Picard tags Harmonist deliberately leaves alone, which is where #322 and #323 came from.

Fixes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2PKanbm1rsX7Zx8mnNUj7