### PR TITLE
Stop the page hiding findings it has just counted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,18 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **A tag MusicBrainz has no value for is now shown as a pending removal.** The
+  album page reported nothing at all for it while the *Update available* flag
+  counted it, so an album could be flagged and then show no reason for it — a
+  barcode or ASIN your files carry and MusicBrainz doesn't is common on digital
+  releases, and a re-tag deletes it. A tag MusicBrainz has no *counterpart* for,
+  like a genre or the recovered Bandcamp URL in the comment, stays silent as
+  before — nothing is pending there (#340).
+- **Identifier columns are shown from the start when they are the only thing
+  that differs.** The tracklist could say *"11 of 11 tracks differ"* above a
+  table with nothing marked, because the difference was in a hidden column and
+  the MusicBrainz line hid with it. They stay hidden when a visible column
+  already accounts for the count (#339).
 - **A library that predates a newly added tag is no longer flagged wholesale.**
   `albumartists` is new in Harmonist and nearly as new in Picard, so no existing
   library carried it — and one field put every album in the *Update available*

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -212,8 +212,26 @@ class FieldComparison:
 
     @property
     def differs(self) -> bool:
-        """Whether this row is something the user should look at. ONLY_DISK is
-        excluded on purpose: a Bandcamp URL in the comment is not a finding."""
+        """Whether this row is something the user should look at.
+
+        ONLY_DISK is a finding when the field is COMPARABLE, and silent when it
+        is not (#340). The two cases look identical in the agreement alone, and
+        `comparable` is the only thing that tells them apart:
+
+        * MusicBrainz has no counterpart for the field — `genre`, and the
+          recovered Bandcamp URL in `comment`. Nothing is pending; a re-tag
+          preserves them. Calling those findings would put every adopted album
+          permanently in the Inbox over a URL Harmonist put there itself. This is
+          the case the blanket exclusion was written for.
+        * MusicBrainz has a counterpart and simply no value — a barcode it does
+          not know. **A re-tag deletes that**, so it is exactly the kind of
+          pending change this table exists to state. Excluding it left the page
+          saying "1 of 18 tags differ" about an album the update flag had
+          flagged for two others, because `owned.diff` counts `'X' -> None` and
+          this did not.
+        """
+        if self.agreement is Agreement.ONLY_DISK:
+            return self.comparable
         return self.agreement in (
             Agreement.DIFFERS,
             Agreement.ONLY_MB,
@@ -1086,6 +1104,25 @@ class TracklistComparison:
     def identifier_columns(self) -> tuple[TrackColumn, ...]:
         """The columns the "Show identifiers" control reveals (#319)."""
         return tuple(c for c in self.columns if c.identifier)
+
+    @property
+    def reveal_identifiers(self) -> bool:
+        """Whether the identifier columns should start SHOWN (#339).
+
+        True exactly when hiding them would leave a stated difference with
+        nothing visible behind it: at least one row whose every difference is in
+        a hidden column. That row's own MusicBrainz line is suppressed too — by
+        `mb_only_identifiers`, which exists so a row cannot get "an empty purple
+        row carrying only a hexagon" — so the table shows the reader nothing at
+        all while the summary above it counts the row as differing.
+
+        Deliberately narrower than "any identifier differs". A track differing on
+        its title AND its ISRC already has a visible difference accounting for
+        the count, so the identifiers stay behind their control and the table
+        stays narrow — which is what #319 was for. Revealing on any identifier
+        difference would undo it on most albums that have one.
+        """
+        return any(t.mb_only_identifiers for t in self.tracks)
 
     @property
     def identifier_summary(self) -> str:
@@ -2158,6 +2195,14 @@ def _track_fields(
         # `album_fields` states: which MusicBrainz thing an id names, and whether
         # a value is a credit, are properties of the FIELD. The two strings being
         # compared cannot say.
+        #
+        # `comparable` is per-ROW here, not per-field, and that is load-bearing
+        # since #340 made a comparable ONLY_DISK field a finding. A video track
+        # (#226) and every row of the disk-only view (#228) have `mb=None` for
+        # ALL their fields, so without this each of them would light up as a row
+        # full of pending removals — when the whole claim of a video row is
+        # "present, and that is all". MusicBrainz has no counterpart for the row,
+        # which is precisely what `comparable` means.
         fields.append(replace(row, entity=c.entity, credit=c.credit))
     fields.append(
         _length_field(
@@ -2166,6 +2211,18 @@ def _track_fields(
             unreadable=unreadable,
         )
     )
+    # `comparable` is per-ROW here, not per-field, and it is load-bearing since
+    # #340 made a comparable ONLY_DISK field a finding. A video track (#226) and
+    # every row of the disk-only view (#228) have no MusicBrainz counterpart at
+    # all, so all their fields land in ONLY_DISK — and without this each row
+    # would light up as a set of pending removals, when the whole claim of a
+    # video row is "present, and that is all".
+    #
+    # Applied to the WHOLE row rather than inside the loop above: `#` and Length
+    # are built outside it, and marking only the tag columns left those two
+    # still reading as findings on exactly the rows this protects.
+    if mb is None:
+        return tuple(replace(f, comparable=False) for f in fields)
     return tuple(fields)
 
 
@@ -2185,8 +2242,21 @@ def _length_field(disk_ms: int | None, mb_ms: int | None, *, unreadable: bool) -
         return FieldComparison(
             "Length", Kind.SCALAR, Agreement.MATCHES, disk=_mmss(disk_ms), mb=_mmss(mb_ms)
         )
-    return compare_value(
-        "Length", kind=Kind.SCALAR, disk=_mmss(disk_ms), mb=_mmss(mb_ms), unreadable=unreadable
+    # `comparable=False`, always, and it is the one field that needs saying
+    # explicitly (#340). A length is NOT a tag — nothing writes one to a file —
+    # so a length MusicBrainz does not carry can never be a pending removal, and
+    # the rule that makes a comparable ONLY_DISK field a finding would otherwise
+    # report every digital release whose lengths MusicBrainz lacks. What
+    # `comparable` is really standing in for throughout is "a field Harmonist
+    # writes from MusicBrainz", which everywhere else it names exactly.
+    #
+    # A length that genuinely DIFFERS is untouched: that lands in DIFFERS, which
+    # does not consult this flag.
+    return replace(
+        compare_value(
+            "Length", kind=Kind.SCALAR, disk=_mmss(disk_ms), mb=_mmss(mb_ms), unreadable=unreadable
+        ),
+        comparable=False,
     )
 
 

--- a/templates/partials/_track_list.html
+++ b/templates/partials/_track_list.html
@@ -43,7 +43,7 @@
    govern every cell of the identifier columns at once (#319). The toggle itself
    is in the section's header since #328 and reaches down to this class; the
    wrapper is what it reaches for. #}
-<div class="tracklist">
+<div class="tracklist{{ ' tracklist--ids' if tracklist.reveal_identifiers }}">
 <div class="overflow-x-auto">
     <table class="track-diff">
         {# The number and length columns are named so they can be aligned by

--- a/templates/partials/_tracks_section.html
+++ b/templates/partials/_tracks_section.html
@@ -36,9 +36,16 @@
            carrying no hx-* of its own is the pattern History already uses; the
            rule `make template-lint` enforces is against an inline handler on an
            element htmx also drives. #}
+        {# Checked from the start when hiding them would leave a stated
+           difference invisible (#339) — every difference on some row is in a
+           hidden column, so the table shows nothing while the note above counts
+           the row as differing. BOTH halves of the initial state have to agree:
+           this box and the `tracklist--ids` class on the wrapper inside
+           `_track_list.html`. Set one without the other and the control renders
+           checked over a hidden table, which reads as a broken toggle. #}
         <label class="inline-flex items-center gap-1.5 cursor-pointer select-none
                       text-2xs uppercase tracking-widest font-bold text-muted hover:text-ink transition">
-            <input type="checkbox" class="cursor-pointer"
+            <input type="checkbox" class="cursor-pointer"{{ ' checked' if tracklist.reveal_identifiers }}
                    onchange="this.closest('section').querySelector('.tracklist').classList.toggle('tracklist--ids', this.checked)">
             Show identifiers
             <span class="font-normal normal-case tracking-normal text-muted">{{ tracklist.identifier_summary }}</span>

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -167,10 +167,17 @@ def test_absent_on_disk_reads_as_only_mb_not_as_a_conflict():
 def test_a_field_musicbrainz_has_no_opinion_on_is_not_a_difference():
     """The comment carries the Bandcamp URL. MB has no counterpart, so
     comparing would invent a finding."""
-    f = compare_field(
-        "Comment",
-        disk=consensus([("1.flac", "https://pioulard.bandcamp.com/album/obreel")]),
-        mb=None,
+    # `comparable=False` as `album_fields` marks it — the comment names no
+    # TagSet attribute, so MusicBrainz has no counterpart for it. Since #340 that
+    # flag is what separates this from a barcode MusicBrainz merely lacks, so a
+    # bare `compare_field` here would no longer be the object production builds.
+    f = replace(
+        compare_field(
+            "Comment",
+            disk=consensus([("1.flac", "https://pioulard.bandcamp.com/album/obreel")]),
+            mb=None,
+        ),
+        comparable=False,
     )
     assert f.agreement is Agreement.ONLY_DISK
     assert not f.differs
@@ -247,6 +254,39 @@ def _tagset(**overrides: object) -> TagSet:
         "track_total": 1,
     }
     return TagSet(**{**base, **overrides})  # type: ignore[arg-type]
+
+
+def test_a_tag_musicbrainz_lacks_is_reported_as_a_pending_removal():
+    """#340. A re-tag clears an owned field MusicBrainz has no value for, and the
+    panel used to say nothing at all about it — while the update flag counted it.
+    The page reported "1 of 18 tags differ" on an album flagged for two others.
+
+    Two rules over one set of facts: `owned.diff` sees `'X' -> None` as a change
+    because it is one, and `differs` excluded ONLY_DISK wholesale. The exclusion
+    was written for a field MusicBrainz has no counterpart for — it is now scoped
+    to exactly that.
+    """
+    row = compare_field("Barcode", disk=consensus([("1.flac", "602547690074")]), mb=None)
+
+    assert row.agreement is Agreement.ONLY_DISK
+    assert row.differs, "a re-tag would delete it, and the reader is never told"
+
+
+def test_a_tag_musicbrainz_never_had_a_counterpart_for_stays_quiet():
+    """The case the ONLY_DISK exclusion was written for, and it must keep working.
+
+    The recovered Bandcamp URL lives in `comment`, which MusicBrainz has no
+    counterpart for at all — `album_fields` marks it `comparable=False`. Nothing
+    is pending there: a re-tag preserves it, so calling it a finding would put
+    every adopted album permanently in the Inbox over a URL Harmonist put there.
+    """
+    row = replace(
+        compare_field("Comment", disk=consensus([("1.flac", "https://x")]), mb=None),
+        comparable=False,
+    )
+
+    assert row.agreement is Agreement.ONLY_DISK
+    assert not row.differs
 
 
 def test_summary_counts_only_real_findings():
@@ -1400,6 +1440,46 @@ def test_the_heading_states_the_medium_and_the_track_count_too():
     )
     assert [s.mb for s in both.discs[1].heading.slots] == ["Disc 2 — Live Angle", "CD", None]
     assert both.discs[1].heading.mark_index == 1
+
+
+def test_identifiers_are_revealed_when_hiding_them_would_show_nothing():
+    """#339. The page said "11 of 11 tracks differ" over a table where nothing at
+    all was marked.
+
+    Every track of *Surfing on Sine Waves* differs on its ISRC and nothing else.
+    ISRC is an identifier column, hidden by default (#319) — and because every
+    difference on those rows is hidden, `mb_only_identifiers` suppresses the
+    purple line too, which on its own terms is right (it exists to prevent "a
+    difference marked against nothing"). Together they state a finding and hide
+    all of its evidence.
+    """
+    tl = tracklist(
+        [_file(1, "Nightcall", isrcs=["GBAAA0000001"]), _file(2, "Odd Look", isrcs=["X"])],
+        [
+            _mb_track(1, "Nightcall", isrcs=["GBAAA0000002"]),
+            _mb_track(2, "Odd Look", isrcs=["Y"]),
+        ],
+    )
+
+    assert any(t.mb_only_identifiers for t in tl.tracks), "the shape this is about"
+    assert tl.reveal_identifiers
+
+
+def test_identifiers_stay_hidden_when_a_visible_column_explains_the_count():
+    """The narrower half, and what keeps #319 worth having.
+
+    A track differing on its title AND its ISRC has a visible difference that
+    accounts for the headline, so the identifiers stay behind their control and
+    the table stays narrow. Revealing on any identifier difference would undo
+    #319 on most albums that have one.
+    """
+    tl = tracklist(
+        [_file(1, "Nightcal", isrcs=["GBAAA0000001"])],
+        [_mb_track(1, "Nightcall", isrcs=["GBAAA0000002"])],
+    )
+
+    assert not any(t.mb_only_identifiers for t in tl.tracks)
+    assert not tl.reveal_identifiers
 
 
 def test_the_headline_reports_a_disc_that_differs():

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6053,6 +6053,63 @@ def test_a_missing_track_and_a_missing_disc_are_both_marked(client, cfg, monkeyp
     assert "Disc 2 not in your files" in body
 
 
+def test_identifiers_start_revealed_when_they_are_the_only_difference(client, cfg, monkeypatch):
+    """#339, end to end and in both halves.
+
+    The page said "1 of 1 tracks differ" over a table where nothing was marked.
+    Asserted through the rendered response because the two halves of the initial
+    state live in different partials since #328 — the checkbox in the section
+    header, the class on the wrapper inside the tracklist — and a model test
+    cannot see them disagree.
+    """
+    # TWO tracks, with a different ISRC each: rule 1 only earns a column when the
+    # readings differ BETWEEN tracks, so a one-track album can never reach the
+    # state this is about.
+    d = _make_tagged_album(cfg, "Isrc", mbid="rel-isrc", tagged_at=datetime.now(UTC))
+    shutil.copy(SINE_M4A, d / "02 Track.m4a")
+    for name, title, isrc in (
+        ("01 Track.m4a", "Quoth", b"GBAAA0000001"),
+        ("02 Track.m4a", "Audax", b"GBAAA0000003"),
+    ):
+        audio = MP4(d / name)
+        audio[ATOM_TITLE] = [title]
+        audio[ATOM_MB_ALBUM_ID] = [b"rel-isrc"]
+        audio["trkn"] = [(1 if "01" in name else 2, 2)]
+        audio["----:com.apple.iTunes:ISRC"] = [isrc]
+        audio.save()
+
+    def fake_release(mbid):
+        return {
+            "id": mbid,
+            "title": "Isrc",
+            "medium-list": [
+                {
+                    "position": "1",
+                    "track-list": [
+                        {
+                            "id": "t1",
+                            "title": "Quoth",
+                            "length": "1000",
+                            "recording": {"id": "r1", "isrc-list": ["GBAAA0000002"]},
+                        },
+                        {
+                            "id": "t2",
+                            "title": "Audax",
+                            "length": "1000",
+                            "recording": {"id": "r2", "isrc-list": ["GBAAA0000004"]},
+                        },
+                    ],
+                }
+            ],
+        }
+
+    monkeypatch.setattr("harmonist.web.main.mb_lookup.fetch_release", fake_release)
+    body = client.get(f"/library/{_id_for(cfg, d)}/compare").text
+
+    assert re.search(r'<div class="tracklist tracklist--ids">', body), "the wrapper"
+    assert re.search(r'<input type="checkbox" class="cursor-pointer" checked', body), "the box"
+
+
 def test_a_featured_credit_reads_as_the_artists_it_names(client, cfg, monkeypatch):
     """#309's second half, end to end.
 


### PR DESCRIPTION
Two ways the album page stated a difference and then showed nothing for it. Both found by walking a real library rather than by reading code.

## #340 — the page and the update flag disagreed

`FieldComparison.differs` excluded `ONLY_DISK` wholesale, so a barcode MusicBrainz has no value for read as "nothing to see" — while `owned.diff` counted `'X' → None` and flagged the album, because **a re-tag really does delete it**.

*Underworld — Barbara Barbara* was flagged while its page reported the only differing tag as `Album artists`, which #337 had just decided is not a reason to update. A flagged album showing no reason for it.

`FieldComparison.comparable` already drew the needed distinction and `differs` simply didn't use it — its own docstring says so: a field with no MusicBrainz *counterpart* lands in ONLY_DISK, and so does a comparable field MusicBrainz merely has no *value* for. The first stays silent (nothing is pending; calling the recovered Bandcamp URL a finding would put every adopted album in the Inbox forever). The second is a pending removal and is now stated.

### Two guards this needed, both caught by the suite

**`comparable` is per-ROW for tracks, not per-field.** A video track (#226) and every row of the disk-only view (#228) have no MusicBrainz counterpart at all, so *all* their fields are ONLY_DISK — each row would have lit up as a set of pending removals when its whole claim is "present, and that is all". Applied to the whole row rather than inside the column loop, because `#` and `Length` are built outside it and marking only the tag columns left those two still reading as findings on exactly the rows the guard protects.

**`Length` is `comparable=False`, always.** A length is not a tag — nothing writes one to a file — so a length MusicBrainz lacks can never be a pending removal, and every digital release whose lengths it lacks would have been reported. What `comparable` stands in for throughout is *"a field Harmonist writes from MusicBrainz"*; `Length` is the one place that needed saying out loud.

## #339 — the tracklist counted rows it then marked nothing on

Every track of *Polygon Window — Surfing on Sine Waves* differs on its ISRC alone. ISRC is hidden by default (#319), and because every difference on those rows is hidden, `mb_only_identifiers` suppresses the purple line too — correct on its own terms, since it exists to prevent *"a difference marked against nothing"*. Together: **"11 of 11 tracks differ" over a table with nothing marked.**

The identifiers now start revealed exactly when hiding them would leave a stated difference invisible. Narrower than "reveal whenever an identifier differs" on purpose — a track differing on its title as well already has a visible difference accounting for the count, so #319 keeps its narrow table on every album that has one.

## Testing

`make check` green; `make e2e` green (28).

Both halves of #339's initial state are asserted through the **rendered response**, because since #328 they live in different partials — the checkbox in the section header, the class on the wrapper inside the tracklist. Setting one without the other renders a checked box over a hidden table, which reads as a broken toggle. Each half fails the test on its own; verified by mutation, along with the reveal rule itself.

## Not fixed here, deliberately

Whether a re-tag should remove an owned field MusicBrainz has no value for **at all**. MusicBrainz not knowing a barcode is not evidence that yours is wrong. If that later changes the flag clears by itself, and this rendering becomes what explained why it was ever flagged.

Fixes #339
Fixes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2PKanbm1rsX7Zx8mnNUj7