### PR TITLE
Write the compilation flag, so players stop shattering VA albums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- Harmonist now writes the **`compilation`** flag on Various Artists releases.
+  Plex and every iTunes-lineage player read it to decide whether an album is a
+  VA compilation; without it a 20-track compilation is shattered into twenty
+  one-track albums, one per track artist. Set only when MusicBrainz credits the
+  release to Various Artists itself — a greatest-hits album by one artist does
+  **not** get it, because flagging one of those is what makes a player split it
+  apart. An album that stops being a compilation on a re-match has the tag
+  removed (#323).
 - Harmonist now writes **`albumartists`**, the album-level list of artist names
   Picard writes alongside `albumartist`. On a collaboration the joined phrase —
   *zakè & rhubiqs* — leaves a player guessing where one name ends and the next

--- a/docs/design.md
+++ b/docs/design.md
@@ -895,10 +895,16 @@ Everything not in the set is left exactly as found: the comment carrying a recov
 
 `Owned` is split by **scope** — whether a field's value depends on which track it is:
 
-- **Album** — `mb_album_id`, `album`, `album_artist`, `album_artist_sort`, `album_artists`, `mb_album_artist_ids`, `mb_release_group_id`, `mb_album_type`, `mb_album_status`, `mb_album_country`, `date`, `original_date`, `script`, `label`, `catalog_number`, `barcode`, `asin`, `disc_total`.
+- **Album** — `mb_album_id`, `album`, `album_artist`, `album_artist_sort`, `album_artists`, `mb_album_artist_ids`, `mb_release_group_id`, `mb_album_type`, `mb_album_status`, `mb_album_country`, `compilation`, `date`, `original_date`, `script`, `label`, `catalog_number`, `barcode`, `asin`, `disc_total`.
 - **Track** — `title`, `artist`, `artist_sort`, `artists`, `track_num`, `track_total`, `disc_num`, `disc_subtitle`, `media`, `mb_track_id`, `mb_release_track_id`, `mb_artist_ids`, `isrcs`.
 
 `media`, `disc_subtitle`, `disc_num` and `track_total` are derived from the *medium*, so they are track-scoped even though they look album-level: on a 2-disc release, or a CD+DVD set, they genuinely differ between tracks. The scope drives the tagging audit records (#86), which record an album-level change once per album rather than once per track.
+
+**`compilation` is set by an identity check, not a name match** (#323). It is written exactly when the release artist is MusicBrainz's special **Various Artists** artist, `89ad4ac3-39f7-470e-963a-56509c546377` — the same id Harmonist already writes into `mb_album_artist_ids`, so this is a comparison against a value MusicBrainz gives us rather than a guess at the string "Various Artists", which would flag a real band called that and miss a release credited in another language.
+
+It is **not** the release group's `compilation` *secondary type*, and the distinction is the whole point: that type describes the release group's nature, so a greatest-hits album by one artist carries it — and flagging one of those is precisely what makes a player shatter the album into one album per track artist, the failure the tag exists to prevent. Harmonist writes the primary type only (see §5).
+
+Like every optional field it is written only when set, so "not a compilation" is the tag's *absence*; because it is owned, an album that stops being one on a re-match has the tag removed by the same clear that handles every other field, with no code of its own.
 
 The `Owned` member values are exactly the `TagSet` attribute names, and a test asserts the two sets match. That guards drift in both directions: a new `TagSet` field nobody classified would be written but never cleared, and an `Owned` member with no field behind it would clear a tag Harmonist never writes.
 
@@ -906,13 +912,12 @@ The `Owned` member values are exactly the `TagSet` attribute names, and a test a
 
 ### The tags Harmonist does *not* write
 
-`Owned` says what is written; this says what is deliberately left out, which the code cannot. Measured against [Picard's own tag documentation](https://picard-docs.musicbrainz.org/en/latest/variables/tags_basic.html), Harmonist's 31 owned fields land as 32 of the 38 **basic** tags and none of the ~19 **advanced** (relationship-derived) ones.
+`Owned` says what is written; this says what is deliberately left out, which the code cannot. Measured against [Picard's own tag documentation](https://picard-docs.musicbrainz.org/en/latest/variables/tags_basic.html), Harmonist's 32 owned fields land as 33 of the 38 **basic** tags and none of the ~19 **advanced** (relationship-derived) ones.
 
 The table is the standing answer to "why doesn't Harmonist write X" — so it is kept to the *reason*, and never restates the covered set, which would rot the moment `Owned` changed.
 
 | Picard tag(s) | Verdict | Why |
 | --- | --- | --- |
-| `compilation` | Planned (#323) | The Various Artists flag; without it players shatter a VA album per track artist. |
 | `genre` | Deferred (#12) | Read-only today: a genre tagged elsewhere is displayed and never clobbered. Needs the `genres` include and a policy on genre-vs-folksonomy-tag. |
 | `composer`, `composersort`, `lyricist`, `writer`, `arranger`, `conductor`, `performer:*`, `producer`, `engineer`, `mixer`, `djmixer`, `remixer`, `director`, `work`, `musicbrainz_workid`, `musicbrainz_composerid`, `language`, `license`, `website` | Undecided | The entire advanced set is one `RELEASE_INCLUDES` change away, in the same single request — but that tuple **is the `mb_cache` key** (§4), so adding to it invalidates every cached release and re-fetches the library at one rate-limited request per album. `Owned` roughly doubles, landing on the comparison (#106), the audit records (#86) and undo (#157); ID3 needs the `TMCL`/`TIPL` multi-value frames, which no backend writes. Relationships also churn in MusicBrainz far more than release facts, so #32's pass would report updates constantly. Worth splitting: composer/lyricist/work is the classical and soundtrack case; the credits half is a much larger surface for much less benefit. |
 | `comment` | Never | Claimed as **user space**. It carries a recovered Bandcamp URL and is excluded from every backend's owned mapping so a re-tag preserves it. Picard puts the release disambiguation here; Harmonist shows that on the album page instead. |

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -407,6 +407,7 @@ _KINDS: dict[str, Kind] = {
     Owned.MB_ALBUM_TYPE: Kind.SCALAR,
     Owned.MB_ALBUM_STATUS: Kind.SCALAR,
     Owned.MB_ALBUM_COUNTRY: Kind.SCALAR,
+    Owned.COMPILATION: Kind.SCALAR,
     Owned.DATE: Kind.SCALAR,
     Owned.ORIGINAL_DATE: Kind.SCALAR,
     Owned.SCRIPT: Kind.SCALAR,
@@ -532,29 +533,29 @@ _NOT_COMPARED: frozenset[Owned] = frozenset({Owned.MB_ALBUM_ID})
 #: on the machine someone tags from.
 _DISPLAY_ORDER: tuple[Owned, ...] = (
     # Row 1-4: what the release IS, beside who it is BY. `album_artists` sits
-    # directly under the singular phrase it unjoins (#322), and `script` — the
-    # writing system of the title above it — moved up from the paperwork block
-    # to keep the two columns square once the artist side grew to four.
+    # directly under the singular phrase it unjoins (#322), and `compilation`
+    # (#323) under the release facts it belongs with — it is set from the
+    # release artist, so it faces that artist's ids across the row.
     Owned.ALBUM,
     Owned.ALBUM_ARTIST,
     Owned.MB_RELEASE_GROUP_ID,
     Owned.ALBUM_ARTISTS,
     Owned.MB_ALBUM_TYPE,
     Owned.ALBUM_ARTIST_SORT,
-    Owned.SCRIPT,
+    Owned.COMPILATION,
     Owned.MB_ALBUM_ARTIST_IDS,
     # Row 5-6: which edition, and when.
     Owned.MB_ALBUM_STATUS,
     Owned.MB_ALBUM_COUNTRY,
     Owned.DATE,
     Owned.ORIGINAL_DATE,
-    # Row 7-9: the release's paperwork. An odd field count leaves the last row
-    # half-full, which is the right place for the gap.
+    # Row 7-9: the release's paperwork.
     Owned.LABEL,
     Owned.CATALOG_NUMBER,
     Owned.BARCODE,
     Owned.ASIN,
     Owned.DISC_TOTAL,
+    Owned.SCRIPT,
 )
 
 

--- a/src/harmonist/formats/_vorbis.py
+++ b/src/harmonist/formats/_vorbis.py
@@ -21,7 +21,7 @@ from typing import Any
 from mutagen.flac import Picture
 
 from . import quality
-from .owned import Owned
+from .owned import FLAG_TRUE, Owned, as_flag
 from .types import ScanFields, TagSet, TrackTags
 
 # Vorbis comment keys (uppercase by convention; lookups are case-insensitive).
@@ -35,6 +35,8 @@ KEY_ISRC = "ISRC"
 KEY_RELEASE_TYPE = "RELEASETYPE"
 KEY_RELEASE_STATUS = "RELEASESTATUS"
 KEY_RELEASE_COUNTRY = "RELEASECOUNTRY"
+#: Picard's `compilation` — the Various Artists flag (#323), written as "1".
+KEY_COMPILATION = "COMPILATION"
 KEY_TITLE = "TITLE"
 KEY_ALBUM = "ALBUM"
 KEY_ARTIST = "ARTIST"
@@ -79,6 +81,7 @@ OWNED_KEYS: dict[Owned, tuple[str, ...]] = {
     Owned.MB_ALBUM_TYPE: (KEY_RELEASE_TYPE,),
     Owned.MB_ALBUM_STATUS: (KEY_RELEASE_STATUS,),
     Owned.MB_ALBUM_COUNTRY: (KEY_RELEASE_COUNTRY,),
+    Owned.COMPILATION: (KEY_COMPILATION,),
     Owned.DATE: (KEY_DATE,),
     # One field, two keys: Picard writes the year alongside the full date.
     Owned.ORIGINAL_DATE: (KEY_ORIGINAL_DATE, KEY_ORIGINAL_YEAR),
@@ -371,6 +374,7 @@ class VorbisTagger:
             Owned.MB_ALBUM_TYPE: one(KEY_RELEASE_TYPE),
             Owned.MB_ALBUM_STATUS: one(KEY_RELEASE_STATUS),
             Owned.MB_ALBUM_COUNTRY: one(KEY_RELEASE_COUNTRY),
+            Owned.COMPILATION: as_flag(one(KEY_COMPILATION)),
             Owned.DATE: one(KEY_DATE),
             Owned.ORIGINAL_DATE: one(KEY_ORIGINAL_DATE),
             Owned.SCRIPT: one(KEY_SCRIPT),
@@ -436,6 +440,10 @@ class VorbisTagger:
             tags[KEY_RELEASE_STATUS] = [tagset.mb_album_status]
         if tagset.mb_album_country:
             tags[KEY_RELEASE_COUNTRY] = [tagset.mb_album_country]
+        # Written only when true — absence IS "not a compilation", so an album
+        # that stops being one has the key removed by the clear above (#149).
+        if tagset.compilation:
+            tags[KEY_COMPILATION] = [FLAG_TRUE]
 
         if tagset.mb_track_id:
             tags[KEY_TRACK_ID] = [tagset.mb_track_id]
@@ -553,6 +561,11 @@ class VorbisTagger:
         for fld, key in _LIST_KEYS.items():
             if value := values.get(fld):
                 tags[key] = [str(v) for v in value]
+
+        # Not in `_SINGLE_KEYS`: those write `str(value)`, which would put the
+        # word "True" in the file where `_read_owned` expects "1".
+        if values.get(Owned.COMPILATION):
+            tags[KEY_COMPILATION] = [FLAG_TRUE]
 
         # ORIGINALYEAR is derived from the date rather than stored separately —
         # `_read_owned` reads only ORIGINALDATE, so taking the year from

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -14,7 +14,7 @@ from typing import Any
 from mutagen.mp4 import MP4, MP4Cover
 
 from . import quality
-from .owned import Owned
+from .owned import Owned, as_flag
 from .types import ScanFields, TagSet, TrackTags
 
 EXTENSIONS = (".m4a", ".mp4")
@@ -68,6 +68,12 @@ ATOM_COMMENT = "\xa9cmt"
 ATOM_ARTIST_SORT = "soar"
 ATOM_ALBUM_ARTIST_SORT = "soaa"
 
+#: Picard's `compilation` — the Various Artists flag (#323). A NATIVE BOOLEAN
+#: atom, unlike every other owned atom here: mutagen stores `cpil` as a bare
+#: `True`/`False` rather than a list, so it goes through neither the text nor
+#: the freeform tables below.
+ATOM_COMPILATION = "cpil"
+
 # Numeric / binary
 ATOM_TRACK_NUM = "trkn"
 ATOM_DISC_NUM = "disk"
@@ -91,6 +97,7 @@ OWNED_ATOMS: dict[Owned, tuple[str, ...]] = {
     Owned.MB_ALBUM_TYPE: (ATOM_MB_ALBUM_TYPE,),
     Owned.MB_ALBUM_STATUS: (ATOM_MB_ALBUM_STATUS,),
     Owned.MB_ALBUM_COUNTRY: (ATOM_MB_ALBUM_COUNTRY,),
+    Owned.COMPILATION: (ATOM_COMPILATION,),
     Owned.DATE: (ATOM_DATE,),
     Owned.ORIGINAL_DATE: (ATOM_ORIGINAL_DATE, ATOM_ORIGINAL_YEAR),
     Owned.SCRIPT: (ATOM_SCRIPT,),
@@ -337,6 +344,9 @@ def _read_owned(audio: MP4) -> dict[str, Any]:
         Owned.MB_ALBUM_TYPE: _binary_atom_str(audio, ATOM_MB_ALBUM_TYPE),
         Owned.MB_ALBUM_STATUS: _binary_atom_str(audio, ATOM_MB_ALBUM_STATUS),
         Owned.MB_ALBUM_COUNTRY: _binary_atom_str(audio, ATOM_MB_ALBUM_COUNTRY),
+        # `audio.get` returns the bare bool for `cpil`, not a list — see the
+        # atom's definition above.
+        Owned.COMPILATION: as_flag(audio.get(ATOM_COMPILATION)),
         Owned.DATE: _text_atom(audio, ATOM_DATE),
         Owned.ORIGINAL_DATE: _binary_atom_str(audio, ATOM_ORIGINAL_DATE),
         Owned.SCRIPT: _binary_atom_str(audio, ATOM_SCRIPT),
@@ -418,6 +428,11 @@ def _apply_owned(audio: MP4, values: Mapping[str, Any]) -> None:
     for fld, atom in _BINARY_LIST_ATOMS.items():
         if value := values.get(fld):
             audio[atom] = [str(v).encode("utf-8") for v in value]
+
+    # A native boolean atom, so it belongs to none of the three tables above —
+    # writing it through them would put the string "True" in the file.
+    if values.get(Owned.COMPILATION):
+        audio[ATOM_COMPILATION] = True
 
     # ORIGINALYEAR is derived rather than stored: `_read_owned` reads only
     # ORIGINALDATE, so writing the year from anywhere else could disagree with
@@ -527,6 +542,10 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> dict[str, Any
         audio[ATOM_MB_ALBUM_STATUS] = [tagset.mb_album_status.encode("utf-8")]
     if tagset.mb_album_country:
         audio[ATOM_MB_ALBUM_COUNTRY] = [tagset.mb_album_country.encode("utf-8")]
+    # Written only when true — absence IS "not a compilation", so an album that
+    # stops being one has the atom removed by the clear above (#149).
+    if tagset.compilation:
+        audio[ATOM_COMPILATION] = True
 
     # ---- Per-track MBID atoms ----
     if tagset.mb_track_id:

--- a/src/harmonist/formats/mp3.py
+++ b/src/harmonist/formats/mp3.py
@@ -23,6 +23,7 @@ from mutagen.id3 import (
     APIC,
     ID3,
     TALB,
+    TCMP,
     TDOR,
     TDRC,
     TIT2,
@@ -44,7 +45,7 @@ from mutagen.id3 import (
 from mutagen.mp3 import MP3
 
 from . import quality
-from .owned import Owned
+from .owned import FLAG_TRUE, Owned, as_flag
 from .types import ScanFields, TagSet, TrackTags
 
 EXTENSIONS = (".mp3",)
@@ -88,6 +89,9 @@ OWNED_FRAMES: dict[Owned, tuple[str, ...]] = {
     Owned.MB_ALBUM_TYPE: (f"TXXX:{TXXX_ALBUM_TYPE}",),
     Owned.MB_ALBUM_STATUS: (f"TXXX:{TXXX_ALBUM_STATUS}",),
     Owned.MB_ALBUM_COUNTRY: (f"TXXX:{TXXX_ALBUM_COUNTRY}",),
+    # iTunes' non-standard frame, and the one every iTunes-lineage player reads
+    # for the Various Artists flag (#323). mutagen has it.
+    Owned.COMPILATION: ("TCMP",),
     Owned.DATE: ("TDRC",),
     Owned.ORIGINAL_DATE: ("TDOR",),
     Owned.SCRIPT: (f"TXXX:{TXXX_SCRIPT}",),
@@ -350,6 +354,7 @@ def _read_owned(tags: Any) -> dict[str, Any]:
         Owned.MB_ALBUM_TYPE: _txxx(tags, TXXX_ALBUM_TYPE),
         Owned.MB_ALBUM_STATUS: _txxx(tags, TXXX_ALBUM_STATUS),
         Owned.MB_ALBUM_COUNTRY: _txxx(tags, TXXX_ALBUM_COUNTRY),
+        Owned.COMPILATION: as_flag(_text(tags, "TCMP")),
         Owned.DATE: _text(tags, "TDRC"),
         Owned.ORIGINAL_DATE: _text(tags, "TDOR"),
         Owned.SCRIPT: _txxx(tags, TXXX_SCRIPT),
@@ -451,6 +456,11 @@ def _apply_owned(tags: ID3, values: Mapping[str, Any]) -> None:
     for fld, desc in _TXXX_LIST_FIELDS.items():
         if value := values.get(fld):
             _set_txxx(tags, desc, [str(v) for v in value])
+
+    # Not in `_TEXT_FRAMES`: those write `str(value)`, which would put the word
+    # "True" in the frame where `_read_owned` expects "1".
+    if values.get(Owned.COMPILATION):
+        tags.setall("TCMP", [TCMP(encoding=Encoding.UTF8, text=[FLAG_TRUE])])
 
     if track_id := values.get(Owned.MB_TRACK_ID):
         tags.add(UFID(owner=UFID_OWNER, data=str(track_id).encode("ascii")))
@@ -560,6 +570,10 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> dict[str, Any
         _set_txxx(tags, TXXX_ALBUM_STATUS, [tagset.mb_album_status])
     if tagset.mb_album_country:
         _set_txxx(tags, TXXX_ALBUM_COUNTRY, [tagset.mb_album_country])
+    # Written only when true — absence IS "not a compilation", so an album that
+    # stops being one has the frame removed by the clear above (#149).
+    if tagset.compilation:
+        tags.setall("TCMP", [TCMP(encoding=Encoding.UTF8, text=[FLAG_TRUE])])
 
     # ---- Per-track MB IDs ----
     if tagset.mb_track_id:

--- a/src/harmonist/formats/owned.py
+++ b/src/harmonist/formats/owned.py
@@ -76,6 +76,7 @@ class Owned(StrEnum):
     MB_ALBUM_TYPE = "mb_album_type"
     MB_ALBUM_STATUS = "mb_album_status"
     MB_ALBUM_COUNTRY = "mb_album_country"
+    COMPILATION = "compilation"
     DATE = "date"
     ORIGINAL_DATE = "original_date"
     SCRIPT = "script"
@@ -115,6 +116,9 @@ SCOPE: dict[Owned, Scope] = {
     Owned.MB_ALBUM_TYPE: Scope.ALBUM,
     Owned.MB_ALBUM_STATUS: Scope.ALBUM,
     Owned.MB_ALBUM_COUNTRY: Scope.ALBUM,
+    # A property of the RELEASE artist — whether it is MusicBrainz's Various
+    # Artists — so it cannot vary between tracks, however varied their credits.
+    Owned.COMPILATION: Scope.ALBUM,
     Owned.DATE: Scope.ALBUM,
     Owned.ORIGINAL_DATE: Scope.ALBUM,
     Owned.SCRIPT: Scope.ALBUM,
@@ -238,6 +242,12 @@ SIGNIFICANCE: dict[str, Significance] = {
     # an unchanged release payload carries no such evidence. It is a merge, a
     # re-point, or a MusicBrainz edit that replaced the track, and nothing here
     # can tell those apart.
+    # A restatement of who the release artist is: the flag is set exactly when
+    # that artist is MusicBrainz's Various Artists, so it moves only when
+    # `album_artist` does, and it is Identity for the same reason. Its
+    # consequence argues the same way — a player reads it to decide whether the
+    # album is one album at all.
+    Owned.COMPILATION: Significance.IDENTITY,
     Owned.MB_ALBUM_ID: Significance.IDENTITY,
     Owned.MB_RELEASE_GROUP_ID: Significance.IDENTITY,
     Owned.MB_ALBUM_ARTIST_IDS: Significance.IDENTITY,
@@ -313,6 +323,37 @@ def _absent(value: object) -> bool:
     return value is None or value == "" or value == []
 
 
+#: How a set boolean tag is spelled in the text formats — ID3's `TCMP` and the
+#: Vorbis `COMPILATION` comment both carry `"1"`, which is what Picard writes and
+#: what `as_flag` reads back. MP4's `cpil` is a native boolean atom and needs
+#: none of this. Named so the writer and the reader cannot drift on the spelling.
+FLAG_TRUE = "1"
+
+
+def as_flag(raw: object) -> bool | None:
+    """A boolean tag as `True`, or None when it isn't set (#323).
+
+    The three backends spell the same flag three ways — `"1"` in a Vorbis
+    comment, `"1"` in ID3's `TCMP`, a native `cpil` bool in MP4 — and all three
+    have to hand `_read_owned` a value shaped exactly like the `TagSet`
+    attribute, or the field reports a phantom change on every re-tag. One
+    reading, shared, is what keeps them from each inventing their own.
+
+    **Never `False`.** Harmonist writes the flag only when true, so "not a
+    compilation" is the tag's ABSENCE — and `_absent` below already collapses
+    `None`, `""` and `[]` into one answer. Returning `False` would add a fourth
+    spelling of nothing that `values_differ` treats as a value, so an ordinary
+    album would differ from MusicBrainz on this field forever. A file carrying
+    an explicit `COMPILATION=0` therefore reads as absent, which is what a write
+    would leave it as anyway.
+    """
+    if isinstance(raw, bool):
+        return raw or None
+    if isinstance(raw, (list, tuple)):
+        raw = raw[0] if raw else None
+    return True if str(raw).strip().lower() in {"1", "true", "yes"} else None
+
+
 def values_differ(a: object, b: object) -> bool:
     """Whether two values of one owned field are meaningfully different.
 
@@ -367,6 +408,7 @@ LABELS: dict[str, str] = {
     Owned.MB_ALBUM_TYPE: "Release type",
     Owned.MB_ALBUM_STATUS: "Release status",
     Owned.MB_ALBUM_COUNTRY: "Country",
+    Owned.COMPILATION: "Compilation",
     Owned.DATE: "Date",
     Owned.ORIGINAL_DATE: "Original date",
     Owned.SCRIPT: "Script",

--- a/src/harmonist/formats/types.py
+++ b/src/harmonist/formats/types.py
@@ -120,6 +120,18 @@ class TagSet:
     mb_album_status: str | None = None
     mb_album_country: str | None = None
 
+    # Picard's `compilation` — the Various Artists flag (#323). Plex and every
+    # iTunes-lineage player read it to decide whether the album is a VA
+    # compilation; without it a 20-track compilation is shattered into twenty
+    # one-track albums, one per track artist.
+    #
+    # `True` or absent, never `False`: Harmonist writes it only when set, so
+    # "not a compilation" is the tag's absence — see `owned.as_flag`. NOT the
+    # release group's `compilation` secondary type, which a greatest-hits album
+    # by one artist also carries, and flagging one of those is precisely what
+    # makes a player split it apart.
+    compilation: bool | None = None
+
     mb_track_id: str | None = None
     mb_release_track_id: str | None = None
     mb_artist_ids: list[str] = field(default_factory=list)

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -1012,6 +1012,7 @@ def _build_tagset(
         mb_album_type=(rg.get("primary-type") or "").lower() or None,
         mb_album_status=(release.get("status") or "").lower() or None,
         mb_album_country=release.get("country"),
+        compilation=_compilation_flag(release.get("artist-credit")),
         mb_track_id=(track.get("recording") or {}).get("id"),
         mb_release_track_id=track.get("id"),
         mb_artist_ids=_artist_ids(track_artist_credit),
@@ -1295,6 +1296,33 @@ def artist_credits(release: Release) -> dict[str, tuple[CreditPart, ...]]:
         else:
             found.setdefault(phrase, parts)
     return {phrase: parts for phrase, parts in found.items() if parts}
+
+
+#: MusicBrainz's special **Various Artists** artist. A real MBID like any other,
+#: and the whole of the compilation rule (#323).
+#:
+#: The test is an id comparison because the id is what MusicBrainz gives us:
+#: Harmonist already writes this exact string into `mb_album_artist_ids`, so
+#: matching on the *string* "Various Artists" would be guessing at an identity
+#: that is available exactly — the thing review-gate item 2 forbids. It would
+#: also be wrong in both directions: a real band could be called that, and a
+#: release credited to VA in another language would be missed.
+VARIOUS_ARTISTS_ID = "89ad4ac3-39f7-470e-963a-56509c546377"
+
+
+def _compilation_flag(artist_credit: list[Any] | None) -> bool | None:
+    """True when this release is credited to Various Artists, else None (#323).
+
+    None rather than False because the tag is written only when set — see
+    `owned.as_flag`, and `formats.types.TagSet.compilation`.
+
+    Deliberately NOT the release group's `compilation` secondary type. That
+    describes the release group's nature, so a greatest-hits album by one artist
+    carries it — and flagging one of those is precisely what makes a player
+    shatter it into one album per track artist, the failure this tag exists to
+    prevent. Harmonist writes the primary type only (design §5).
+    """
+    return True if VARIOUS_ARTISTS_ID in _artist_ids(artist_credit) else None
 
 
 def _artist_ids(artist_credit: list[Any] | None) -> list[str]:

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -1325,10 +1325,10 @@ def test_the_panel_pairs_release_fields_against_artist_fields():
     ADJACENCY: it lives in the pairs, and sampling two of them cannot see a
     third that has drifted into the wrong column.
 
-    `Album artists` (#322) made the artist column four long, so `Script` moved up
-    from the paperwork block to square the two — and left an odd number of album
-    fields, which is why `Genre` now pairs with `Disc total` and `Comment` ends
-    the grid alone.
+    `Album artists` and `Compilation` (#322, #323) both landed in the release/
+    artist blocks, which makes the album fields an even eighteen again — so
+    `Script` keeps its old place beside `Disc total` and `Genre` and `Comment`
+    stay paired at the end.
     """
     fields = album_fields([("1.flac", TrackTags(album="Obreel"))], _tagset(album="Obreel"))
 
@@ -1336,13 +1336,13 @@ def test_the_panel_pairs_release_fields_against_artist_fields():
         "Album",           "Album artist",
         "Release group",   "Album artists",
         "Release type",    "Album artist sort",
-        "Script",          "Album artist IDs",
+        "Compilation",     "Album artist IDs",
         "Release status",  "Country",
         "Date",            "Original date",
         "Label",           "Cat. no.",
         "Barcode",         "ASIN",
-        "Disc total",      "Genre",
-        "Comment",
+        "Disc total",      "Script",
+        "Genre",           "Comment",
     ]  # fmt: skip
 
 

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -916,6 +916,59 @@ def test_write_with_no_cover_preserves_embedded_art(tmp_path, ext, fixture):
 
 
 @pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
+def test_the_compilation_flag_is_written_as_a_flag_and_removed_when_it_goes(tmp_path, ext, fixture):
+    """#323, both halves, in the order a re-match performs them.
+
+    Two assertions, and the RAW one is the load-bearing half. `owned.as_flag`
+    reads `"true"` as set — deliberately, for files another tagger wrote — so a
+    round trip through `read_owned` alone goes green with `str(True)` in the
+    file, where an iTunes-lineage player reads TCMP="True" as unset. The value
+    on disk has to be the one those players read: `"1"` in ID3 and the Vorbis
+    comment, a native boolean in MP4's `cpil`.
+
+    The `read_owned` assertion earns its place beside it for the opposite
+    reason: that is the shape the comparison and the undo consume, and a flag
+    written correctly but read back as `"1"` would report a change on every
+    re-tag forever.
+
+    The removal is what makes "written only when true" safe: an album that stops
+    being a VA compilation must lose the tag, and being owned is what does it
+    with no code of its own (#149).
+    """
+    from harmonist.formats.owned import Owned
+
+    path = _copy_fixture(tmp_path, fixture)
+
+    formats.write_tags(path, _tagset(compilation=True), None)
+    assert _read_raw_compilation(path) is True
+    assert formats.read_owned(path)[Owned.COMPILATION] is True
+
+    formats.write_tags(path, _tagset(), None)  # re-matched to a single-artist release
+    assert _read_raw_compilation(path) is None
+    assert formats.read_owned(path)[Owned.COMPILATION] is None
+
+
+def _read_raw_compilation(path: Path) -> bool | None:
+    """The compilation flag exactly as it sits in the file, through the native
+    tag layer — True only for the value that format's players read as set."""
+    ext = path.suffix.lower()
+    if ext in (".m4a", ".mp4"):
+        from mutagen.mp4 import MP4
+
+        raw = MP4(path).get("cpil")
+        return True if raw is True else None
+    if ext == ".mp3":
+        from mutagen.mp3 import MP3
+
+        frame = MP3(path).tags.get("TCMP")
+        return True if frame is not None and list(frame.text) == ["1"] else None
+    from mutagen import File as MutagenFile
+
+    values = MutagenFile(path).tags.get("COMPILATION")
+    return True if list(values or []) == ["1"] else None
+
+
+@pytest.mark.parametrize(("ext", "fixture"), FIXTURES)
 def test_media_round_trips(tmp_path, ext, fixture):
     """Regression for #149: MP3 wrote `media` to TMED and read it back from
     TXXX:MEDIA, so every MP3 Harmonist tagged reported Media missing on the
@@ -949,6 +1002,7 @@ def _full_tagset() -> Any:
         mb_album_type="Album",
         mb_album_status="official",
         mb_album_country="GB",
+        compilation=True,
         mb_track_id="rec-1",
         mb_release_track_id="rt-1",
         mb_artist_ids=["ar-1"],

--- a/test/test_picard_spec.py
+++ b/test/test_picard_spec.py
@@ -280,6 +280,36 @@ def test_sort_artists_original_date_script_atoms(tmp_path):
     assert _atom_strs(t2, ATOM_ALBUM_ARTISTS) == ["Reference Artist"]
 
 
+def test_the_compilation_atom_is_a_native_boolean(tmp_path):
+    """#323. `cpil` is MP4's own boolean atom, not a freeform `----:` one, so it
+    is the single owned field that goes through none of this backend's three
+    value tables — written through them it would land as the string "True",
+    which every iTunes-lineage player reads as unset.
+
+    Its own test rather than an entry in the inventory below, because the
+    inventory's release is single-artist: `cpil` is correctly absent there, so
+    that test cannot see this atom at all. Naming that is the point — it is the
+    exact shape of the DISCSUBTITLE gap, where a fixture that didn't exercise a
+    field certified for months that the field wasn't written.
+    """
+    release = _fully_populated_release()
+    release["artist-credit"] = [
+        {
+            "artist": {
+                "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                "name": "Various Artists",
+                "sort-name": "Various Artists",
+            },
+            "name": "Various Artists",
+        },
+    ]
+    album_dir = _setup_album(tmp_path, 2)
+    PicardCompatibleTagger().tag_album(album_dir, release)
+
+    for name in ("01 Track 1.m4a", "02 Track 2.m4a"):
+        assert MP4(album_dir / name)["cpil"] is True
+
+
 # ---------- exhaustive atom inventory ----------
 #
 # Picard atoms Harmonist does not write yet, as of this list: LANGUAGE, WORK,
@@ -291,6 +321,11 @@ def test_sort_artists_original_date_script_atoms(tmp_path):
 # DISCSUBTITLE was on the list while the tagger had been writing it for months
 # (test_disc_subtitle.py); the assertion passed because the fixture release gave
 # its medium no title, so the gap was true of the fixture and false of the code.
+#
+# `cpil` is deliberately NOT in the set below and is not a gap either: the
+# release here is single-artist, so the compilation flag is correctly unwritten
+# (#323, covered above). Leaving it out keeps this test's "extra" half live — a
+# change that started writing the flag unconditionally would fail here.
 
 EXPECTED_PICARD_ATOMS_WE_WRITE = {
     # Album-level MBIDs

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -532,6 +532,79 @@ def test_a_collaboration_names_both_album_artists_on_every_track():
     assert tagsets[1].artists == ["Featured Artist", "Other"]
 
 
+def _various_artists_release() -> dict:
+    """`_release_2_tracks` credited to MusicBrainz's Various Artists, with each
+    track credited to its own artist — the shape of a real compilation."""
+    release = _release_2_tracks()
+    release["artist-credit"] = [
+        {
+            "artist": {
+                "id": tagger.VARIOUS_ARTISTS_ID,
+                "name": "Various Artists",
+                "sort-name": "Various Artists",
+            },
+            "name": "Various Artists",
+        },
+    ]
+    tracks = release["medium-list"][0]["track-list"]
+    tracks[0]["artist-credit"] = [
+        {"artist": {"id": "art-ccc", "name": "Kangding Ray", "sort-name": "Kangding Ray"}},
+    ]
+    return release
+
+
+def test_a_various_artists_release_carries_the_compilation_flag():
+    """#323. Without it Plex and every iTunes-lineage player shatter a VA
+    compilation into one album per track artist.
+
+    Album-scoped, so the flag is on EVERY track however the tracks are credited
+    — which is the whole point: a player groups by what the files agree on.
+    """
+    tagsets = tagger.tagsets_for(_various_artists_release())
+
+    assert [t.compilation for t in tagsets] == [True, True]
+
+
+def test_an_ordinary_release_carries_no_compilation_flag():
+    """Absent, not False. Harmonist writes the tag only when set, so an album
+    that stops being a compilation has it removed by the owned-set clear (#149)
+    with no extra code — and `owned.as_flag` never produces a False that would
+    read as a value and differ from MusicBrainz forever."""
+    assert [t.compilation for t in tagger.tagsets_for(_release_2_tracks())] == [None, None]
+
+
+def test_a_greatest_hits_release_by_one_artist_is_not_a_compilation():
+    """The wrong turn this rule is most likely to take.
+
+    MusicBrainz's release-group `compilation` SECONDARY TYPE describes the
+    release group's nature, so a one-artist greatest-hits album carries it — and
+    flagging one of those is precisely what makes a player split the album apart.
+    The flag is about the release ARTIST, and nothing else.
+    """
+    release = _release_2_tracks()
+    release["release-group"]["secondary-type-list"] = ["Compilation"]
+
+    assert tagger.tagsets_for(release)[0].compilation is None
+
+
+def test_a_band_merely_named_various_artists_is_not_flagged():
+    """The identity is an id comparison, never a name match (review-gate item 2).
+
+    Matching the string would guess at an identity MusicBrainz gives exactly —
+    and would be wrong in both directions: it flags a real act with that name,
+    and it misses a release credited to Various Artists in another language.
+    """
+    release = _release_2_tracks()
+    release["artist-credit"] = [
+        {
+            "artist": {"id": "art-imposter", "name": "Various Artists", "sort-name": "V"},
+            "name": "Various Artists",
+        },
+    ]
+
+    assert tagger.tagsets_for(release)[0].compilation is None
+
+
 def test_tag_album_track_artist_credit_overrides_release(album_with_tracks):
     """Track 2 has its own artist-credit; should be used for ©ART and Artist Id atom."""
     album_dir = album_with_tracks(2)


### PR DESCRIPTION
Plex and every iTunes-lineage player read `compilation` to decide whether an album is a Various Artists compilation. Without it a 20-track VA compilation is shattered into twenty one-track albums, one per track artist — a library-level disfigurement caused by a missing boolean.

## The rule is an identity check

The flag is set exactly when the release artist is MusicBrainz's special **Various Artists** artist, `89ad4ac3-39f7-470e-963a-56509c546377` — an MBID Harmonist already writes into `mb_album_artist_ids`, so this is a comparison against a value MusicBrainz gives us rather than a guess at the string "Various Artists". Matching the string would be wrong in both directions: it flags a real act called that, and it misses a release credited in another language.

Deliberately **not** the release group's `compilation` *secondary type*. That describes the release group's nature, so a greatest-hits album by one artist carries it — and flagging one of those is precisely what makes a player split the album apart. Both wrong turns have a test that fails if taken.

## Shape on disk

`TCMP` (ID3), `COMPILATION` (Vorbis), `cpil` (MP4). `cpil` is a **native boolean atom**, the one owned field that goes through none of the M4A backend's three value tables — written through them it would land as the string `"True"`, which every player reads as unset.

Written only when true, so absence *is* "not a compilation". That is what makes the removal free: an album that stops being a VA compilation on a re-match loses the tag through the owned-set clear (#149), with no code of its own. `owned.as_flag` gives the three backends one reading of the three spellings and **never returns `False`**, so an ordinary album doesn't differ from MusicBrainz on this field forever.

## Tests, and one that nearly didn't count

The first version of the format test asserted only through `read_owned`, and the mutation check **passed**: `as_flag` accepts `"true"`, so writing `str(True)` round-tripped cleanly while leaving a value no player reads. It now asserts the raw on-disk value per format as well, and MP3/FLAC/Opus go red under that mutation.

`.m4a` is immune to that particular one — mutagen coerces `cpil` to a real bool — so it was mutated the way it could actually break, writing a freeform `----:com.apple.iTunes:COMPILATION` atom instead. Three tests go red.

The MP4 inventory test cannot see `cpil` at all, because its fixture release is single-artist and the flag is correctly absent there. That is the exact shape of the `DISCSUBTITLE` gap, so it gets a VA fixture of its own and a comment saying why the atom is not in the expected set.

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2PKanbm1rsX7Zx8mnNUj7