### PR TITLE
Pace the update check off a goal window, not a hand-set cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ versions follow [semantic versioning](https://semver.org).
   MusicBrainz knew only of Germany. The Country row now lists them all beside
   the tag, with each country's own release date (#329).
 
+### Changed
+
+- **Background update checks are gentler on MusicBrainz.** They now spread the
+  albums they have to look at evenly across a day instead of asking about a
+  hundred of them in a burst every hour (#349).
+
 ### Fixed
 
 - **A release country Picard chose is no longer reported as out of date.**

--- a/docs/design.md
+++ b/docs/design.md
@@ -1413,11 +1413,13 @@ closure holds the *startup* config, so reading the level from there would leave
 the setting saved, looking applied, and silently doing nothing — worse than
 having required the restart.
 
-**And a way out of the first empty hour.** `run_periodically` fires one full
-interval after startup and never at startup, so turning the check on at 10:00
-buys an hour in which the library looks exactly as it did. `POST
+**And a way out of the first empty interval.** `run_periodically` fires one full
+interval after startup and never at startup, so turning the check on buys ten
+minutes in which the library looks exactly as it did. `POST
 /settings/update-check` — **Check now**, beside the level — runs one pass
-immediately. It shares the tick's guards rather than bypassing them, `off`
+immediately. It runs an *ordinary* tick, a couple of albums rather than a sweep:
+giving the button its own larger budget would put the burst back in at the one
+moment somebody is certainly sitting in front of the app. It shares the tick's guards rather than bypassing them, `off`
 included: the level is what the button asks permission from, so it cannot be the
 way round it. Whichever guard declines says so in the flash, because a control
 answered with silence reads as broken whether it ran or refused.
@@ -1447,14 +1449,51 @@ the id MusicBrainz redirected to (§5), and a **deleted** one, which stores
 nothing at all because a negative is never cached. `gardener._asked` remembers
 the ids this process has spent a request on, which closes both.
 
+**The rate is derived from a goal, not chosen** (#349). `gardener.SWEEP_WINDOW`
+(24h) says how long a full sweep of everything currently due should take, and a
+tick — `gardener.SWEEP_TICK`, ten minutes — asks about `tick / window` of the
+queue, so two or three albums at a time. The point is that the rate answers to
+the size of the backlog: a first run with the whole library due gets a
+proportionally larger slice and still finishes inside the day, while steady state
+settles at `len(library) / RECHECK_AFTER` a day, which is the demand rather than
+a multiple of it.
+
+This replaced a hand-set pair — a hundred albums an hour — that worked out at
+roughly eight times what the goal needed and spent it in hundred-request bursts.
+Two properties of the replacement are worth stating because neither is obvious:
+
+* **The window must be well under `RECHECK_AFTER`.** The queue settles where
+  inflow meets outflow: albums come due at `len(library) / RECHECK_AFTER` a day
+  and clear at `due / SWEEP_WINDOW`. A day-long window holds the queue at a
+  seventh of the library; a week-long one settles with the whole library
+  permanently overdue.
+* **Sizing the slice is also what stops the pattern repeating.** `_due` orders
+  off the fetch times an earlier pass wrote, so whatever is swept together comes
+  due together one `RECHECK_AFTER` later and the shape recurs. Under the old cap
+  that shape was a hundred-album burst, stamped on the library by its first run
+  and replayed weekly; under a two-album slice there is nothing left to recur.
+  Deliberately no jitter: a start time nobody coordinates and a rate that varies
+  with the library are spread enough, and randomising the clock would be a knob
+  to document for no gain.
+
+The tick lives in `gardener` beside the window rather than in `web/main.py`,
+because the constant that schedules the pass and the constant the pass divides by
+are the same fact; keeping them in two modules is how the old pair drifted.
+
 **It stands aside** for a sync, a reconcile pass, or a library that has not been
 scanned yet, and refuses to start on top of a pass still running. One reason
 between them: the rate limit is a single shared queue and anything the user set
 in motion is waiting on it, while the check's albums have waited a week and can
-wait another hour. And when MusicBrainz keeps failing it gives up for the pass
-rather than spending a request per album to learn the same thing each time — a
-404 is an answer and does not count towards that, or a library with five
-deleted releases would abort every pass at the fifth.
+wait another ten minutes. And when MusicBrainz keeps failing it gives up rather
+than spending a request per album to learn the same thing each time — a 404 is an
+answer and does not count towards that, or a library with five deleted releases
+would abort every pass at the fifth. That failure run is held **across** ticks
+(`gardener._consecutive_failures`): a tick is a handful of albums now, so a
+counter reset every ten minutes could never reach the threshold, and an outage
+would be met with a fresh slice of requests every tick forever. Held, the
+threshold is reached once and every later tick ends on its first failure until
+something answers — one request and one line per ten minutes, and the loud
+warning fires only on the transition.
 
 #### The per-album refresh
 

--- a/src/harmonist/gardener.py
+++ b/src/harmonist/gardener.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -281,21 +282,84 @@ def _rest(worked: float, duty: float) -> None:
 #: asking six times too often costs six times the budget for the same answer.
 RECHECK_AFTER = timedelta(days=7)
 
-#: The most albums one pass will ask about. At the 1 req/s MusicBrainz floor
-#: this is the pass's *duration* as much as its size — a hundred albums is under
-#: two minutes — which is what keeps it off the shared rate limiter while
-#: somebody is using the app.
+#: How long a full sweep of everything currently due should take (#349). The
+#: *goal*, from which the rate is derived — not a rate that happens to reach the
+#: goal, which is what the hand-set hundred-an-hour cap this replaces was.
 #:
-#: With the interval it is also the sweep rate: a hundred an hour is 2,400 a
-#: day, so a library big enough to matter still completes a cycle well inside
-#: `RECHECK_AFTER`. #273 turns both into settings for anyone whose does not.
-ALBUMS_PER_PASS = 100
+#: Deriving is what makes it self-stabilising. A large backlog — a first run,
+#: where the whole library is due at once — yields a proportionally larger slice
+#: and still clears inside a day; steady state settles at exactly
+#: `len(library) / RECHECK_AFTER` a day, which is the demand and not a multiple
+#: of it. The old pair provisioned 2,400 fetches a day against a demand of ~286
+#: for a 2,000-album library, and spent them in hundred-request bursts.
+#:
+#: **Meaningfully shorter than `RECHECK_AFTER`, and that is not a taste.** The
+#: backlog settles where inflow meets outflow: albums come due at
+#: `len(library) / RECHECK_AFTER` a day and are cleared at `due / SWEEP_WINDOW`,
+#: so a day-long window holds the queue at a seventh of the library and the lag
+#: at about a day. Set it to a week and the equilibrium is the whole library
+#: permanently overdue. #273 exposes it; the arithmetic is why it should not be
+#: set much higher.
+SWEEP_WINDOW = timedelta(hours=24)
+
+#: How often a tick fires, and so how big a slice one gets: a tick is
+#: `SWEEP_TICK / SWEEP_WINDOW` of what is due, which at these values is 1/144 —
+#: two or three albums for a library of a couple of thousand.
+#:
+#: Ten minutes rather than the hour it replaces, because the tick length IS the
+#: burst length. An hourly tick doing the same daily total still delivers it as
+#: twelve back-to-back requests and then nothing; at ten minutes there is no
+#: burst left to speak of. Short enough, too, that the pass stands aside for a
+#: sync within ten minutes rather than an hour — the guards are re-read per
+#: tick.
+#:
+#: **Not jittered, deliberately.** A slice this small has no burst to spread and
+#: nothing to fall into lockstep with: what lands together is two or three
+#: albums, which is what a tick drains anyway. The pattern worth breaking up was
+#: the hundred-album one — `_due` orders off the fetch times an earlier pass
+#: wrote, so a burst comes due again as a burst one `RECHECK_AFTER` later, and
+#: the shape repeats forever — and sizing the slice is what breaks it, not
+#: randomising the clock. Between a start time nobody coordinates and a rate
+#: that already varies with the library, there is enough spread here without a
+#: knob to explain.
+#:
+#: Lives here beside the window rather than in `web/main.py` (where it was, as
+#: `_UPDATE_CHECK_INTERVAL`) precisely because `sweep` now has to know it: the
+#: slice is a fraction of the window, so the constant that *schedules* the pass
+#: and the constant the pass *divides by* must be the same one. Two constants in
+#: two modules that had to be kept in step is how the rate drifted to 8x the
+#: goal in the first place.
+SWEEP_TICK = timedelta(minutes=10)
+
+#: The most of a tick that may be spent fetching, so a slice always fits inside
+#: the tick that scheduled it. At the 1 req/s MusicBrainz floor a slice is
+#: roughly one second an album, and a library big enough for `SWEEP_WINDOW` to
+#: hand out more albums than that would run each pass into the next — which the
+#: lock refuses, so the excess is silently dropped anyway. Better to bound it
+#: here, where the reason is written down.
+_TICK_FETCH_BUDGET = 0.5
+
+#: Seconds one MusicBrainz request occupies. Not a limiter — `musicbrainzngs`
+#: owns the actual 1 req/s floor — just the figure `_slice_size` costs a fetch
+#: at when deciding how many fit in a tick.
+_SECONDS_PER_FETCH = 1.0
 
 #: How many MusicBrainz failures in a row end a pass early. MusicBrainz being
 #: down looks exactly like this, and grinding through the rest of the queue to
 #: fail at each one spends a request apiece and buries the first failure — the
 #: only one that says anything — under ninety-nine identical ones.
 _GIVE_UP_AFTER = 5
+
+#: The failure run, ACROSS ticks (#349). It was a local of `sweep`, which was
+#: sound while a pass was a hundred albums and is dead code now that one is
+#: two or three: a counter that resets every ten minutes can never reach five,
+#: so an outage would be met with a fresh slice of requests every tick, forever,
+#: which is the opposite of what #349 is for. Held here, five failures end the
+#: tick they land in and every tick after it ends on its first failure — one
+#: request and one line per ten minutes — until something succeeds.
+#:
+#: In memory, like `_asked`: a restart re-learns it at the cost of one slice.
+_consecutive_failures = 0
 
 #: Sorts before every real timestamp, so "never asked" is the stalest thing
 #: there is and an album nobody has ever looked at goes to the front of the
@@ -345,10 +409,35 @@ class PassResult:
     gave_up: bool = False
 
 
+def _slice_size(due_count: int, *, tick: timedelta, window: timedelta) -> int:
+    """How many of `due_count` releases this tick's share of `window` is worth.
+
+    The whole of #349's rate change, and deliberately one line of arithmetic
+    with its reasoning around it rather than a constant somebody chose. A tick
+    is `tick / window` of the goal, so the pass asks about that fraction of
+    whatever is outstanding — which means the rate answers to the size of the
+    backlog instead of to a number picked when the library was a different size.
+
+    Rounded **up**, so a due list smaller than the ratio still moves. Left at
+    exactly zero it would stall: a one-album backlog is 1/144th of a tick's
+    worth, and a floor would never let that album be asked about at all.
+
+    Capped so the slice fits inside the tick that scheduled it (see
+    `_TICK_FETCH_BUDGET`). A pass that outran its tick would be refused by the
+    lock rather than queued, so the excess is dropped either way; bounding it
+    here is the version that has a reason attached.
+    """
+    share = math.ceil(due_count * (tick / window))
+    fits = int(tick.total_seconds() * _TICK_FETCH_BUDGET / _SECONDS_PER_FETCH)
+    return max(0, min(share, fits))
+
+
 def sweep(
     albums: Sequence[Album],
     *,
-    limit: int = ALBUMS_PER_PASS,
+    tick: timedelta = SWEEP_TICK,
+    window: timedelta = SWEEP_WINDOW,
+    limit: int | None = None,
     recheck_after: timedelta = RECHECK_AFTER,
 ) -> PassResult:
     """Ask MusicBrainz about the albums whose release we have looked at least
@@ -379,17 +468,29 @@ def sweep(
     nothing — going and looking IS the operation, and the refreshed row it
     leaves behind is what dates the next pass's queue.
 
+    **How many it asks about is derived, not chosen** (#349). One tick gets
+    `tick / window` of whatever is currently due, so the pass sweeps everything
+    outstanding across `window` and no faster — see `_slice_size`. `limit`
+    overrides that outright, for a caller (and for tests) that means a specific
+    number rather than a rate; nothing in the app passes it.
+
     Blocking on both the network and the disk, so call it from a worker thread,
     never the event loop.
     """
+    global _consecutive_failures
     now = datetime.now(UTC)
     due = _due(albums, recheck_after=recheck_after, now=now)
-    log.info("update check: %d album(s) due, asking MusicBrainz about up to %d", len(due), limit)
+    slice_size = limit if limit is not None else _slice_size(len(due), tick=tick, window=window)
+    # DEBUG, not INFO: at one tick every ten minutes this line is 144 a day on a
+    # library with nothing to say. What a healthy pass has to report is the
+    # closing summary, and that only speaks up when there is something in it.
+    log.debug(
+        "update check: %d album(s) due, asking MusicBrainz about up to %d", len(due), slice_size
+    )
     asked = examined = flagged = gone = failed = 0
-    consecutive = 0
     gave_up = False
     reported = time.monotonic()
-    for mbid, group in due[:limit]:
+    for mbid, group in due[:slice_size]:
         # Read the baseline BEFORE the fetch: `fetch_release` replaces the row
         # on its way back, so afterwards there is nothing left to compare with.
         before = mb_cache.stored_release(mbid)
@@ -410,11 +511,11 @@ def sweep(
             # what turns it into something waiting for them.
             log.info("update check: MusicBrainz no longer has release %s", mbid)
             gone += 1
-            consecutive = 0
+            _consecutive_failures = 0
             continue
         except mb_lookup.MBError:
             failed += 1
-            consecutive += 1
+            _consecutive_failures += 1
             # Kept out of the Activity feed (`_diagnostic`): nothing was lost,
             # the next pass retries, and a MusicBrainz wobble is not the user's
             # to act on. The log still has it, with the traceback.
@@ -424,18 +525,34 @@ def sweep(
                 exc_info=True,
                 extra={"_diagnostic": True},
             )
-            if consecutive >= _GIVE_UP_AFTER:
-                # This one IS mirrored. A pass that gave up leaves the flags
-                # stale for a week, and that is a thing the user can only find
-                # out from us.
-                log.warning(
-                    "update check: giving up this pass after %d MusicBrainz failures in a row",
-                    consecutive,
-                )
+            if _consecutive_failures >= _GIVE_UP_AFTER:
+                # Only the FIRST tick to give up says so out loud. This warning
+                # IS mirrored into the Activity feed — a check that stopped
+                # looking is a thing the user can only find out from us — and
+                # the counter now spans ticks (#349), so without the transition
+                # test a sustained outage would post the same non-news every ten
+                # minutes for as long as it lasted. The same "one line per
+                # episode" rule `run_periodically` follows.
+                if _consecutive_failures == _GIVE_UP_AFTER:
+                    log.warning(
+                        "update check: giving up after %d MusicBrainz failures in a row; "
+                        "backing off until one succeeds",
+                        _consecutive_failures,
+                    )
+                else:
+                    log.debug(
+                        "update check: still backing off after %d failures in a row",
+                        _consecutive_failures,
+                    )
                 gave_up = True
                 break
             continue
-        consecutive = 0
+        if _consecutive_failures:
+            log.info(
+                "update check: MusicBrainz answered again after %d failure(s) in a row",
+                _consecutive_failures,
+            )
+        _consecutive_failures = 0
         if before is not None and _same_release(before, release):
             continue  # MusicBrainz has said nothing new; read no files
         examined += len(group)
@@ -449,7 +566,15 @@ def sweep(
     result = PassResult(
         asked=asked, examined=examined, flagged=flagged, gone=gone, failed=failed, gave_up=gave_up
     )
-    log.info(
+    # INFO only when the tick has something to report (#349). At an hourly tick
+    # asking about a hundred albums this line was always worth reading; at one
+    # every ten minutes asking about two it is 144 lines a day saying nothing
+    # happened, which is how a log stops being read. A tick that found something
+    # — a payload that moved, a release gone, a fetch that failed — still says
+    # so; #274's digest is what turns the rest into something a user sees.
+    notable = bool(result.examined or result.gone or result.failed or result.gave_up)
+    log.log(
+        logging.INFO if notable else logging.DEBUG,
         "update check: %s — asked about %d release(s), %d had moved, %d album(s) "
         "have an update, %d gone from MusicBrainz, %d fetch(es) failed",
         "gave up early" if result.gave_up else "done",

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -231,17 +231,13 @@ _LIBRARY_QUERY_MAX = 100
 # isn't there either: an unchanged library is a stat per file and no tag reads.
 _RESCAN_INTERVAL = timedelta(hours=1)
 
-# How often the gardener's update check runs when it is switched on (#270).
-# Also a constant for now, and for a different reason from the rescan's: it is
-# half of a rate — with `gardener.ALBUMS_PER_PASS` it says how fast the library
-# is swept — and the two are no use apart. #273 makes the pair a setting
-# together, alongside the trust level.
-#
-# Deliberately the same hour as the rescan rather than a nightly slot: the pass
-# is short, capped, and skipped whenever anything else is working, so spreading
-# it thinly across the day keeps it out of the way better than concentrating it
-# at 3am would — and there is no hour at which a NAS is reliably idle.
-_UPDATE_CHECK_INTERVAL = timedelta(hours=1)
+# The update check's cadence lives in `gardener` (`SWEEP_TICK`), not here
+# (#349). It used to be `_UPDATE_CHECK_INTERVAL` beside the rescan's,
+# which was wrong in a way that only shows up in the arithmetic: the tick is not
+# an independent knob, it is the denominator the pass divides `SWEEP_WINDOW` by
+# to size its slice. Kept in two modules the pair drifted, and the rate ended up
+# at roughly eight times what the goal needed, delivered in hundred-request
+# bursts. One constant, owned by the code that has to reason about it.
 
 # The header that tells `/library` to name the resolved view in the address bar
 # (#180). The search form cannot spell its own `hx-push-url`: it does not know the
@@ -691,7 +687,7 @@ def create_app(
         # reading it would make the setting save, look applied, and do nothing.
         check_task = asyncio.create_task(
             periodic.run_periodically(
-                _UPDATE_CHECK_INTERVAL,
+                gardener.SWEEP_TICK,
                 lambda: _update_check_if_idle(_app, sync_runner, reconcile_runner, scan_runner),
                 name="update check",
                 stop_event=watch_stop,
@@ -2213,7 +2209,8 @@ def _update_check_if_idle(
     The other three share one reason: the MusicBrainz rate limit is a single
     shared queue, and anything the user set in motion is waiting on it. A sync or
     a reconcile pass is spending it already, and the check is in no hurry — its
-    albums have been unasked-about for a week and one more hour changes nothing.
+    albums have been unasked-about for a week and ten more minutes change
+    nothing.
     It skips the tick rather than deferring it, like the periodic rescan does,
     because the next one comes round soon and nothing is waiting on this one. The
     first scan is the same argument at startup: the pass reads
@@ -2232,10 +2229,18 @@ def _update_check_if_idle(
         log.debug("Skipping update check: background update checks are off")
         return "background update checks are off"
     if sync_runner.is_running or reconcile_runner.is_running:
-        log.info("Skipping update check: sync or reconcile in progress")
+        # DEBUG since #349 shortened the tick to ten minutes: a long sync would
+        # otherwise write this same line six times an hour for as long as it
+        # ran, which is the noise that makes a log unread. Nothing is lost by
+        # standing aside quietly — the user started the sync, and **Check now**
+        # still answers with the reason in words.
+        log.debug("Skipping update check: sync or reconcile in progress")
         return "a sync or reconcile is using the MusicBrainz budget"
     if not scan_runner.has_completed():
-        log.info("Skipping update check: the library has not been scanned yet")
+        # DEBUG for the same reason: the first scan of a large library outlasts
+        # several ten-minute ticks, and "not scanned yet" during the first scan
+        # is the expected state rather than news. The scan announces itself.
+        log.debug("Skipping update check: the library has not been scanned yet")
         return "the library hasn't finished scanning yet"
     if not _update_check_lock.acquire(blocking=False):
         log.warning("Skipping update check: the previous pass is still running")
@@ -3562,10 +3567,18 @@ def _register_routes(app: FastAPI) -> None:
         """Run the background pass now, instead of waiting for the next tick.
 
         `run_periodically` fires one full interval after startup and never at
-        startup, so turning the check on at 10:00 buys an hour of a library that
-        looks exactly as it did — which reads as a setting that didn't take
-        (#312). This is the escape hatch from that hour, and the only way to see
-        the pass work on demand.
+        startup, so turning the check on buys an interval of a library that looks
+        exactly as it did — which reads as a setting that didn't take (#312).
+        This is the escape hatch from that wait, and the only way to see the pass
+        work on demand.
+
+        **It runs one ordinary tick, not a bigger one** (#349). A tick is now a
+        share of `gardener.SWEEP_WINDOW` — a couple of albums rather than a
+        hundred — so the press buys the ten minutes to the next one and not a
+        sweep. Deliberately: giving the button its own larger budget would put
+        the burst #349 removed back into the app at the one moment somebody is
+        certainly sitting in front of it, and the honest reading of "check now"
+        is that the check starts now, which it does.
 
         Not a mutation: it starts a read-only pass on a worker thread and
         returns at once, so there is nothing for the inbox or the library to

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -775,10 +775,17 @@ def _forget_what_was_asked():
     A leak would make a later pass skip an album for reasons that test never set
     up — and it would do it by making the pass *quieter*, which is the direction
     an assertion about call counts reads as success.
+
+    `_consecutive_failures` is the same shape and the same hazard since #349
+    made it span ticks: a run left standing at the threshold would make the next
+    test's pass give up on its first album, which again looks like success to
+    anything counting requests.
     """
     gardener._asked.clear()
+    gardener._consecutive_failures = 0
     yield
     gardener._asked.clear()
+    gardener._consecutive_failures = 0
 
 
 def _inc() -> str:
@@ -961,6 +968,148 @@ def test_the_stalest_album_goes_first_when_the_cap_bites(tmp_path, monkeypatch):
     assert asked == ["rel-ancient"]
 
 
+# --- How big a tick is (#349) ------------------------------------------------
+#
+# The pass used to ask about a hundred albums an hour because a hundred and an
+# hour were the two numbers chosen, and the pair worked out at roughly eight
+# times the rate `RECHECK_AFTER` actually asks for — spent in hundred-request
+# bursts at a volunteer service. These pin the replacement: the slice is a
+# fraction of what is outstanding, so the rate answers to the backlog rather
+# than to a constant somebody picked when the library was a different size.
+
+
+def test_a_tick_asks_about_its_share_of_the_window_and_no_more(tmp_path, monkeypatch):
+    """The change itself. A tick is `SWEEP_TICK / SWEEP_WINDOW` of what is due —
+    1/144 at the shipped values — so 288 outstanding releases cost two requests,
+    not the hundred the old cap would have spent."""
+    activity_store.init(tmp_path / "activity.db")
+    albums = [
+        _tagged(tmp_path, _release(mbid=f"rel-{i:03d}"), name=f"Album {i}") for i in range(288)
+    ]
+    asked = _serving(monkeypatch, *(_release(mbid=f"rel-{i:03d}") for i in range(288)))
+
+    result = gardener.sweep(albums, tick=timedelta(minutes=10), window=timedelta(hours=24))
+
+    assert len(asked) == 2
+    assert result.asked == 2
+
+
+@pytest.mark.parametrize("due", [1, 7, 143, 144, 288, 2000, 20000])
+def test_whatever_is_due_is_swept_inside_the_window(due):
+    """The goal, stated as the property it actually is: a tick's slice, repeated
+    for a window's worth of ticks, covers the backlog. That is what makes the
+    rate self-stabilising — a first run with the whole library due gets a
+    proportionally larger slice and still finishes in a day, while steady state
+    settles at the demand rather than at a multiple of it.
+
+    The old pair could not state this, because neither constant knew what was
+    outstanding.
+
+    True up to what a tick can physically fetch — past ~43,000 due releases the
+    per-tick cap bites and the window stops being reachable at 1 req/s. The
+    parametrised sizes stay under that on purpose: it is the honest ceiling of
+    the property, not a case the test is dodging."""
+    tick, window = timedelta(minutes=10), timedelta(hours=24)
+    ticks_per_window = window / tick
+
+    slice_size = gardener._slice_size(due, tick=tick, window=window)
+
+    assert slice_size * ticks_per_window >= due
+
+
+def test_one_album_due_is_still_asked_about():
+    """Rounded up, and this is why: one album is 1/144th of a tick's worth, so a
+    floor would leave it at zero and it would never be asked about at all — the
+    backlog would sit at one forever while the pass reported nothing wrong."""
+    assert gardener._slice_size(1, tick=timedelta(minutes=10), window=timedelta(hours=24)) == 1
+
+
+def test_nothing_due_asks_about_nothing():
+    """The quiet case, and the common one. Rounding up must not round an empty
+    queue up to one — that would spend a request per tick, forever, on a library
+    with nothing outstanding."""
+    assert gardener._slice_size(0, tick=timedelta(minutes=10), window=timedelta(hours=24)) == 0
+
+
+def test_a_slice_never_outruns_the_tick_that_scheduled_it():
+    """A library large enough for the window to hand out more albums than a tick
+    has seconds would run each pass into the next, where the lock refuses it and
+    the excess is dropped anyway. Bounded here, at half a tick's worth of
+    requests, so the drop has a reason rather than being a side effect."""
+    tick = timedelta(minutes=10)
+
+    slice_size = gardener._slice_size(1_000_000, tick=tick, window=timedelta(hours=24))
+
+    assert slice_size <= tick.total_seconds() / 2
+
+
+def test_an_outage_is_not_met_with_a_fresh_slice_every_tick(tmp_path, monkeypatch):
+    """The failure run spans ticks (#349), and has to. It was a local of `sweep`,
+    which was sound while a pass was a hundred albums: five failures in a row
+    ended it. A tick is two or three albums now, so a counter that reset every
+    ten minutes could never reach five — and MusicBrainz being down would be met
+    with a fresh handful of requests every tick, forever, which is the opposite
+    of what the pacing is for.
+
+    Held across ticks, the run reaches the threshold and every later tick ends
+    on its first failure: one request per ten minutes until something answers."""
+    activity_store.init(tmp_path / "activity.db")
+    albums = [
+        _tagged(tmp_path, _release(mbid=f"rel-{i:03d}"), name=f"Album {i}") for i in range(20)
+    ]
+    asked: list[str] = []
+
+    def _down(mbid: str) -> dict:
+        asked.append(mbid)
+        raise mb_lookup.MBError("MusicBrainz is not answering")
+
+    monkeypatch.setattr(mb_lookup, "fetch_release", _down)
+
+    for _ in range(gardener._GIVE_UP_AFTER):
+        gardener.sweep(albums, limit=1)
+    spent_getting_there = len(asked)
+    later = gardener.sweep(albums, limit=10)
+
+    assert spent_getting_there == gardener._GIVE_UP_AFTER
+    assert later.gave_up is True
+    assert later.asked == 1  # the tick ended on its first failure, not its tenth
+
+
+def test_musicbrainz_answering_again_ends_the_back_off(tmp_path, monkeypatch):
+    """Self-healing, and without it the back-off is a one-way door: a wobble
+    during the night would leave every later tick ending on its first album for
+    the life of the process, with the library quietly going stale behind it.
+
+    The proof has to be a **later failure**, not the successful tick. `gave_up`
+    only ever becomes true on a failure, so a tick where everything answered
+    reports False whether the run was cleared or not — asserting on it passes
+    identically with the reset deleted. So: recover, then fail once, and check
+    that one failure is treated as the first of a new run rather than the sixth
+    of the old one."""
+    activity_store.init(tmp_path / "activity.db")
+    albums = [
+        _tagged(tmp_path, _release(mbid=f"rel-{i:03d}"), name=f"Album {i}") for i in range(20)
+    ]
+    failing = True
+
+    def _flaky(mbid: str) -> dict:
+        if failing:
+            raise mb_lookup.MBError("MusicBrainz is not answering")
+        return _release(mbid=mbid)
+
+    monkeypatch.setattr(mb_lookup, "fetch_release", _flaky)
+    for _ in range(gardener._GIVE_UP_AFTER):
+        gardener.sweep(albums, limit=1)
+
+    failing = False
+    gardener.sweep(albums, limit=3)  # MusicBrainz is back
+    failing = True
+    wobble = gardener.sweep(albums, limit=3)
+
+    assert wobble.failed == 3  # all three tried: a new run, not a resumed one
+    assert wobble.gave_up is False
+
+
 def test_two_albums_on_one_release_cost_one_request(tmp_path, monkeypatch):
     """A duplicate rip in two folders (#243) names one release twice. One fetch
     answers for both, and asking again would spend a second rate-limited request
@@ -1039,7 +1188,11 @@ def test_a_musicbrainz_outage_stops_the_pass_rather_than_grinding_through_it(tmp
 
     monkeypatch.setattr(mb_lookup, "fetch_release", _down)
 
-    result = gardener.sweep(albums)
+    # `limit` rather than the derived slice: this is about how a run of failures
+    # is counted, not about how big a tick is, and the derived slice for eight
+    # albums is one — which would make the test pass without ever exercising the
+    # counter.
+    result = gardener.sweep(albums, limit=len(albums))
 
     assert result.gave_up is True
     assert len(asked) == gardener._GIVE_UP_AFTER
@@ -1057,7 +1210,7 @@ def test_a_deleted_release_does_not_count_towards_giving_up(tmp_path, monkeypatc
     ]
     asked = _serving(monkeypatch)  # nothing answers for any of them
 
-    result = gardener.sweep(albums)
+    result = gardener.sweep(albums, limit=len(albums))  # see the outage test above
 
     assert result.gave_up is False
     assert result.gone == len(albums)
@@ -1195,7 +1348,9 @@ def _engaged_timers(cfg, monkeypatch):
     """The periodic tasks the lifespan engages, and the app they tick against.
 
     The actions are captured rather than run, so a test drives a tick when it
-    wants one instead of waiting out an hour-long interval.
+    wants one instead of waiting out the interval. The interval each task was
+    engaged on is captured beside it, under `f"{name} cadence"`, because the
+    lifespan is the only place that decides it.
     """
     from fastapi.testclient import TestClient
 
@@ -1205,6 +1360,7 @@ def _engaged_timers(cfg, monkeypatch):
 
     async def _record(interval, action, *, name, stop_event=None):
         actions[name] = action
+        actions[f"{name} cadence"] = interval
         if stop_event is not None:
             await stop_event.wait()
 
@@ -1233,6 +1389,22 @@ def test_the_update_check_timer_is_engaged_whatever_the_level(engaged, monkeypat
 
     with _engaged_timers(cfg, monkeypatch) as (_app, actions):
         assert "update check" in actions
+
+
+def test_the_check_ticks_on_the_interval_its_slice_is_sized_against(engaged, monkeypatch):
+    """The two halves of the rate have to be the same constant (#349). `sweep`
+    sizes a slice as `SWEEP_TICK / SWEEP_WINDOW` of the queue, which is only the
+    truth if the lifespan schedules it on `SWEEP_TICK` — schedule it on anything
+    else and the pass sweeps at a rate nothing in the code states.
+
+    Nothing else would notice. The pass would still run, still stay inside the
+    rate limit, and still report identical flags; only the *rate* would be
+    wrong, and a rate is not visible in any one pass's result. That is exactly
+    how the constants this replaced drifted to eight times the goal."""
+    cfg, _ = engaged
+
+    with _engaged_timers(cfg, monkeypatch) as (_app, actions):
+        assert actions["update check cadence"] == gardener.SWEEP_TICK
 
 
 def test_turning_the_check_on_takes_effect_without_a_restart(engaged, monkeypatch):


### PR DESCRIPTION
#270's pass stayed inside the documented rate limit but spent its budget in the least neighbourly shape available: ~100 fetches back-to-back at the 1 req/s floor, then 59 minutes of silence, on the hour, forever.

Three constants set the pace and none of them read the others — `RECHECK_AFTER` (the goal), `ALBUMS_PER_PASS` (the cap) and `_UPDATE_CHECK_INTERVAL` (the tick). The arithmetic says the pair was set too high: capacity was 2,400 fetches a day against a demand of ~286 for a 2,000-album library on a weekly recheck. Roughly eight times what the goal needed, delivered in bursts — and the burst echoed itself, because `_due` orders off the fetch times an earlier pass wrote, so everything swept inside one 100-album burst came due again inside one 100-album burst a week later.

## What changed

The rate is derived from the goal instead of picked. `SWEEP_WINDOW` (24h) says how long a full sweep of everything due should take; one tick asks about `tick / window` of the queue. That is self-stabilising in a way a fixed cap is not — a first run with the whole library due gets a proportionally larger slice and still finishes inside the day, while steady state settles at exactly the demand rather than a multiple of it.

`SWEEP_TICK` moves to `gardener` from `web/main.py`, because the constant that *schedules* the pass and the constant the pass *divides by* are the same fact, and keeping them in two modules is how the old pair drifted in the first place. The tick drops to ten minutes: the tick length **is** the burst length, so an hourly tick doing the same daily total would still deliver it twelve requests at a time.

For a 2,000-album library at steady state: from ~100 requests back-to-back hourly to two or three per ten minutes, no burst larger than three.

## No jitter

It was in the first draft and came back out. Two of its three justifications were always weak — a household starting several images on the same minute is close to hypothetical, and nothing here is clock-based. The third, the self-perpetuating weekly echo, looked like the strong one and does not survive the rest of the change: the echo is a property of the *hundred-album* burst. Once a tick stamps two or three albums with the same `fetched_at`, what comes due together a week later is two or three albums — which is exactly what a tick drains anyway. Sizing the slice breaks the pattern; randomising the clock never did. `web/periodic.py` is therefore untouched.

## Two consequences that needed handling

- **The failure run had become dead code.** `consecutive` was a local of `sweep`, sound at a hundred albums a pass and unreachable at three — a counter reset every ten minutes can never reach five, so an outage would have been met with a fresh slice of requests every tick forever. It spans ticks now: the threshold is reached once and every later tick ends on its first failure until something answers, with the loud warning only on the transition.
- **Six times the ticks is six times the log.** The per-tick INFO lines and the two "standing aside" guard lines drop to DEBUG, and the closing summary speaks up only when the tick found something.

## Notes

- **Check now** runs an ordinary tick — a couple of albums, not a sweep. Giving the button its own larger budget would put the burst back in at the one moment somebody is certainly sitting in front of the app, and the press still buys the ten minutes to the next tick.
- `sweep(..., limit=)` no longer has a production caller; it is an override for tests that mean a specific number rather than a rate. Kept because the alternative encodes the cap as two interacting time constants at every call site.
- Nine tests added, all mutation-checked. One of them was wrong and the check caught it: `test_musicbrainz_answering_again_ends_the_back_off` passed with the reset deleted, because `gave_up` only ever goes true on a failure. It now recovers, fails once, and asserts that failure is the first of a new run.

`make check`: exit 0.

Fixes #349