### PR TITLE
Write the secondary release types, and stop deleting Picard's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,16 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **A re-tag no longer deletes MusicBrainz secondary release types.** Harmonist
+  wrote only the primary type, so nothing on disk recorded that an album was
+  live, a remix or a soundtrack — and on a Picard-tagged library it was worse
+  than incomplete: the reader took only the first value, so a live album
+  compared as matching and then lost *live* on the next re-tag, with the album
+  page reporting agreement the whole time. The release type is now written the
+  way Picard writes it, as one multi-value tag holding the primary type and the
+  secondary ones. **Navidrome reads this tag and has no other source for it**, so
+  this is what makes its album *Type* filter work. Albums tagged by an earlier
+  version will report an update available until re-tagged (#331).
 - **Disc headings were rendering at the size and colour of the column headings
   beneath them.** The rule that sizes them lost the cascade to a more specific
   one, so none of it ever applied and a disc heading was indistinguishable from

--- a/docs/design.md
+++ b/docs/design.md
@@ -815,7 +815,13 @@ Per-album (same on every track):
 - `----:com.apple.iTunes:MusicBrainz Album Artist Id` — release-artist MBID(s)
 - `----:com.apple.iTunes:MusicBrainz Release Group Id`
 - `----:com.apple.iTunes:MusicBrainz Album Type` — **lower-cased** (`album`, not
-  `Album`), matching Picard. Primary type only; secondary types are not written.
+  `Album`), matching Picard, and **multi-valued**: the primary type followed by
+  the release group's secondary types (`album`, `live`), in that order. One tag
+  holding both, exactly as Picard builds it — `releasetype = primary +
+  secondary` in its `mbjson.py`. The secondary types are what say an album is
+  live, a remix or a soundtrack, and Navidrome reads this tag and has no other
+  source for it (#331). They cost no extra request: `secondary-type-list` rides
+  along with the `release-groups` include §4 already asks for.
 - `----:com.apple.iTunes:MusicBrainz Album Status` — **lower-cased** (`official`),
   matching Picard.
 - `----:com.apple.iTunes:MusicBrainz Album Release Country`

--- a/src/harmonist/formats/_vorbis.py
+++ b/src/harmonist/formats/_vorbis.py
@@ -120,7 +120,6 @@ _SINGLE_KEYS: dict[Owned, str] = {
     Owned.ALBUM_ARTIST: KEY_ALBUM_ARTIST,
     Owned.ALBUM_ARTIST_SORT: KEY_ALBUM_ARTIST_SORT,
     Owned.MB_RELEASE_GROUP_ID: KEY_RELEASE_GROUP_ID,
-    Owned.MB_ALBUM_TYPE: KEY_RELEASE_TYPE,
     Owned.MB_ALBUM_STATUS: KEY_RELEASE_STATUS,
     Owned.MB_ALBUM_COUNTRY: KEY_RELEASE_COUNTRY,
     Owned.DATE: KEY_DATE,
@@ -145,6 +144,8 @@ _SINGLE_KEYS: dict[Owned, str] = {
 
 #: Owned fields carried as several values under one key.
 _LIST_KEYS: dict[Owned, str] = {
+    # Multi-value since #331: the primary type plus the secondaries.
+    Owned.MB_ALBUM_TYPE: KEY_RELEASE_TYPE,
     Owned.ALBUM_ARTISTS: KEY_ALBUM_ARTISTS,
     Owned.MB_ALBUM_ARTIST_IDS: KEY_ALBUM_ARTIST_ID,
     Owned.ARTISTS: KEY_ARTISTS,
@@ -371,7 +372,9 @@ class VorbisTagger:
             Owned.ALBUM_ARTISTS: many(KEY_ALBUM_ARTISTS),
             Owned.MB_ALBUM_ARTIST_IDS: many(KEY_ALBUM_ARTIST_ID),
             Owned.MB_RELEASE_GROUP_ID: one(KEY_RELEASE_GROUP_ID),
-            Owned.MB_ALBUM_TYPE: one(KEY_RELEASE_TYPE),
+            # Multi-value since #331 — see the m4a backend for what the
+            # scalar reader cost on a Picard-tagged live album.
+            Owned.MB_ALBUM_TYPE: many(KEY_RELEASE_TYPE),
             Owned.MB_ALBUM_STATUS: one(KEY_RELEASE_STATUS),
             Owned.MB_ALBUM_COUNTRY: one(KEY_RELEASE_COUNTRY),
             Owned.COMPILATION: as_flag(one(KEY_COMPILATION)),
@@ -435,7 +438,7 @@ class VorbisTagger:
         if tagset.mb_release_group_id:
             tags[KEY_RELEASE_GROUP_ID] = [tagset.mb_release_group_id]
         if tagset.mb_album_type:
-            tags[KEY_RELEASE_TYPE] = [tagset.mb_album_type]
+            tags[KEY_RELEASE_TYPE] = list(tagset.mb_album_type)
         if tagset.mb_album_status:
             tags[KEY_RELEASE_STATUS] = [tagset.mb_album_status]
         if tagset.mb_album_country:

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -341,7 +341,11 @@ def _read_owned(audio: MP4) -> dict[str, Any]:
         Owned.ALBUM_ARTISTS: _binary_atom_list(audio, ATOM_ALBUM_ARTISTS),
         Owned.MB_ALBUM_ARTIST_IDS: _binary_atom_list(audio, ATOM_MB_ALBUM_ARTIST_ID),
         Owned.MB_RELEASE_GROUP_ID: _binary_atom_str(audio, ATOM_MB_RELEASE_GROUP_ID),
-        Owned.MB_ALBUM_TYPE: _binary_atom_str(audio, ATOM_MB_ALBUM_TYPE),
+        # Multi-value: primary type then the secondaries (#331). Through the
+        # LIST reader, or a Picard-tagged live album reads back as plain
+        # "album" — equal to what Harmonist would write, so the difference
+        # never surfaced and the next re-tag wrote the truncation back.
+        Owned.MB_ALBUM_TYPE: _binary_atom_list(audio, ATOM_MB_ALBUM_TYPE),
         Owned.MB_ALBUM_STATUS: _binary_atom_str(audio, ATOM_MB_ALBUM_STATUS),
         Owned.MB_ALBUM_COUNTRY: _binary_atom_str(audio, ATOM_MB_ALBUM_COUNTRY),
         # `audio.get` returns the bare bool for `cpil`, not a list — see the
@@ -472,7 +476,6 @@ _TEXT_ATOMS: dict[Owned, str] = {
 _BINARY_ATOMS: dict[Owned, str] = {
     Owned.MB_ALBUM_ID: ATOM_MB_ALBUM_ID,
     Owned.MB_RELEASE_GROUP_ID: ATOM_MB_RELEASE_GROUP_ID,
-    Owned.MB_ALBUM_TYPE: ATOM_MB_ALBUM_TYPE,
     Owned.MB_ALBUM_STATUS: ATOM_MB_ALBUM_STATUS,
     Owned.MB_ALBUM_COUNTRY: ATOM_MB_ALBUM_COUNTRY,
     Owned.ORIGINAL_DATE: ATOM_ORIGINAL_DATE,
@@ -489,6 +492,8 @@ _BINARY_ATOMS: dict[Owned, str] = {
 
 #: Owned fields stored as multi-valued freeform atoms.
 _BINARY_LIST_ATOMS: dict[Owned, str] = {
+    # Multi-value since #331: the primary type plus the secondaries.
+    Owned.MB_ALBUM_TYPE: ATOM_MB_ALBUM_TYPE,
     Owned.ALBUM_ARTISTS: ATOM_ALBUM_ARTISTS,
     Owned.MB_ALBUM_ARTIST_IDS: ATOM_MB_ALBUM_ARTIST_ID,
     Owned.ARTISTS: ATOM_ARTISTS,
@@ -537,7 +542,7 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> dict[str, Any
     if tagset.mb_release_group_id:
         audio[ATOM_MB_RELEASE_GROUP_ID] = [tagset.mb_release_group_id.encode("utf-8")]
     if tagset.mb_album_type:
-        audio[ATOM_MB_ALBUM_TYPE] = [tagset.mb_album_type.encode("utf-8")]
+        audio[ATOM_MB_ALBUM_TYPE] = [t.encode("utf-8") for t in tagset.mb_album_type]
     if tagset.mb_album_status:
         audio[ATOM_MB_ALBUM_STATUS] = [tagset.mb_album_status.encode("utf-8")]
     if tagset.mb_album_country:

--- a/src/harmonist/formats/mp3.py
+++ b/src/harmonist/formats/mp3.py
@@ -351,7 +351,9 @@ def _read_owned(tags: Any) -> dict[str, Any]:
         Owned.ALBUM_ARTISTS: _txxx_list(tags, TXXX_ALBUM_ARTISTS),
         Owned.MB_ALBUM_ARTIST_IDS: _txxx_list(tags, TXXX_ALBUM_ARTIST_ID),
         Owned.MB_RELEASE_GROUP_ID: _txxx(tags, TXXX_RELEASE_GROUP_ID),
-        Owned.MB_ALBUM_TYPE: _txxx(tags, TXXX_ALBUM_TYPE),
+        # Multi-value since #331 — see the m4a backend for what the scalar
+        # reader cost. ID3 carries the several values in one TXXX frame.
+        Owned.MB_ALBUM_TYPE: _txxx_list(tags, TXXX_ALBUM_TYPE),
         Owned.MB_ALBUM_STATUS: _txxx(tags, TXXX_ALBUM_STATUS),
         Owned.MB_ALBUM_COUNTRY: _txxx(tags, TXXX_ALBUM_COUNTRY),
         Owned.COMPILATION: as_flag(_text(tags, "TCMP")),
@@ -505,7 +507,6 @@ _TEXT_FRAMES: dict[Owned, Any] = {
 _TXXX_FIELDS: dict[Owned, str] = {
     Owned.MB_ALBUM_ID: TXXX_ALBUM_ID,
     Owned.MB_RELEASE_GROUP_ID: TXXX_RELEASE_GROUP_ID,
-    Owned.MB_ALBUM_TYPE: TXXX_ALBUM_TYPE,
     Owned.MB_ALBUM_STATUS: TXXX_ALBUM_STATUS,
     Owned.MB_ALBUM_COUNTRY: TXXX_ALBUM_COUNTRY,
     Owned.SCRIPT: TXXX_SCRIPT,
@@ -517,6 +518,8 @@ _TXXX_FIELDS: dict[Owned, str] = {
 
 #: Owned fields carried as several strings in one TXXX frame.
 _TXXX_LIST_FIELDS: dict[Owned, str] = {
+    # Multi-value since #331: the primary type plus the secondaries.
+    Owned.MB_ALBUM_TYPE: TXXX_ALBUM_TYPE,
     Owned.ALBUM_ARTISTS: TXXX_ALBUM_ARTISTS,
     Owned.MB_ALBUM_ARTIST_IDS: TXXX_ALBUM_ARTIST_ID,
     Owned.ARTISTS: TXXX_ARTISTS,
@@ -565,7 +568,7 @@ def write_tags(path: Path, tagset: TagSet, cover: bytes | None) -> dict[str, Any
     if tagset.mb_release_group_id:
         _set_txxx(tags, TXXX_RELEASE_GROUP_ID, [tagset.mb_release_group_id])
     if tagset.mb_album_type:
-        _set_txxx(tags, TXXX_ALBUM_TYPE, [tagset.mb_album_type])
+        _set_txxx(tags, TXXX_ALBUM_TYPE, list(tagset.mb_album_type))
     if tagset.mb_album_status:
         _set_txxx(tags, TXXX_ALBUM_STATUS, [tagset.mb_album_status])
     if tagset.mb_album_country:

--- a/src/harmonist/formats/types.py
+++ b/src/harmonist/formats/types.py
@@ -116,7 +116,25 @@ class TagSet:
 
     mb_album_artist_ids: list[str] = field(default_factory=list)
     mb_release_group_id: str | None = None
-    mb_album_type: str | None = None
+    #: Primary type first, then MusicBrainz's secondary types, all lower-cased
+    #: (#331). ONE multi-value tag, exactly as Picard builds it in
+    #: `mbjson.py`: `releasetype = primary + secondary`.
+    #:
+    #: A list rather than a scalar because the secondary types are what say an
+    #: album is live, a remix or a soundtrack — and Navidrome reads this tag and
+    #: has no other source for that. Written as a scalar it was worse than
+    #: incomplete: the readers took the first value, so a Picard-tagged live
+    #: album compared equal to Harmonist's "album" and then lost "live" on the
+    #: next re-tag, with the page reporting agreement throughout.
+    #:
+    #: SINGULAR still, though it holds several. The name is `Owned.MB_ALBUM_TYPE`'s
+    #: value, and that string is persisted: `activity_store` keeps each tagging's
+    #: changes as JSON `{field: [before, after]}`, and `tag_history` renders a row
+    #: through `_LABELS.get(field, field)`. Rename it and every release-type
+    #: change already in someone's history stops resolving to a label and renders
+    #: as raw `mb_album_type` — the #309 bug, on a field that has no reason to
+    #: pay for a plural.
+    mb_album_type: list[str] = field(default_factory=list)
     mb_album_status: str | None = None
     mb_album_country: str | None = None
 

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -1009,7 +1009,7 @@ def _build_tagset(
         # first night over a capital letter — #283's failure mode on a second
         # field. Any future field taken from a MusicBrainz vocabulary belongs in
         # this pair, not beside it.
-        mb_album_type=(rg.get("primary-type") or "").lower() or None,
+        mb_album_type=_release_types(rg),
         mb_album_status=(release.get("status") or "").lower() or None,
         mb_album_country=release.get("country"),
         compilation=_compilation_flag(release.get("artist-credit")),
@@ -1323,6 +1323,34 @@ def _compilation_flag(artist_credit: list[Any] | None) -> bool | None:
     prevent. Harmonist writes the primary type only (design §5).
     """
     return True if VARIOUS_ARTISTS_ID in _artist_ids(artist_credit) else None
+
+
+def _release_types(rg: Release) -> list[str]:
+    """The release group's type, as Picard writes it: primary then secondaries.
+
+    ONE multi-value tag (`picard/mbjson.py`, `release_group_to_metadata`):
+
+        m['releasetype'] = m.getall('~primaryreleasetype') + m.getall('~secondaryreleasetype')
+
+    Order is Picard's — primary first, then MusicBrainz's own order for the rest
+    — because the two libraries have to agree value for value or an adopted
+    album differs on this field forever (#290). Lower-cased for the same reason,
+    which the primary already was; the secondaries join it rather than sitting
+    beside it in a second convention.
+
+    The secondaries are what say an album is live, a remix or a soundtrack, and
+    Navidrome reads this tag and has no other source for that (#331). They cost
+    no extra request: `secondary-type-list` rides along with the `release-groups`
+    include `RELEASE_INCLUDES` already asks for.
+
+    Empty when the release group has no primary type, which is how the backends
+    know to leave the tag off entirely — a secondary type with no primary would
+    be a shape neither Picard nor a player expects.
+    """
+    primary = (rg.get("primary-type") or "").lower()
+    if not primary:
+        return []
+    return [primary, *((t or "").lower() for t in rg.get("secondary-type-list") or [])]
 
 
 def _artist_ids(artist_credit: list[Any] | None) -> list[str]:

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -810,6 +810,30 @@ def _album_row(disk_album: str, *, alias: str | None = None, **track_overrides):
     return {f.label: f for f in fields}
 
 
+def test_a_missing_secondary_release_type_is_reported_as_a_difference():
+    """The half of #331 that made it invisible rather than merely incomplete.
+
+    Before the fix the release type was a scalar on both sides, so a file
+    carrying "album" compared equal to a release whose type is "album; live" —
+    the page said the tags matched, and the re-tag that followed wrote the
+    truncation back. The finding and the loss cancelled each other out.
+
+    Asserted through `album_fields`, because the panel is where the user would
+    have seen it: a difference this table declines to report is one nothing else
+    on the page can raise.
+    """
+    row = {
+        f.label: f
+        for f in album_fields(
+            [("1.flac", TrackTags(album="Obreel", owned={"mb_album_type": ["album"]}))],
+            _tagset(album="Obreel", mb_album_type=["album", "live"]),
+        )
+    }["Release type"]
+
+    assert row.agreement is Agreement.DIFFERS
+    assert (row.disk, row.mb) == ("album", "album; live")
+
+
 def test_the_disambiguated_album_title_reads_as_a_match():
     """Picard appends the release disambiguation to the album title when told to,
     so `Obreel (expanded edition)` and `Obreel` are the same album by the user's

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -999,7 +999,8 @@ def _full_tagset() -> Any:
         script="Latn",
         mb_album_artist_ids=["aa-1"],
         mb_release_group_id="rg-1",
-        mb_album_type="Album",
+        # Multi-value since #331: primary type plus the secondaries.
+        mb_album_type=["album", "live"],
         mb_album_status="official",
         mb_album_country="GB",
         compilation=True,

--- a/test/test_picard_spec.py
+++ b/test/test_picard_spec.py
@@ -169,9 +169,50 @@ def test_album_level_mbid_atoms_match_picard_names(tmp_path):
     # Picard lower-cases both of these vocabulary fields, so we do too — an
     # adopted library carries "album"/"official" and would otherwise differ from
     # Harmonist on the type forever (#290).
-    assert _atom_str(audio, ATOM_MB_ALBUM_TYPE) == "album"
+    assert _atom_strs(audio, ATOM_MB_ALBUM_TYPE) == ["album"]
     assert _atom_str(audio, ATOM_MB_ALBUM_STATUS) == "official"
     assert _atom_str(audio, ATOM_MB_ALBUM_COUNTRY) == "GB"
+
+
+def test_the_release_type_carries_the_secondary_types_too(tmp_path):
+    """#331. Picard writes ONE multi-value tag holding the primary type and every
+    secondary one — `picard/mbjson.py:971`:
+
+        m['releasetype'] = m.getall('~primaryreleasetype') + m.getall('~secondaryreleasetype')
+
+    Harmonist wrote the primary alone, so nothing on disk recorded that an album
+    was live, and Navidrome — which reads this tag and has no other source for
+    it — could not tell. Primary first, then MusicBrainz's own order, every value
+    lower-cased like the primary already was (#290).
+    """
+    release = _fully_populated_release()
+    release["release-group"]["secondary-type-list"] = ["Live", "Compilation"]
+    album_dir = _setup_album(tmp_path, 2)
+
+    PicardCompatibleTagger().tag_album(album_dir, release)
+
+    audio = MP4(album_dir / "01 Track 1.m4a")
+    assert _atom_strs(audio, ATOM_MB_ALBUM_TYPE) == ["album", "live", "compilation"]
+
+
+def test_a_picard_tagged_secondary_type_survives_a_re_tag(tmp_path):
+    """The half that made #331 a data-loss bug rather than a missing feature.
+
+    A Picard-tagged live album already carries ["album", "live"]. Harmonist's
+    reader took `value[0]`, so the page compared "album" against "album" and
+    reported agreement — and then the re-tag wrote a single value over the top
+    and "live" was gone, with nothing on the page having said so.
+    """
+    album_dir = _setup_album(tmp_path, 2)
+    picard_tagged = MP4(album_dir / "01 Track 1.m4a")
+    picard_tagged[ATOM_MB_ALBUM_TYPE] = [b"album", b"live"]
+    picard_tagged.save()
+
+    release = _fully_populated_release()
+    release["release-group"]["secondary-type-list"] = ["Live"]
+    PicardCompatibleTagger().tag_album(album_dir, release)
+
+    assert _atom_strs(MP4(album_dir / "01 Track 1.m4a"), ATOM_MB_ALBUM_TYPE) == ["album", "live"]
 
 
 def test_album_level_optional_metadata_atoms(tmp_path):


### PR DESCRIPTION
Harmonist wrote the release group's **primary type alone**, so nothing on disk recorded that an album was live, a remix or a soundtrack — and Navidrome reads this tag and has no other source for it.

On an adopted Picard library it was worse than incomplete. Picard writes **one multi-value tag** holding the primary type and every secondary one (`picard/mbjson.py`, `release_group_to_metadata`):

```python
m['releasetype'] = m.getall('~primaryreleasetype') + m.getall('~secondaryreleasetype')
```

Harmonist's readers took `value[0]` (`formats/m4a.py:165`, `formats/mp3.py:146`), so a Picard-tagged live album read back as plain `album`, compared equal to what Harmonist would write, and lost `live` on the next re-tag — **with the album page reporting agreement the whole time.** The finding and the loss cancelled each other out, which is why nothing had caught it.

## The change

`mb_album_type` is a `list[str]`, written through the list path each backend already had for `artists` and `isrcs`, and read through the list reader that was sitting beside the scalar one. Primary first, then MusicBrainz's own order, all lower-cased — the two libraries have to agree value for value or an adopted album differs on this field forever (#290).

**No extra MusicBrainz request.** `secondary-type-list` arrives with the `release-groups` include `RELEASE_INCLUDES` already asks for. I'd flagged in the issue that the only in-repo evidence for that key was a fixture agreeing with itself, so it is now verified against a live payload: The Who's *Live at Leeds* (`d91cabb9-17fc-30bc-beff-c6f72aaecb5b`) returns `secondary-type-list: ['Live']`, and `_release_types` yields `['album', 'live']`.

## The field keeps its singular name

Though it now holds several. That string is `Owned.MB_ALBUM_TYPE`'s value, and it is **persisted**: each tagging's changes go into `activity.db` as JSON `{field: [before, after]}` (`activity_store.py:165`), and `tag_history` renders a row through `_LABELS.get(field, field)` (`tag_history.py:233`). Renaming it would leave every release-type change already in a user's history unable to resolve to a label, rendering as raw `mb_album_type` — the #309 bug, for a plural this field has no reason to pay for.

## Expected consequence

Albums tagged by an earlier version hold `['album']` against a release that now yields `['album', 'live']`, so **every live, compilation, soundtrack and remix album reports an update available until re-tagged**. `mb_album_type` is IDENTITY in the significance map, so the gardener routes those to the Inbox. Accepted deliberately rather than overlooked.

## Testing

`make check` green. Three tests, all mutation-checked:

- The write path, against a release with two secondary types.
- The **re-tag survival** case — a file already carrying `["album", "live"]` keeps both.
- The **comparison** — the album panel now reports the difference instead of silently agreeing. This one exists because a mutation check exposed that my first two tests only covered the write half: restoring the old scalar reader left them green, and the reader is exactly what made the loss invisible.

The reader is also covered across all four formats by the existing mechanical round-trip test, whose fixture now carries the multi-value shape — restoring the scalar reader fails it.

Fixes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2PKanbm1rsX7Zx8mnNUj7