### PR TITLE
Write one Activity entry for one press, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Clearing a MusicBrainz match, or unlinking a Bandcamp purchase, writes one
+  Activity entry instead of two** — the second was unlinked from the album and
+  repeated its name in the message (#342).
+
 ## [1.13.0] - 2026-09-01
 
 ### Added

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -4065,7 +4065,12 @@ def _register_routes(app: FastAPI) -> None:
           re-adopt it. The album stays correctly tagged in the Library (COMPLETE);
           the freed purchase re-surfaces as unmatched for correct handling. Without
           this, keeping the wrong `store_url` would just re-link the same wrong
-          purchase on the next sync."""
+          purchase on the next sync.
+
+        The activity entry is `_flash_response`'s, and only its — recording one
+        here as well wrote the feed twice for one press (#342). The purchase id
+        being dropped isn't lost with it: `_audit_sidecar_change` diffs `item_id`
+        (and `store_url`) as `old->new` under this request's action id."""
         album = _find_album(request, album_id)
         sc = album.sidecar
         if sc is None or sc.bandcamp is None or sc.bandcamp.item_id is None:
@@ -4075,17 +4080,13 @@ def _register_routes(app: FastAPI) -> None:
                 level=Level.WARNING,
                 album=album,
             )
-        old_id = sc.bandcamp.item_id
         if forget_url:
             new_sc = replace(sc, store_url=None, bandcamp=None)
-            dest, arrow = "Library (URL forgotten)", "Library → Library (forgot the wrong URL)"
+            dest = "Library (URL forgotten)"
         else:
             new_sc = replace(sc, bandcamp=BandcampInfo(item_id=None, band_id=sc.bandcamp.band_id))
-            dest, arrow = "Needs Link", "Library → Needs Link"
+            dest = "Needs Link"
         sidecar_mod.write(album.path, new_sc)
-        activity.record(
-            f"Unlinked {album.artist} — {album.title} (was Bandcamp purchase {old_id}): {arrow}"
-        )
         request.app.state.scan_runner.request_scan()
         return _flash_response("Unlinked", f"now {dest}", album=album)
 
@@ -4101,6 +4102,11 @@ def _register_routes(app: FastAPI) -> None:
         No candidate — re-offering the release the user just called wrong would
         undo their own judgement, which is the one way this differs from the undo.
 
