### PR TITLE
Don't flag a library for a credit list it was never given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,12 @@ versions follow [semantic versioning](https://semver.org).
   *zakè & rhubiqs* — leaves a player guessing where one name ends and the next
   begins, so the album files under a single composite artist; Navidrome and Plex
   read the list instead. Written on the next tagging or re-tag (#322).
-  **Albums tagged by an earlier version don't carry it**, so they will report an
-  update available until re-tagged; a library Picard has tagged already has the
-  tag and is unaffected.
+  **No existing library carries this tag** — it is nearly as new in Picard, which
+  added it in 3.0.0rc1 — so an album missing it is the normal case rather than a
+  defect. Where the album has a single artist it is not reported as needing an
+  update at all, because `albumartist` beside it already says the same thing; on
+  a collaboration, where the list is the only record of where one name ends and
+  the next begins, a missing one **is** reported (#337).
 - An album with a MusicBrainz update waiting carries an **Update** badge on its
   Library tile (#293).
 - Harmonist can **check your library against MusicBrainz in the background**, so
@@ -98,6 +101,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **A library that predates a newly added tag is no longer flagged wholesale.**
+  `albumartists` is new in Harmonist and nearly as new in Picard, so no existing
+  library carried it — and one field put every album in the *Update available*
+  filter. A credit list that would hold a single name is now written when
+  Harmonist tags anyway, but its absence is no longer a reason to re-tag: the
+  scalar `albumartist` beside it already says the same thing. A missing list on
+  a genuine collaboration is still reported, and a list that disagrees always
+  was and still is (#337).
 - **Every dated M4A album no longer reports an update available forever.**
   Harmonist wrote the original-date tags in upper case where Picard writes them
   in lower, and MP4 tag names are case-sensitive — so it could not see its own

--- a/src/harmonist/formats/owned.py
+++ b/src/harmonist/formats/owned.py
@@ -311,6 +311,55 @@ def needs_review(significance: Significance) -> bool:
 BY_VALUE: frozenset[Owned] = frozenset({Owned.TITLE})
 
 
+#: Multi-value credit lists whose ABSENCE is not a defect while they would hold
+#: a single name — the scalar twin beside them already says it (#337).
+#:
+#: Mapped to that twin rather than listed on their own, so the entry states WHY
+#: it is exempt and can be checked rather than taken on trust. Same idiom as
+#: `compare._SUBSUMED_BY` and `_ALBUM_COUNTERPART`.
+#:
+#: The problem this answers: `albumartists` is new in Picard as well as here —
+#: `PICARD-700`, 2026-08-25, in `3.0.0rc1` only — so NO existing library carries
+#: it, and one IDENTITY-classified field put every album in a real library into
+#: the Inbox on its first pass. That is the failure `SIGNIFICANCE` above already
+#: warns about (#283, #290), met for the first time.
+#:
+#: Load-bearing on a real collaboration and redundant otherwise, which is what
+#: makes the exemption conditional rather than a blanket opt-out: the joined
+#: phrase cannot be split safely — "Nick Cave & the Bad Seeds" is ONE artist
+#: containing an ampersand — so with two names the list is the only way a player
+#: can recover them, and with one the phrase already is the name.
+DUPLICATES_WHEN_SINGLE: dict[Owned, Owned] = {
+    Owned.ALBUM_ARTISTS: Owned.ALBUM_ARTIST,
+    Owned.ARTISTS: Owned.ARTIST,
+}
+
+
+def is_opportunistic(field: str, before: object, after: object) -> bool:
+    """Whether this change is one to make while tagging, but not a reason to tag.
+
+    True only for an ABSENCE that would be filled with a single name. Three
+    things are deliberately outside it:
+
+    * A field not in `DUPLICATES_WHEN_SINGLE` — the exemption is per-field and
+      declared, never inferred from a value that happens to look redundant.
+    * A value that is present and disagrees. That is a defect whatever its
+      length, and reading "opportunistic" as "never worth flagging" would let a
+      wrong credit sit unreported forever.
+    * A value that would hold more than one name, where the list is the only
+      record of where one artist ends and the next begins.
+
+    Note what this does NOT do: it never stops the change being WRITTEN, or
+    recorded. A re-tag that happens for any other reason fills the tag in and
+    says so in the history. See `gardener.refresh_flag` for why the distinction
+    has to live at the flag rather than in `diff`.
+    """
+    twin = next((f for f in DUPLICATES_WHEN_SINGLE if f.value == field), None)
+    if twin is None or not _absent(before):
+        return False
+    return isinstance(after, list) and len(after) <= 1
+
+
 def _absent(value: object) -> bool:
     """Whether a value counts as "this tag isn't there".
 

--- a/src/harmonist/gardener.py
+++ b/src/harmonist/gardener.py
@@ -59,6 +59,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 from . import album_files, formats, mb_cache, mb_lookup, tagger
+from .formats import owned
 from .models import Album, AlbumState, Release
 
 log = logging.getLogger(__name__)
@@ -169,7 +170,23 @@ def refresh_flag(album: Album, release: Release) -> tagger.AlbumPlan | None:
         # it last said until something can read it.
         log.exception("could not tell whether %s has a tag update available", album.path)
         return None
-    album.update_available = bool(plan.changes)
+    # Not `bool(plan.changes)` since #337. A change that only ADDS a credit list
+    # holding one name is one to make while tagging anyway and not a reason to
+    # tag: `album_artist` beside it already says the same thing, and a player
+    # without the list falls back to the phrase. `albumartists` is new in Picard
+    # too, so no existing library carries it — left counted, one field put every
+    # album in a real library into the Inbox.
+    #
+    # Filtered HERE rather than in `owned.diff`, and that is the whole of the
+    # design: `plan.changes` is also what the activity record and the undo are
+    # built from, so a re-tag that fills the tag in must still say that it did.
+    # The album page keeps showing it as a pending change for the same reason —
+    # the page says what a re-tag would do, this flag says whether you need one.
+    album.update_available = any(
+        not owned.is_opportunistic(field, before, after)
+        for changes in plan.changes.values()
+        for field, (before, after) in changes.items()
+    )
     return plan
 
 

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -445,6 +445,75 @@ def test_a_picard_tagged_album_does_not_flag_on_the_release_type(tmp_path):
     assert _flag(album, release) is False
 
 
+def test_a_library_that_predates_album_artists_is_not_flagged_by_it(tmp_path):
+    """#337, and the reason it was found: an entire dogfood library reported an
+    update whose only differing field was `Album artists`.
+
+    `albumartists` is new in Picard too — `PICARD-700`, 2026-08-25, in
+    `3.0.0rc1` only — so NO existing library carries it, however it was tagged.
+    One IDENTITY-classified field therefore put every album in the Inbox, which
+    is exactly the shape `owned.py` warns about (#283, #290).
+
+    On a single-artist credit the tag is pure redundancy: `album_artist` already
+    says it, and a player that lacks the list falls back to the phrase. So its
+    absence is not a reason to re-tag.
+    """
+    from mutagen.mp4 import MP4
+
+    from harmonist.tagger import ATOM_ALBUM_ARTISTS
+
+    release = _release()
+    album = _tagged(tmp_path, release)
+    # What every library tagged before last week looks like.
+    f = MP4(album.path / "01 Track 1.m4a")
+    del f[ATOM_ALBUM_ARTISTS]
+    f.save()
+
+    assert _flag(album, release) is False
+
+
+def test_a_collaboration_missing_album_artists_IS_flagged(tmp_path):
+    """The control, and the half that keeps the exemption honest.
+
+    With two artists credited the tag is load-bearing rather than redundant: the
+    joined phrase cannot be split safely — "Nick Cave & the Bad Seeds" is ONE
+    artist containing an ampersand — so a player has no way to recover the names
+    without it. Absent there, it IS a reason to re-tag.
+    """
+    from mutagen.mp4 import MP4
+
+    from harmonist.tagger import ATOM_ALBUM_ARTISTS
+
+    release = _release()
+    release["artist-credit"] = [
+        {"artist": {"id": "art-aaa", "name": "Jane", "sort-name": "Jane"}, "name": "Jane"},
+        " & ",
+        {"artist": {"id": "art-bbb", "name": "John", "sort-name": "John"}, "name": "John"},
+    ]
+    album = _tagged(tmp_path, release)
+    f = MP4(album.path / "01 Track 1.m4a")
+    del f[ATOM_ALBUM_ARTISTS]
+    f.save()
+
+    assert _flag(album, release) is True
+
+
+def test_a_wrong_album_artists_is_always_flagged(tmp_path):
+    """The exemption is for an ABSENCE, never for a disagreement. A single-artist
+    album whose list names somebody else is wrong, and stays a finding."""
+    from mutagen.mp4 import MP4
+
+    from harmonist.tagger import ATOM_ALBUM_ARTISTS
+
+    release = _release()
+    album = _tagged(tmp_path, release)
+    f = MP4(album.path / "01 Track 1.m4a")
+    f[ATOM_ALBUM_ARTISTS] = [b"Somebody Else"]
+    f.save()
+
+    assert _flag(album, release) is True
+
+
 # ---------------------------------------------------------------------------
 # Explaining the flag (#291)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An entire dogfood library reported *update available* — **950 of 965 albums** — with `Album artists` the only differing field.

## Why

`albumartists` is new here (#322) and nearly as new in Picard: `PICARD-700`, committed **2026-08-25**, released in **3.0.0rc1 only**. So **no existing library carries it**, however it was tagged. The `[Unreleased]` changelog claim that *"a library Picard has tagged already has the tag and is unaffected"* was simply wrong, and is corrected here — verified against a Picard-tagged album in the dogfood library, which carries `ARTISTS`, `aART` and the artist ids but no `ALBUMARTISTS`.

`Owned.ALBUM_ARTISTS` is `Significance.IDENTITY`, so the gardener routes it to review. One field therefore put the whole library in the Inbox — the failure `formats/owned.py` already warns about (*"~90% of an adopted library on its first night"*, #283/#290), met for the first time by a real library.

## What the tag is for, and why the exemption is conditional

It is the album credit **unjoined** — it carries no join phrases (`picard/mbjson.py`, `artist_credit_from_node`, builds `albumartist` and `albumartists` in one loop from opposite halves). Its value is that **the joined phrase cannot be split safely**: *Let Love In* has `albumartist = "Nick Cave & the Bad Seeds"`, one artist containing an ampersand. A player splitting on "&" shatters that band; with the list present it reads one element and knows not to.

So: **load-bearing on a genuine collaboration, pure redundancy on the single-artist majority**, where `albumartist` says the same thing and a player falls back to it.

Hence a change that *adds* a credit list holding **one** name no longer sets the flag. Two names and it does. A list that is **present and disagrees** always was a finding and still is — an exemption for an absence must never become one for a defect.

```python
#: Multi-value credit lists whose ABSENCE is not a defect while they would hold
#: a single name — the scalar twin beside them already says it.
DUPLICATES_WHEN_SINGLE: dict[Owned, Owned] = {
    Owned.ALBUM_ARTISTS: Owned.ALBUM_ARTIST,
    Owned.ARTISTS:       Owned.ARTIST,
}
```

Mapped to the twin rather than listed alone, so the entry states *why* and can be checked — the idiom `compare._SUBSUMED_BY` already uses. It picks up `artists`, the per-track twin with the identical argument, without a second decision later.

## Two design constraints, both deliberate

**Not a new `Significance` level**, though that was the first shape proposed. That enum is explicitly *"what KIND of change this is — deliberately not whether it needs review"*, with levels ordered by how much of the album they call into question so #273's trust setting stays intelligible. "Absence isn't a defect" is not a point on that scale, and the enum's own docstring records that an earlier draft answering two questions with one word was wrong.

**Filtered at the flag, never in `owned.diff`.** `plan.changes` is also what the activity record and the undo are built from, so a re-tag that fills the tag in must still *say* that it did. The album page keeps showing it as a pending change for the same reason — the page says what a re-tag would do, the flag says whether you need one.

## Accepted consequence

On a single-artist album that differs on nothing else, the tag arrives only when the album is re-tagged for some other reason. That is what opportunistic means, and the fallback is lossless.

## Testing

`make check` green. Three tests — the exempt case, a collaboration that stays flagged, and a present-but-wrong list that stays flagged — each mutation-checked: dropping the single-name condition, extending the exemption to present values, and reverting the flag to `bool(plan.changes)` all go red independently.

Fixes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2PKanbm1rsX7Zx8mnNUj7