### PR TITLE
Keep the sync checkpoint behind purchases it didn't finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **A purchase a sync couldn't finish with is no longer lost for good.** The
+  sync remembered where it got to as "the newest purchase I saw", not "the
+  newest one I finished with" — so a pre-order Bandcamp wasn't serving yet, or
+  an album deferred by the per-sync download limit, dropped below that mark and
+  was never looked at again, even once released. The mark now stops short of
+  anything still owed, and the sync says so when it finishes: *"1 pre-order not
+  released yet — each sync retries them"* (#351).
+
 - **A release country Picard chose is no longer reported as out of date.**
   Picard writes whichever of the release's countries your
   `preferred_release_countries` setting names, which is rarely MusicBrainz's

--- a/src/harmonist/bandcamp_hook.py
+++ b/src/harmonist/bandcamp_hook.py
@@ -116,6 +116,29 @@ def _case_collision(band_dir: Path) -> Path | None:
     return None
 
 
+def _item_id(item: Any) -> int:
+    """A purchase's Bandcamp item_id as an int, 0 if it has none."""
+    try:
+        return int(getattr(item, "item_id", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _is_preorder(item: Any) -> bool:
+    """True if this purchase is a Bandcamp pre-order.
+
+    `getattr(item, "is_preorder", False)` does NOT do this: BandcampItem's
+    `__getattr__` raises **KeyError** for an absent key, and getattr's default
+    only catches AttributeError. Every live collection item carries the key
+    today, so the difference would only show on a payload that drops it — i.e.
+    it would take the sync down at the exact moment there is least to go on.
+    """
+    try:
+        return bool(item.is_preorder)
+    except (KeyError, AttributeError):
+        return False
+
+
 def construct_bandcamp_url(item: Any) -> str | None:
     """Construct the public Bandcamp album URL from a BandcampItem.
 
@@ -341,6 +364,13 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
         # Genuinely-new albums NOT downloaded this run because the per-sync
         # download limit was reached — i.e. how many remain for the next sync.
         self.skipped_for_limit = 0
+        # Pre-orders Bandcamp won't serve yet (reported by the sync runner, so a
+        # skip that used to be silent is visible in the feed).
+        self.deferred_preorders = 0
+        # item_ids this run SAW but did not finish with — a skipped pre-order, a
+        # purchase deferred by the download cap. The collection checkpoint must
+        # not advance past any of them (#351); see _save_collection_checkpoint.
+        self._unfinished: set[int] = set()
         # Potential downloads accumulated this run (link mode: purchases we
         # couldn't confidently match and so didn't download). Swapped into the
         # module-level in-memory store at the end of the sync.
@@ -372,7 +402,60 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
         if self._link_only:
             log.info("link-only sync: not advancing the collection checkpoint")
             return
-        super()._save_collection_checkpoint()
+        if not self._unfinished:
+            super()._save_collection_checkpoint()
+            return
+        # The parent checkpoints the NEWEST purchase it paged, whatever this run
+        # did with the ones below it — and the next sync stops paginating there.
+        # Anything left undone would drop below that line and never be offered
+        # again: a pre-order the parent skipped is by definition the newest
+        # purchase, so it buries itself, released or not (#351).
+        #
+        # This is upstream's bug (meeb/bandcampsync#69 — same symptom, same
+        # `last_seen_item_id`, same "delete the state file" workaround), fixed
+        # here at the adapter layer because Harmonist has to keep a purchase
+        # reachable regardless. Revisit if upstream lands its own fix.
+        #
+        # Hand the parent a collection truncated to just past the OLDEST
+        # unfinished purchase, so the checkpoint only ever covers finished work.
+        # Truncate rather than write our own state file: dry-run, sync-error and
+        # atomic-write handling stay the parent's, as does the file format.
+        items = list(getattr(self.bandcamp, "collection_items", None) or [])
+        if not items:
+            items = list(getattr(self.bandcamp, "purchases", None) or [])
+        # Bandcamp pages the collection newest → oldest, so the safe checkpoint
+        # is the first purchase OLDER than the oldest unfinished one.
+        cut = max(
+            (i for i, it in enumerate(items) if _item_id(it) in self._unfinished),
+            default=-1,
+        )
+        if cut < 0:
+            super()._save_collection_checkpoint()  # unfinished, but none of them paged
+            return
+        safe = items[cut + 1 :]
+        if not safe:
+            # Nothing paged this run is safe to checkpoint. Leave the existing
+            # one alone — it is older still, so it can only be conservative.
+            log.info(
+                "holding the collection checkpoint: %d purchase(s) left unfinished, "
+                "the oldest of them being the oldest purchase paged this sync",
+                len(self._unfinished),
+            )
+            audit.record("checkpoint.hold", held_for=_item_id(items[cut]), covers="-")
+            return
+        original = self.bandcamp.collection_items
+        self.bandcamp.collection_items = safe
+        try:
+            super()._save_collection_checkpoint()
+        finally:
+            self.bandcamp.collection_items = original
+        log.info(
+            "holding the collection checkpoint at purchase %s: %d newer purchase(s) "
+            "left unfinished this sync and must stay re-pageable",
+            _item_id(safe[0]),
+            len(self._unfinished),
+        )
+        audit.record("checkpoint.hold", held_for=_item_id(items[cut]), covers=_item_id(safe[0]))
 
     async def sync_items(self) -> None:
         # Seed dedup from the in-memory library index FIRST: any purchase whose
@@ -818,11 +901,14 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
             local_path = self.local_media.get_path_for_purchase(item)
             if (
                 not self.ignores.is_ignored(item)
-                and not getattr(item, "is_preorder", False)
+                and not _is_preorder(item)
                 and not getattr(item, "hidden", False)
                 and not self.local_media.is_locally_downloaded(item, local_path)
             ):
                 self.skipped_for_limit += 1
+                # Deferred, not declined — the checkpoint must stay behind it or
+                # "run Sync again" can never reach it (#351).
+                self._unfinished.add(item_id_int)
                 return False
 
         # Detect a case-collision BEFORE the download creates the folder (after,
@@ -831,6 +917,8 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
         local_path = self.local_media.get_path_for_purchase(item)
         collided = _case_collision(local_path.parent)
         result = bool(super().sync_item(item, encoding))
+        if not result:
+            self._note_preorder_deferral(item, local_path)
         if result:
             self.new_items += 1
             # Mint the album's id NOW, before the sidecar exists, so these audit
@@ -865,6 +953,39 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
             else:
                 self._run_post_download(local_path)
         return result
+
+    def _note_preorder_deferral(self, item: Any, local_path: Path) -> None:
+        """Record a purchase the parent skipped because it is an unreleased
+        pre-order — the one skip that is genuinely *owed* rather than declined.
+
+        bandcampsync returns a bare False for it (`sync.py`: `if item.is_preorder`)
+        and says so at INFO on the `sync` logger, which `_configure_logging` pins
+        to WARNING — so today the skip reaches neither the log nor the feed. Mark
+        it unfinished so the collection checkpoint stays behind it and the next
+        sync can retry (#351), and count it so the sync's closing line can say a
+        purchase is still owed.
+
+        Guarded against the parent's *earlier* exits: an ignored, hidden or
+        already-downloaded purchase also returns False, for its own good reasons,
+        and is finished business — holding the checkpoint for one would pin it
+        there for good.
+        """
+        if not _is_preorder(item):
+            return
+        if (
+            self.ignores.is_ignored(item)
+            or getattr(item, "hidden", False)
+            or self.local_media.is_locally_downloaded(item, local_path)
+        ):
+            return
+        self._unfinished.add(_item_id(item))
+        self.deferred_preorders += 1
+        log.info(
+            "pre-order not downloadable yet: %s / %s (item_id=%s) — the next sync retries it",
+            getattr(item, "band_name", "?"),
+            getattr(item, "item_title", "?"),
+            _item_id(item),
+        )
 
     def _run_post_download(self, album_dir: Path) -> None:
         """Invoke the post-download hook (MB auto-resolve). Never aborts sync."""

--- a/src/harmonist/web/sync_runner.py
+++ b/src/harmonist/web/sync_runner.py
@@ -106,6 +106,7 @@ class SyncRunner:
         log.info("sync started")
         new_items = 0
         remaining = 0
+        preorders = 0
         error: str | None = None
         try:
             result = self._runner_fn()
@@ -116,6 +117,10 @@ class SyncRunner:
             )
             # Albums deferred because the per-sync download limit was reached.
             remaining = int(getattr(result, "skipped_for_limit", 0))
+            # Purchases Bandcamp won't serve yet (unreleased pre-orders). The
+            # skip happens inside bandcampsync on a logger we silence, so
+            # without this the sync just reports "0 new items" (#351).
+            preorders = int(getattr(result, "deferred_preorders", 0))
         except Exception as e:
             log.exception("sync failed")
             error = str(e)
@@ -133,4 +138,9 @@ class SyncRunner:
             msg = f"Bandcamp sync finished — {new_items} new item{plural}"
             if remaining:
                 msg += f"; {remaining} more reached the per-sync limit — run Sync again"
+            if preorders:
+                msg += (
+                    f"; {preorders} pre-order{'' if preorders == 1 else 's'} "
+                    "not released yet — each sync retries them"
+                )
             activity.info(msg)

--- a/test/test_bandcamp_hook.py
+++ b/test/test_bandcamp_hook.py
@@ -58,6 +58,19 @@ class _StubItem:
         self.item_title = data.get("item_title", "Test Album")
 
 
+class _KeylessItem(_StubItem):
+    """A purchase whose payload has no `is_preorder` key at all — BandcampItem
+    raises KeyError (not AttributeError) for that, so `getattr(…, default)`
+    does not save you."""
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        del self.is_preorder  # fall through to __getattr__ below
+
+    def __getattr__(self, key):
+        raise KeyError(f'BandcampItem value "{key}" does not exist')
+
+
 # ---------- construct_bandcamp_url ----------
 
 
@@ -212,6 +225,8 @@ def _bare_syncer(max_downloads: int = 5) -> HarmonistSyncer:
     s.new_items = 0
     s.skipped_for_limit = 0
     s._pending_this_run = []
+    s.deferred_preorders = 0
+    s._unfinished = set()
     s._adopt_index = {}
     s._adopt_consumed = set()
     s.bandcamp = MagicMock()
@@ -409,16 +424,141 @@ def test_link_only_does_not_advance_checkpoint(monkeypatch):
     assert saved == []  # parent never reached → checkpoint left as-is
 
 
+def _capture_checkpoint(monkeypatch) -> list[int | None]:
+    """Record the item_id the parent would checkpoint on — i.e. the head of the
+    collection list we hand it. `None` if it was called with nothing to save;
+    an empty capture means it was never reached at all."""
+    seen: list[int | None] = []
+
+    def fake_save(self) -> None:
+        items = list(self.bandcamp.collection_items)
+        seen.append(int(items[0].item_id) if items else None)
+
+    monkeypatch.setattr("harmonist.bandcamp_hook._BCSyncer._save_collection_checkpoint", fake_save)
+    return seen
+
+
 def test_normal_sync_advances_checkpoint(monkeypatch):
+    """Nothing left undone → the checkpoint covers the newest purchase, exactly
+    as bandcampsync would on its own."""
     s = _bare_syncer()
     s._link_only = False
-    saved: list[int] = []
-    monkeypatch.setattr(
-        "harmonist.bandcamp_hook._BCSyncer._save_collection_checkpoint",
-        lambda self: saved.append(1),
-    )
+    s.bandcamp.collection_items = [_StubItem(item_id=i) for i in (30, 20, 10)]
+    seen = _capture_checkpoint(monkeypatch)
     s._save_collection_checkpoint()
-    assert saved == [1]  # parent called → checkpoint advances normally
+    assert seen == [30]  # parent called with the whole collection → newest wins
+
+
+def test_checkpoint_stops_short_of_a_purchase_the_sync_left_undone(monkeypatch):
+    """The checkpoint is where the NEXT sync stops paginating, so it may only
+    cover purchases this run actually finished with. One left undone (a skipped
+    pre-order, a cap deferral) pulls it back to the first purchase older than
+    that one — otherwise it drops below the line and is never paged again (#351)."""
+    s = _bare_syncer()
+    s.bandcamp.collection_items = [_StubItem(item_id=i) for i in (30, 20, 10)]
+    s._unfinished = {20}
+    seen = _capture_checkpoint(monkeypatch)
+    s._save_collection_checkpoint()
+    assert seen == [10]  # 20 stays above the line and gets retried next sync
+
+
+def test_holding_the_checkpoint_is_idempotent(monkeypatch):
+    """The clamp works by handing the parent a truncated collection, so it must
+    put the real one back — otherwise a second save (or anything else reading
+    the collection afterwards) sees only the tail we cut it down to."""
+    s = _bare_syncer()
+    items = [_StubItem(item_id=i) for i in (30, 20, 10)]
+    s.bandcamp.collection_items = items
+    s._unfinished = {20}
+    seen = _capture_checkpoint(monkeypatch)
+    s._save_collection_checkpoint()
+    s._save_collection_checkpoint()
+    assert seen == [10, 10]
+    assert s.bandcamp.collection_items == items  # collection restored, not consumed
+
+
+def test_checkpoint_is_left_alone_when_the_oldest_purchase_is_undone(monkeypatch):
+    """Nothing paged this run is safe to checkpoint → don't write one at all.
+    The existing checkpoint is older still, so leaving it is the safe answer."""
+    s = _bare_syncer()
+    s.bandcamp.collection_items = [_StubItem(item_id=i) for i in (30, 20, 10)]
+    s._unfinished = {10}
+    seen = _capture_checkpoint(monkeypatch)
+    s._save_collection_checkpoint()
+    assert seen == []  # parent never reached
+
+
+def test_a_skipped_preorder_holds_the_checkpoint_back(tmp_path, monkeypatch):
+    """The real #351 sequence: bandcampsync skips a pre-order (downloading
+    nothing, logging at INFO on a logger we silence). It is the newest purchase,
+    so the checkpoint would otherwise land on its own token and bury it — the
+    release date never gets a chance to matter."""
+    s = _bare_syncer()
+    s.local_media.get_path_for_purchase = lambda item: tmp_path / str(item.item_id)
+    s.local_media.is_locally_downloaded = lambda item, path: False
+    s.ignores.is_ignored = lambda item: False
+    # The parent downloads nothing for any of them (it skips the pre-order; the
+    # other two are already on disk) — only the pre-order is UNFINISHED.
+    monkeypatch.setattr(
+        "harmonist.bandcamp_hook._BCSyncer.sync_item",
+        lambda self, item, encoding=None: False,
+    )
+    items = [
+        _StubItem(item_id=30),
+        _StubItem(item_id=20, is_preorder=True),
+        _StubItem(item_id=10),
+    ]
+    s.bandcamp.collection_items = items
+    for item in items:
+        s.sync_item(item)
+    seen = _capture_checkpoint(monkeypatch)
+    s._save_collection_checkpoint()
+    assert seen == [10]  # the pre-order stays above the line
+
+
+def test_a_cap_deferred_purchase_holds_the_checkpoint_back(tmp_path, monkeypatch):
+    """A cap deferral's "run Sync again" is only true if the next sync can still
+    see the deferred purchases. The cap defers the OLDEST purchases, so a capped
+    run must not advance the checkpoint at all."""
+    s = _bare_syncer(max_downloads=2)
+    s.local_media.get_path_for_purchase = lambda item: tmp_path / str(item.item_id)
+    s.local_media.is_locally_downloaded = lambda item, path: False
+    s.ignores.is_ignored = lambda item: False
+    monkeypatch.setattr(
+        "harmonist.bandcamp_hook._BCSyncer.sync_item",
+        lambda self, item, encoding=None: True,
+    )
+    monkeypatch.setattr("harmonist.bandcamp_hook.write_sidecar_for_item", lambda *a, **k: True)
+    items = [_StubItem(item_id=i) for i in (40, 30, 20, 10)]
+    s.bandcamp.collection_items = items
+    for item in items:
+        s.sync_item(item)
+    assert s.skipped_for_limit == 2  # 20 and 10 deferred to the next sync
+    seen = _capture_checkpoint(monkeypatch)
+    s._save_collection_checkpoint()
+    assert seen == []  # checkpoint untouched → the next sync re-pages and finishes
+
+
+def test_an_item_without_an_is_preorder_key_is_not_treated_as_unfinished(tmp_path, monkeypatch):
+    """`BandcampItem.__getattr__` raises KeyError for a missing key, which
+    `getattr(item, "is_preorder", False)` does NOT catch — its default only
+    covers AttributeError. A payload that drops the key must read as "not a
+    pre-order", not crash the sync or pin the checkpoint forever."""
+    s = _bare_syncer()
+    s.local_media.get_path_for_purchase = lambda item: tmp_path / str(item.item_id)
+    s.local_media.is_locally_downloaded = lambda item, path: False
+    s.ignores.is_ignored = lambda item: False
+    monkeypatch.setattr(
+        "harmonist.bandcamp_hook._BCSyncer.sync_item",
+        lambda self, item, encoding=None: False,
+    )
+    items = [_StubItem(item_id=30), _KeylessItem(item_id=20), _StubItem(item_id=10)]
+    s.bandcamp.collection_items = items
+    for item in items:
+        s.sync_item(item)  # must not raise
+    seen = _capture_checkpoint(monkeypatch)
+    s._save_collection_checkpoint()
+    assert seen == [30]  # nothing unfinished → the checkpoint advances normally
 
 
 def test_sync_item_skips_relink_for_already_linked_album(tmp_path, monkeypatch):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6519,6 +6519,43 @@ def test_run_bandcamp_sync_keeps_existing_ignores_file(cfg, monkeypatch):
     assert cfg.ignores_file.read_text() == "12345  # keep me\n"
 
 
+def _sync_finished_message(monkeypatch, **result_fields) -> str:
+    """Run SyncRunner's body against a stub syncer result and return the single
+    Activity line it wrote."""
+    from types import SimpleNamespace
+
+    from harmonist.web.sync_runner import SyncRunner
+
+    said: list[str] = []
+    monkeypatch.setattr("harmonist.activity.info", lambda msg, **kw: said.append(msg))
+    runner = SyncRunner(runner_fn=lambda: SimpleNamespace(**result_fields))
+    runner._run()
+    assert len(said) == 1
+    return said[0]
+
+
+def test_sync_finish_reports_pre_orders_it_could_not_download(monkeypatch):
+    """A pre-order is skipped inside bandcampsync, on a logger we pin to
+    WARNING — so a sync that downloads nothing else reports "0 new items" and
+    the purchase looks lost. Say it is owed and being retried (#351)."""
+    msg = _sync_finished_message(
+        monkeypatch, new_items=0, skipped_for_limit=0, deferred_preorders=1
+    )
+    assert msg == (
+        "Bandcamp sync finished — 0 new items; 1 pre-order not released yet — "
+        "each sync retries them"
+    )
+
+
+def test_sync_finish_says_nothing_about_pre_orders_when_there_are_none(monkeypatch):
+    """The clause only appears when a pre-order was actually deferred — the
+    steady-state line stays as it was."""
+    msg = _sync_finished_message(
+        monkeypatch, new_items=2, skipped_for_limit=0, deferred_preorders=0
+    )
+    assert msg == "Bandcamp sync finished — 2 new items"
+
+
 # ---------- Potential-download actions ----------
 
 


### PR DESCRIPTION
bandcampsync saves the newest purchase it paged as the collection checkpoint, whatever the run did with the ones below it, and the next sync stops paginating there. Anything the run left undone drops below that line and is never paged again.

A pre-order is the case that hurts: bandcampsync skips it (logging at INFO on the `sync` logger, which `_configure_logging` pins to WARNING), and being a fresh purchase it is the newest item — so the checkpoint lands on its own token and the release date never gets a chance to matter. The per-sync download cap has the same shape: it defers the oldest purchases on purpose and promises *"run Sync again"*, which the new checkpoint makes unreachable.

Same defect upstream, independently reported twice: [meeb/bandcampsync#69](https://github.com/meeb/bandcampsync/issues/69), down to *"It is also not part of the ignores.txt"* and "deleted just the state file and it picked it up". Fixed here at the adapter layer regardless — the cap deferral is ours alone.

## What changed

- `HarmonistSyncer` tracks the purchases a run left unfinished (a skipped pre-order, a cap deferral) and hands the parent a collection truncated to just past the **oldest** of them, so the checkpoint only ever covers finished work. If none of it is safe, no checkpoint is written and the existing one — older still — stands.
- Truncate rather than write our own state file: the parent keeps the atomic write, the file format, and its dry-run / sync-error guards. The collection is restored afterwards, so a second save is a no-op rather than clamping again.
- A held checkpoint is audited (`checkpoint.hold`, alongside the existing `checkpoint.clear`), and a deferred pre-order is counted and named in the sync's closing line — the skip reaches the feed instead of being silent.
- `getattr(item, "is_preorder", False)` never defaulted: `BandcampItem.__getattr__` raises `KeyError`, which getattr's default does not catch. Now read through `_is_preorder`.

## Tests

Pure-logic rung — the checkpoint decision is Python with no HTTP in it. Four tests failed first, on the assertion and for the predicted reason; the two written after the code were mutation-checked red, as were the restore-under-`finally` and the KeyError guard.

Fixes #351