+        The activity entry is `_flash_response`'s, and only its — recording one
+        here as well wrote the feed twice for one press (#342). The release id
+        being cleared isn't lost with it: the `sidecar.unlink` write above audits
+        `mbid` as `old->new` under this request's action id.
+
         The on-disk tags are left untouched until the user re-tags.
         Non-destructive."""
         album = _find_album(request, album_id)
@@ -4112,12 +4118,7 @@ def _register_routes(app: FastAPI) -> None:
                 level=Level.WARNING,
                 album=album,
             )
-        old_mbid = sc.mb_release_id
         sidecar_mod.unlink(album.path, sc)
-        activity.record(
-            f"Cleared MB match for {album.artist} — {album.title} "
-            f"(was {old_mbid}): Library → Needs MBID"
-        )
         request.app.state.scan_runner.request_scan()
         return _flash_response(
             "MB match cleared",

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -24,7 +24,7 @@ from mutagen.mp4 import MP4
 
 from harmonist import activity, activity_store, mb_lookup
 from harmonist import sidecar as sc
-from harmonist.activity_store import Level
+from harmonist.activity_store import Level, Source
 from harmonist.config import (
     BandcampConfig,
     Config,
@@ -2934,7 +2934,12 @@ def test_unlink_reverts_complete_album_to_needs_sync(client, cfg):
     assert loaded.bandcamp is None or loaded.bandcamp.item_id is None
     assert loaded.store_url == "https://x.bandcamp.com/album/undo-me"  # kept
     assert next(a for a in scan(cfg.paths.music_dir) if a.path == d).state == AlbumState.NEEDS_SYNC
-    assert any("Unlinked" in e.message and "99" in e.message for e in activity.recent(5))
+    # The outcome is in the feed; the purchase id it dropped is in the audit row
+    # beneath it, where a structured value belongs (#342).
+    assert any("Unlinked" in e.message for e in activity.recent(5))
+    assert any(
+        "item_id=99->None" in e.message for e in activity_store.recent(5, source=Source.AUDIT)
+    )
 
 
 def test_unlink_wrong_match_forgets_url_and_stays_in_library(client, cfg):
@@ -3038,6 +3043,55 @@ def test_rematch_warns_when_no_mb_release(client, cfg):
     r = client.post(f"/library/{_id_for(cfg, d)}/rematch")
     assert r.status_code == 200
     assert "Nothing to re-match" in r.text
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "verb"),
+    [("rematch", "MB match cleared"), ("unlink", "Unlinked")],
+)
+def test_one_action_writes_one_activity_entry(client, cfg, endpoint, verb):
+    """#342: an action that both records and flashes wrote the feed twice.
+
+    `_flash_response` is the funnel for user actions — it writes the activity
+    entry itself — so a handler calling `activity.record()` as well produced two
+    entries for one press. The duplicate was also the worse of the pair: no
+    `album_id`, so it linked to nothing and never joined the album's history,
+    with the album's name inlined into the message instead (the #65 mistake).
+
+    The old identifier the duplicate carried is not lost: `_audit_sidecar_change`
+    diffs `mbid`/`item_id` as `old->new`, under the same `action_id`, which is
+    what the last two assertions hold in place.
+    """
+    d = _make_tagged_album(
+        cfg, f"Dup {endpoint}", mbid="rel-dup", tagged_at=datetime.now(UTC), item_id=7
+    )
+    aid = _id_for(cfg, d)
+    activity_store.clear()
+
+    r = client.post(f"/library/{aid}/{endpoint}")
+    assert r.status_code == 200
+
+    feed = activity_store.recent(50, source=Source.ACTIVITY)
+    assert len(feed) == 1, f"one press, one entry — got {[e.message for e in feed]}"
+    assert feed[0].message.startswith(verb)
+    # It is the well-formed one: linked to the album, with the name in its own
+    # column rather than inlined into the message.
+    assert feed[0].album_id is not None
+    assert "Dup" not in feed[0].message
+
+    # The old identifier still survives, in the audit row beneath the same action.
+    audit_rows = activity_store.recent(50, source=Source.AUDIT)
+    dropped = "mbid=rel-dup->None" if endpoint == "rematch" else "item_id=7->None"
+    assert any(dropped in e.message for e in audit_rows), [e.message for e in audit_rows]
+    assert {e.action_id for e in audit_rows} == {feed[0].action_id}
+
+    # Pressing it again is a no-op warning, not a second outcome: there is
+    # nothing left to clear, and the guard is what keeps the action idempotent.
+    r2 = client.post(f"/library/{aid}/{endpoint}")
+    assert r2.status_code == 200
+    assert "Nothing to" in r2.text
+    again = activity_store.recent(50, source=Source.ACTIVITY)
+    assert [e.message for e in again if e.message.startswith(verb)] == [feed[0].message]
 
 
 def test_library_detail_wrong_match_controls_beside_badges(client, cfg):


### PR DESCRIPTION
Clearing an MB match wrote the feed twice for a single press, at the same second — the well-formed entry from `_flash_response`, and a free-text one the handler recorded itself:

```
17:31:01  Boards of Canada — Tomorrow's Harvest · MB match cleared — → Needs MBID — pick the correct release
17:31:01  Cleared MB match for Boards of Canada — Tomorrow's Harvest (was 38c4b369-…): Library → Needs MBID
```

`library_unlink` had the identical shape and the same duplicate, so the Bandcamp unlink button would have shown it next.

## Cause

`_flash_response` is the funnel for user actions — it writes the activity entry and the status-bar flash from one call — so a handler that also calls `activity.record()` gets two entries. The duplicate was the worse of the pair: no `album_id`, so it linked to nothing and never joined the album's history, and it inlined the album name into the message instead of carrying it in the `album_label` column, which is the #65 mistake the helper's own docstring warns about. On an album with an empty artist it rendered as `Unlinked  — Dup unlink`, double space and all.

## Why nothing is lost

The old identifier each message carried is already in the audit log with more precision: `_audit_sidecar_change` diffs `mbid`, `item_id` and `store_url` as `old->new` on every write, and the request's action scope gives those rows the same `action_id` as the activity entry — so they surface together under the feed's details disclosure. Coverage was checked by tracing the write, not by grepping the handler for `audit.record`. Both docstrings now record where the dropped identifier lives, so the omission doesn't read as an oversight and invite the duplicate back.

## Tests

Web-route rung, red first: both parametrised cases failed on the count assertion with the exact duplicate pair, then passed.

One existing test had been asserting the *duplicate's* content — that the activity message contained the purchase id. It now asserts that id in the audit row, which is the invariant that actually matters.

The new test also presses each button twice: `unlink`'s "Nothing to unlink" guard had no coverage at all, and a second press writing a second outcome is the same bug in another form. Mutation-checked by neutering the guard — it goes red.

`make check` exit 0, 1551 passed.

Fixes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2PKanbm1rsX7Zx8mnNUj7