### PR TITLE
Let an update be ignored until MusicBrainz moves again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- **An update you don't want can be ignored until MusicBrainz changes again.**
+  The album page now says what to do about an update other than take it: a link
+  to edit the release on MusicBrainz — where a correction belongs, and which
+  Harmonist picks up by itself — and **Ignore for now**, which takes the album
+  out of the **Update available** filter until MusicBrainz next moves the
+  release. It is a bookmark rather than a refusal: your edit landing is what
+  brings the album back. Nothing is written, the tile keeps its **Update** badge,
+  and **Stop ignoring** puts it back in the list at any time (#271).
+
 - **The album page names every country a release came out in.** MusicBrainz
   collapses a release issued in several countries to the one country code the
   tag can hold, so an album issued in Germany, the UK and the US read as though

--- a/docs/design.md
+++ b/docs/design.md
@@ -22,6 +22,36 @@ Concretely, this shows up as:
 
 Besides data loss, **usability is a top-tier concern**, not an afterthought.
 
+### MusicBrainz is canonical
+
+"Source of truth" above is meant literally, and it is the rule that settles a
+whole class of design questions before they are argued: **Harmonist applies what
+MusicBrainz says, and keeps no local exception to it.** If a release's data is
+wrong, the fix is to edit it on MusicBrainz, where it benefits everyone and comes
+back to the files on the next check for free. This is not a general-purpose
+tagger; Picard is that, and Harmonist deliberately does not compete with it.
+
+Two things follow, and both are load-bearing:
+
+- **There is no per-album override.** No "don't apply MusicBrainz's album title
+  to this album", no stored rejection of a particular change. Beyond being
+  against the principle, such a thing cannot be built honestly: what would be
+  overridden is a *diff*, and a diff is not a stable object — it is computed
+  between two moving sides, so it merges and splits as MusicBrainz is edited and
+  as the files change. There is no key that survives. #271 has the long version.
+- **A user can still decline to be nagged.** Ignoring an update (#271) is a
+  *bookmark*, not a rejection: it stops an album being listed as work until
+  MusicBrainz next changes the release, which is exactly what happens when the
+  edit the user went off to make lands. So the escape valve is temporal and
+  self-clearing rather than a permanent exception.
+
+Where Harmonist *does* accept a value MusicBrainz did not state, it is because a
+**rule** says the two spellings mean the same thing — Picard's release
+disambiguation in the album title (§5, #283), a release country Picard chose from
+the release's own events (#329). Those are computed fresh every time from what
+the release itself says, never remembered per album, and each one is a deliberate
+addition to this section rather than a user preference.
+
 ### Non-goals
 
 The following are explicitly out of scope for this prototype:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -243,6 +243,37 @@ you tagged it — each with its count:
   the purple **Update** badge on the tiles. (`level` under `[gardener]` in
   `harmonist.toml` is the same setting, for a config-managed install.)
 
+### When you don't want the update
+
+Harmonist takes MusicBrainz at its word — that is the whole of what it does, and
+it keeps no private exceptions to what MusicBrainz says. So if an update looks
+wrong, the thing to fix is the release, and the album's page links you straight
+to it: **Edit the release**, beside the comparison. Your correction lands where
+everyone benefits from it, and Harmonist picks it up on the next check without
+you having to come back and tell it.
+
+Editing MusicBrainz is not instant, though, and in the meantime the album sits in
+the **Update available** list looking like work. **Ignore for now**, beside that
+link, takes it out of the list. It is not a refusal and it does not silence the
+album for good:
+
+- The album comes back the moment MusicBrainz next changes the release — which is
+  exactly what happens when your edit is accepted. That is the point of it.
+  Harmonist can't tell whose edit landed, so any change to the release brings the
+  album back for another look.
+- Nothing is written. The files, the tags and the album's state are untouched,
+  and the tile keeps its purple **Update** badge — the difference is still real,
+  it just stops presenting itself as something to do. (The **Incomplete** filter
+  behaves the same way for an album you've accepted as finished.)
+- The album's page says it is being ignored, and offers **Stop ignoring** to put
+  it back in the list straight away.
+- Re-tagging clears it too: once the files carry what MusicBrainz says, there is
+  nothing left to be waiting for.
+
+If what you actually want is for whole *kinds* of change to be left alone —
+"don't tell me about ISRCs, but do tell me if a track is retitled" — that is a
+setting rather than a per-album decision, and it is not built yet.
+
 Search and the filters compose: searching inside a filter narrows within it, and
 the chip counts follow the search, so each one tells you what it would actually
 show. When both are on, the box says which filter it's searching inside, and an

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -229,6 +229,56 @@ _MIGRATIONS: tuple[tuple[str, ...], ...] = (
             PRIMARY KEY (mbid, inc)
         )""",
     ),
+    # 7 -> 8: updates the user has asked not to be shown again yet (#271).
+    #
+    # A BOOKMARK, NOT A DECISION, and the distinction is the whole design. An
+    # earlier draft of this table stored a *dismissal* — the user rejecting a
+    # particular set of changes — and it could not be keyed. Key a rejection to
+    # the release version and any unrelated later edit invalidates it, so what
+    # was rejected comes back attached to a change nobody has seen; key it to
+    # the fields instead and it stops being a decision and becomes a local
+    # override list ("never apply MusicBrainz's album title here"), which is a
+    # permanent per-album exception to the canonical source this whole project
+    # is built on (`docs/design.md` §1). There is no third key, because a
+    # divergence is not a thing — it is a diff between two moving sides, and
+    # diffs merge and split.
+    #
+    # Ignoring is a different object and keys cleanly. It says *mute this album
+    # until MusicBrainz moves*, because the answer to disliking what MusicBrainz
+    # says is to go and edit MusicBrainz. So the version below is what the user
+    # is waiting to see change, and an unrelated edit lapsing the ignore is the
+    # FEATURE: something landed upstream, which may well be their own edit, and
+    # nothing here can tell whether it was.
+    #
+    # HERE RATHER THAN IN THE SIDECAR. Ignoring fifty albums would otherwise be
+    # fifty writes into the user's music directory, each an audited
+    # `sidecar.update`, each invalidating a scan-cache entry and kicking the file
+    # watcher's settle timer; and every new sidecar field needs a merge rule for
+    # multi-directory albums (#197). None of this conflicts with review-gate item
+    # 3: the album's STATE stays derived, and what is stored is a decision only
+    # the user could have made.
+    #
+    # NOTHING ELSE IS STORED — not the diff, not its significance, not a label.
+    # All of those are recomputed from the cached release (migration 6->7) plus
+    # the files on disk, which costs no MusicBrainz request and cannot drift out
+    # of step with what the album page shows.
+    #
+    # Keyed by `Album.id`, which for a linked album IS its release MBID
+    # (`scanner._album_id`), so two copies of one release (#243) share a row
+    # exactly as they already share a history and a URL.
+    #
+    # A row whose version MusicBrainz has moved past is inert rather than
+    # deleted: it suppresses nothing, and ignoring again REPLACEs it. Collecting
+    # them would be a scan of the table to save a few dozen bytes.
+    #
+    # No index. One row per ignored album — tens, not thousands.
+    (
+        """CREATE TABLE gardener_ignores (
+            album_id        TEXT PRIMARY KEY,
+            release_version TEXT NOT NULL,
+            ignored_at      TEXT NOT NULL
+        )""",
+    ),
 )
 
 SCHEMA_VERSION = len(_MIGRATIONS)  # the version this build expects/creates
@@ -1021,11 +1071,121 @@ def release_fetch_times(inc: str) -> dict[str, datetime]:
 #     row to drop;
 #   * forcing a re-read — that is `max_age=FRESH`, which REPLACEs the row rather
 #     than leaving a gap, so the album page's "read again" never needs a delete;
-#   * eviction — which #271 argues directly against: once findings exist, a row
-#     is the evidence its finding was raised against, and dropping it leaves a
-#     review whose basis can no longer be shown.
+#   * eviction — which #271 argues directly against: a row is what the review
+#     list recomputes an album's pending changes from, and what an ignore's
+#     version is compared against, so dropping one silently un-ignores the album
+#     and empties its review of any explanation.
 #
 # `clear()` below is the whole of the deletion surface, and it is a teardown.
+
+
+@dataclass(frozen=True)
+class IgnoredUpdate:
+    """An album the user has asked not to be shown an update for yet (#271).
+
+    Three fields and no verdict, because ignoring is a bookmark rather than a
+    judgement: it says *stop showing me this until MusicBrainz moves*, and the
+    version is what "moves" is measured against. Everything about the change
+    itself is recomputed when someone looks.
+    """
+
+    album_id: str
+    #: The version of the release payload that was on offer when they ignored
+    #: it — `gardener.release_version`. The ignore lapses the moment the cached
+    #: payload stops matching this, which is how an upstream edit gets noticed.
+    release_version: str
+    ignored_at: datetime
+
+
+def ignore_update(album_id: str, *, release_version: str) -> None:
+    """Stop showing `album_id`'s update until MusicBrainz moves past this version.
+
+    REPLACE rather than INSERT, because an album is ignored at one version at a
+    time: ignoring again after an upstream edit supersedes the earlier bookmark
+    rather than queueing behind it.
+
+    Best-effort like every write here. The consequence of losing one is bounded
+    and self-correcting — the album keeps appearing in the review list, which is
+    the direction that annoys rather than the direction that hides something —
+    but it is still loud, because a user pressing Ignore and watching the album
+    stay put has no way to find out why.
+    """
+    try:
+        conn = _ensure()
+        with _LOCK:
+            conn.execute(
+                "INSERT OR REPLACE INTO gardener_ignores "
+                "(album_id, release_version, ignored_at) VALUES (?, ?, ?)",
+                (album_id, release_version, datetime.now(UTC).isoformat()),
+            )
+            conn.commit()
+    except sqlite3.Error:
+        log.exception(
+            "activity_store ignore_update(%s) failed — the album will keep being listed",
+            album_id,
+            extra=_QUIET_MIRROR,
+        )
+
+
+def unignore_update(album_id: str) -> bool:
+    """Stop ignoring `album_id`'s update. True if it was being ignored.
+
+    The undo half, and also what a re-tag uses: once the files carry what
+    MusicBrainz says there is nothing left to be waiting for, and a row left
+    behind would mute the NEXT divergence if MusicBrainz happened not to have
+    moved in between.
+
+    Returns False on a store failure too, so a caller never reports an undo it
+    cannot vouch for.
+    """
+    try:
+        conn = _ensure()
+        with _LOCK:
+            cur = conn.execute("DELETE FROM gardener_ignores WHERE album_id = ?", (album_id,))
+            conn.commit()
+            return cur.rowcount > 0
+    except sqlite3.Error:
+        log.exception("activity_store unignore_update(%s) failed", album_id, extra=_QUIET_MIRROR)
+        return False
+
+
+def ignored_updates() -> dict[str, IgnoredUpdate]:
+    """Every ignored album, keyed by album id.
+
+    A dict because the caller is joining it to the live library rather than
+    iterating it in order: the review list has the albums and needs to know
+    which of them to leave out.
+
+    RAISES `StoreUnavailableError` on failure rather than returning `{}`. An
+    empty dict here does not hide anything — it would show MORE than it should,
+    listing albums the user has already asked to be left alone — but it says
+    "nothing is ignored" as a fact, which is the confident lie #104 is about, and
+    the surface can say so instead.
+    """
+    try:
+        conn = _ensure()
+        with _LOCK:
+            rows = conn.execute(
+                "SELECT album_id, release_version, ignored_at FROM gardener_ignores"
+            ).fetchall()
+    except sqlite3.Error as exc:
+        log.exception("activity_store ignored_updates() failed", extra=_QUIET_MIRROR)
+        raise StoreUnavailableError("could not read ignored updates") from exc
+    out: dict[str, IgnoredUpdate] = {}
+    for album_id, version, stamp in rows:
+        try:
+            ignored_at = datetime.fromisoformat(stamp)
+        except (TypeError, ValueError):
+            # An unreadable timestamp: the row still says WHICH version was
+            # ignored, which is the load-bearing half, so it is kept with the
+            # epoch rather than dropped — dropping it would silently un-ignore
+            # an album the user asked to be left alone.
+            log.warning("gardener_ignores row %s has an unreadable stamp", album_id)
+            ignored_at = datetime.fromtimestamp(0, UTC)
+        out[album_id] = IgnoredUpdate(
+            album_id=album_id, release_version=version, ignored_at=ignored_at
+        )
+    return out
 
 
 def clear() -> None:
@@ -1053,6 +1213,11 @@ def clear() -> None:
     would be served a payload fetched for a different catalogue, and be right to
     trust it. Re-fetching costs a request the tests never make anyway, since
     they patch the fetch.
+
+    Ignored updates (#271) go too, and for the sharper version of that reason:
+    they name albums by id in the library being torn down, so one left behind
+    would mute an update on an album that no longer exists — or, after a
+    re-seed, on a different one.
     """
     try:
         conn = _ensure()
@@ -1061,6 +1226,7 @@ def clear() -> None:
             conn.execute("DELETE FROM events")
             conn.execute("DELETE FROM album_aliases")
             conn.execute("DELETE FROM mb_release_cache")
+            conn.execute("DELETE FROM gardener_ignores")
             conn.commit()
     except sqlite3.Error:
         # Swallowed rather than raised: the callers are teardown paths (test

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -1157,10 +1157,13 @@ def ignored_updates() -> dict[str, IgnoredUpdate]:
     which of them to leave out.
 
     RAISES `StoreUnavailableError` on failure rather than returning `{}`. An
-    empty dict here does not hide anything — it would show MORE than it should,
-    listing albums the user has already asked to be left alone — but it says
-    "nothing is ignored" as a fact, which is the confident lie #104 is about, and
-    the surface can say so instead.
+    empty dict here does not hide anything — it shows MORE than it should,
+    listing albums the user has asked to be left alone — but it states "nothing
+    is ignored" as a fact, which is the confident lie #104 is about. Raising puts
+    the choice at the surface, which is where the safe direction is known:
+    `web.main._ignored_updates` falls open, and says so in the log rather than in
+    a banner, because being listed again is a visible symptom the user can act on
+    while a missing album is not.
     """
     try:
         conn = _ensure()

--- a/src/harmonist/formats/owned.py
+++ b/src/harmonist/formats/owned.py
@@ -266,6 +266,42 @@ SIGNIFICANCE: dict[str, Significance] = {
     ARTWORK: Significance.COVER_ART,
 }
 
+#: The tag levels, least far-reaching first — the ordering `Significance`'s
+#: docstring claims, written down so it can be used and checked rather than
+#: merely asserted in prose.
+#:
+#: What needs it: a diff usually contains changes of several kinds at once, and a
+#: finding (#271) records ONE verdict for the album. The verdict is the furthest-
+#: reaching change in the diff, because that is what decides how much of the
+#: album is in question — an ISRC arriving beside a retitle does not make the
+#: retitle an enrichment.
+#:
+#: COVER_ART IS ABSENT, and its absence is the enum's own position: cover art is
+#: "its own level rather than a rank among the others", so it has no place in a
+#: line the others sit on. `ranked` refuses it rather than guessing where it
+#: would go. Nothing is lost today — the gardener plans with `cover_path=None`,
+#: so artwork cannot appear in a diff it classifies (#269 owns art, on its own
+#: cadence) — and when something does classify artwork it will need a verdict of
+#: its own, not a rank pretending to compare with a retitle.
+ORDER: tuple[Significance, ...] = (
+    Significance.COSMETIC,
+    Significance.ENRICHMENT,
+    Significance.STRUCTURE,
+    Significance.IDENTITY,
+)
+
+
+def ranked(significance: Significance) -> int:
+    """How far `significance` reaches, as a sortable number.
+
+    Raises `ValueError` for COVER_ART — see `ORDER`. A caller that can produce
+    one has to say what it means before it can be compared, and the failure to
+    do that must not be silently resolved to "least significant", which is where
+    a `.get(..., 0)` would put it.
+    """
+    return ORDER.index(significance)
+
+
 #: Levels whose changes may be applied without asking anyone.
 #:
 #: **Empty, deliberately.** Every change goes to review, whatever its

--- a/src/harmonist/gardener.py
+++ b/src/harmonist/gardener.py
@@ -38,28 +38,35 @@ That payload comparison still earns its keep as #270's early exit — it decides
 whether recomputing is worth the file reads — but it decides *whether to look*,
 not what the answer is.
 
-## Nothing here is persisted
+## Nothing computed here is persisted
 
-No sidecar field, no table, no lifecycle. The flag is a hint that can be rebuilt
-from durable state at any time (`warm_from_cache`), so there is nothing to
-migrate, nothing to dismiss, and nothing for review-gate item 3 to object to.
-The album's state stays derived.
+No sidecar field, no table. The flag, its significance and the version they were
+reached against are all hints that can be rebuilt from durable state at any time
+(`warm_from_cache`), so there is nothing to migrate and nothing for review-gate
+item 3 to object to. The album's state stays derived.
 
-A finding that a human has to *act* on is a different object with a different
-lifetime, and it lives in `activity.db` (#271). This is only the flag.
+The one thing that IS stored is the one thing nothing can recompute: that the
+user pressed **Ignore**, and which version of the release they pressed it
+against (#271). That is a decision, not a derivation — and deliberately a
+*bookmark* rather than a rejection, because MusicBrainz is canonical
+(`docs/design.md` §1): the answer to disliking what it says is to go and edit it,
+and an ignore exists to keep quiet until that lands. `is_ignored` is the whole
+of the reading side; the flag itself never consults it.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
 import time
-from collections.abc import Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
-from . import album_files, formats, mb_cache, mb_lookup, tagger
+from . import activity_store, album_files, formats, mb_cache, mb_lookup, tagger
 from .formats import owned
 from .models import Album, AlbumState, Release
 
@@ -137,25 +144,98 @@ def plan_for(album: Album, release: Release) -> tagger.AlbumPlan:
     )
 
 
-def refresh_flag(album: Album, release: Release) -> tagger.AlbumPlan | None:
-    """Set `album.update_available` from `release`; return the plan behind it.
+@dataclass(frozen=True)
+class Assessment:
+    """What one look at an album against a release found.
+
+    Two fields, because a caller acting on the answer has to tell three
+    situations apart and neither field can do it alone:
+
+    * `plan` set, `verdict` None — the files already carry what MusicBrainz
+      says. Positively nothing outstanding, which is the only answer that may
+      be used to retire a finding (#271).
+    * `plan` set, `verdict` a level — an update is outstanding, and the level
+      says how far it reaches.
+    * `plan` None — no plan could be built. `verdict` then separates the two
+      ways that happens: STRUCTURE when the release no longer fits the files (a
+      real finding, and one of the loudest things MusicBrainz can do), None when
+      the files could not be READ, which is not an answer at all and must not be
+      mistaken for either of the others.
+    """
+
+    plan: tagger.AlbumPlan | None
+    verdict: owned.Significance | None
+
+
+def _countable(plan: tagger.AlbumPlan) -> Iterator[tuple[str, Any, Any]]:
+    """The entries of `plan` that count as an update, as `(field, before, after)`.
+
+    Not every entry does, since #337. A change that only ADDS a credit list
+    holding one name is one to make while tagging anyway and not a reason to
+    tag: `album_artist` beside it already says the same thing, and a player
+    without the list falls back to the phrase. `albumartists` is new in Picard
+    too, so no existing library carries it — left counted, one field put every
+    album in a real library into the Inbox.
+
+    Filtered HERE rather than in `owned.diff`, and that is the whole of the
+    design: `plan.changes` is also what the activity record and the undo are
+    built from, so a re-tag that fills the tag in must still say that it did.
+    The album page keeps showing it as a pending change for the same reason —
+    the page says what a re-tag would do, this says whether you need one.
+
+    One definition for the flag and the verdict both, so an album cannot be
+    flagged for a change no finding can be raised about, or raised about a
+    change the Library never showed.
+    """
+    for changes in plan.changes.values():
+        for field, (before, after) in changes.items():
+            if not owned.is_opportunistic(field, before, after):
+                yield field, before, after
+
+
+def verdict_for(plan: tagger.AlbumPlan) -> owned.Significance | None:
+    """How far the outstanding change in `plan` reaches, or None if none does.
+
+    The **furthest-reaching** entry wins (`owned.ORDER`), because that is what
+    decides how much of the album is in question: an ISRC arriving beside a
+    retitle does not make the retitle an enrichment.
+
+    A `KeyError` from an unclassified field and a `ValueError` from artwork both
+    propagate, and neither is defended against here. Artwork cannot reach this:
+    `plan_for` passes `cover_path=None`, so `_changes_for` records no `ARTWORK`
+    entry (#269 owns cover art, on its own cadence and its own budget). If one
+    ever did arrive it would need a verdict of its own rather than a rank
+    pretending to compare with a retitle — so the loud failure is the correct
+    outcome, and the pass's boundary catch turns it into one.
+    """
+    levels = [
+        tagger.significance_of(field, before, after) for field, before, after in _countable(plan)
+    ]
+    return max(levels, key=owned.ranked) if levels else None
+
+
+def refresh_flag(album: Album, release: Release) -> Assessment:
+    """Set `album`'s update fields from `release`; return what was found.
+
+    Three fields move together and are meant to be read together:
+    `update_available` (is there anything to take), `update_significance` (how
+    far it reaches), and `mb_version` (which payload both of those are true of).
+    Setting them apart is how the Library would come to show a verdict from one
+    release beside a version from another.
 
     The tolerant wrapper every caller uses. A file that cannot be read leaves
-    the flag **as it was** rather than clearing it: the album page's comparison
+    them **as they were** rather than clearing them: the album page's comparison
     and the warm-up both run against libraries on network mounts, and a blinking
     mount must not quietly empty the filter. Under-reporting is the direction
     this feature fails in by design (see `Album.update_available`).
 
-    **A None is not "nothing to take".** It means no plan could be built — the
-    files could not be read, or the release no longer fits them — and in the
-    second of those the flag is set to True. Read the verdict off
-    `album.update_available`; the return value is only for callers that want to
-    *show* the difference, and there is nothing to show in either case. (The
-    structural case is not left unexplained: the album page reports it through
-    `_shape_mismatch` and `absent_media`, which say far more about it than a
-    field diff could.)
+    **A missing plan is not "nothing to take"**, and the two ways of missing one
+    are not the same either — see `Assessment`, which is the whole reason this
+    returns one rather than the plan alone. (The structural case is not left
+    unexplained on screen: the album page reports it through `_shape_mismatch`
+    and `absent_media`, which say far more about it than a field diff could.)
 
-    Mutating the Album in place is what makes the flag visible to the Library:
+    Mutating the Album in place is what makes this visible to the Library:
     `ScanRunner.albums()` hands out the live snapshot, so this is the same
     object the grid will render.
     """
@@ -163,32 +243,21 @@ def refresh_flag(album: Album, release: Release) -> tagger.AlbumPlan | None:
         plan = plan_for(album, release)
     except tagger.TagMismatchError:
         album.update_available = True
-        return None
+        album.update_significance = owned.Significance.STRUCTURE
+        album.mb_version = release_version(release)
+        return Assessment(plan=None, verdict=owned.Significance.STRUCTURE)
     except formats.READ_ERRORS:
         # Loud, per the unattended rule: at 3am the log is the only channel.
         # ERROR rather than WARNING — nothing recovered, we simply cannot say
         # whether this album has an update, and it will keep reporting whatever
         # it last said until something can read it.
         log.exception("could not tell whether %s has a tag update available", album.path)
-        return None
-    # Not `bool(plan.changes)` since #337. A change that only ADDS a credit list
-    # holding one name is one to make while tagging anyway and not a reason to
-    # tag: `album_artist` beside it already says the same thing, and a player
-    # without the list falls back to the phrase. `albumartists` is new in Picard
-    # too, so no existing library carries it — left counted, one field put every
-    # album in a real library into the Inbox.
-    #
-    # Filtered HERE rather than in `owned.diff`, and that is the whole of the
-    # design: `plan.changes` is also what the activity record and the undo are
-    # built from, so a re-tag that fills the tag in must still say that it did.
-    # The album page keeps showing it as a pending change for the same reason —
-    # the page says what a re-tag would do, this flag says whether you need one.
-    album.update_available = any(
-        not owned.is_opportunistic(field, before, after)
-        for changes in plan.changes.values()
-        for field, (before, after) in changes.items()
-    )
-    return plan
+        return Assessment(plan=None, verdict=None)
+    verdict = verdict_for(plan)
+    album.update_available = verdict is not None
+    album.update_significance = verdict
+    album.mb_version = release_version(release)
+    return Assessment(plan=plan, verdict=verdict)
 
 
 def warm_from_cache(albums: Sequence[Album], *, duty: float = WARM_DUTY) -> int:
@@ -444,13 +513,18 @@ def sweep(
     recently, and update their flags from what comes back.
 
     The scheduled half of #32, and **detect-only**: it fetches, compares and
-    sets `album.update_available`, and writes nothing to anybody's files. That
-    is not a stage of a plan, it is what the classifier currently permits —
-    `owned.AUTO_APPLY` is empty, so every change needs a person, and until #271
-    gives a finding somewhere to live there is nothing for this to hand one to.
-    Two things fall out of that: the pass cannot damage a library, and its whole
-    value is that the Library's Update available filter stops depending on
-    somebody having happened to open the album (#287, #293).
+    sets `album.update_available` and `album.update_significance`, and writes
+    nothing to anybody's files. That is not a stage of a plan, it is what the
+    classifier currently permits — `owned.AUTO_APPLY` is empty, so every change
+    needs a person. Two things fall out of that: the pass cannot damage a
+    library, and its whole value is that the Library's Update available filter
+    stops depending on somebody having happened to open the album (#287, #293).
+
+    **It keeps asking about an album the user has ignored** (#271), which is not
+    an oversight. Ignoring says *mute this until MusicBrainz moves*, so asking
+    is the only thing that can ever un-mute it. Nothing about an ignore is read
+    here: the flag stays a plain fact about the files against MusicBrainz, and
+    the surfaces subtract the ignored albums when they draw themselves.
 
     **The early exit is the design.** The stored payload is read BEFORE the
     fetch, and an unchanged one ends the album there — no file reads, no plan,
@@ -596,6 +670,11 @@ def _due(
     in two folders (#243), or one album split across directories that resolved
     apart. One fetch answers for all of them, and asking twice would spend a
     second rate-limited request on a payload we already have in hand.
+
+    An album whose update the user has ignored (#271) is still due, and that is
+    the point of ignoring rather than dismissing: what they are waiting for is
+    MusicBrainz to move, and asking is the only way anyone finds out that it
+    has.
     """
     times = mb_cache.fetch_times()
     by_release: dict[str, list[Album]] = {}
@@ -616,6 +695,27 @@ def _due(
         due.append((last or _NEVER, mbid, group))
     due.sort(key=lambda item: item[0])
     return [(mbid, group) for _, mbid, group in due]
+
+
+def is_ignored(album: Album, ignored: Mapping[str, activity_store.IgnoredUpdate]) -> bool:
+    """Whether the user's Ignore for `album` still holds (#271).
+
+    It holds exactly while MusicBrainz has not moved: the stored version is what
+    was on offer when they pressed Ignore, and `album.mb_version` is what is on
+    offer now. An edit upstream makes those differ and the album comes back —
+    which is the whole point, because the reason to ignore an update is that you
+    are off to go and fix the release, and this is how you find out that
+    something landed.
+
+    Compared against the in-memory version rather than re-reading and re-hashing
+    the cached payload, so a Library grid of two thousand tiles costs two
+    thousand string compares rather than two thousand database reads.
+
+    An album with no `mb_version` — never looked at, or looked at and unreadable
+    — is never ignored. It is not flagged either, so there is nothing to mute.
+    """
+    entry = ignored.get(album.id)
+    return entry is not None and entry.release_version == album.mb_version
 
 
 def _last_look(mbid: str, times: dict[str, datetime]) -> datetime | None:
@@ -642,7 +742,7 @@ def _same_release(before: Release, after: Release) -> bool:
     silently skips an album that might have an update outstanding.
     """
     try:
-        return json.dumps(before, sort_keys=True) == json.dumps(after, sort_keys=True)
+        return _canonical(before) == _canonical(after)
     except (TypeError, ValueError):
         log.warning(
             "update check: could not compare release payloads; reading the files instead",
@@ -650,3 +750,48 @@ def _same_release(before: Release, after: Release) -> bool:
             extra={"_diagnostic": True},
         )
         return False
+
+
+def _canonical(release: Release) -> str:
+    """`release` as the exact string `activity_store.store_release` would write.
+
+    `sort_keys=True` is what makes a stored payload compare equal to the fresh
+    fetch it came from, so it is borrowed from the store rather than chosen
+    here. Raises `TypeError` / `ValueError` on a payload that will not
+    serialise; both callers below decide for themselves what that means.
+    """
+    return json.dumps(release, sort_keys=True)
+
+
+def release_version(release: Release) -> str | None:
+    """A short, stable name for exactly this version of a release payload.
+
+    What a finding is judged against (#271), and the whole of how suppression
+    stays honest: a dismissal remembers the version the user declined, so it
+    lapses precisely when MusicBrainz moves the release and not before, and an
+    open finding whose cached payload no longer matches its version is
+    detectably stale rather than silently describing a change nobody is looking
+    at any more.
+
+    A content hash rather than anything MusicBrainz supplies, because it supplies
+    nothing that would do: a release has no version counter, and its edit history
+    is a separate request per release — the one thing this feature cannot spend.
+
+    Truncated to 16 hex characters. This names one release's own payloads across
+    a handful of versions, not a global namespace, so 64 bits is far past enough
+    and the untruncated digest would only make the row harder to read in a
+    `sqlite3` shell.
+
+    None when the payload will not serialise, which means it cannot be named —
+    and a finding that cannot say what it was judged against is worse than no
+    finding, since it could never be retired or re-raised correctly.
+    """
+    try:
+        return hashlib.sha256(_canonical(release).encode()).hexdigest()[:16]
+    except (TypeError, ValueError):
+        log.warning(
+            "update check: could not name this version of a release payload",
+            exc_info=True,
+            extra={"_diagnostic": True},
+        )
+        return None

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -390,6 +390,26 @@ class Album:
     # and starts False again, which is the self-invalidation we want: a re-tag
     # that took the update clears the flag by construction.
     update_available: bool = False
+    # How far the outstanding update reaches — `owned.Significance` (#271). Set
+    # by the same `gardener.refresh_flag` call as the flag beside it, from the
+    # same plan, so the two can never describe different releases. None when
+    # there is nothing outstanding, and None on a cold start for the same
+    # reason the flag is False.
+    #
+    # Derived and unpersisted, like the flag: it is what the review list sorts
+    # and groups by, and it is rebuilt from the cached release payloads at
+    # startup at the cost of no MusicBrainz requests at all.
+    update_significance: str | None = None
+    # Which version of the cached MusicBrainz payload the two fields above were
+    # computed against — `gardener.release_version`. None until something has
+    # looked.
+    #
+    # Load-bearing for Ignore (#271): ignoring an update records the version it
+    # was ignored at, and the ignore holds only while this still matches. Kept
+    # here rather than re-derived at render time so deciding whether a tile is
+    # muted is a string compare rather than a database read and a hash, which at
+    # Library scale is the difference between free and unusable.
+    mb_version: str | None = None
 
     @property
     def folders(self) -> tuple[Path, ...]:
@@ -397,6 +417,18 @@ class Album:
         every test fixture that constructs one by hand, and every caller that
         predates #197."""
         return self.paths or (self.path,)
+
+    @property
+    def label(self) -> str:
+        """ "Artist — Title", for anything that has to name this album in prose.
+
+        Chiefly the `album_label` column: events and gardener findings both
+        freeze a label at write time, because ids move and albums leave the
+        library, and a record that can no longer be read is not a record.
+
+        The dash goes when one half is missing, so an album with no artist yet
+        reads as its title rather than as "— Title"."""
+        return f"{self.artist} — {self.title}".strip(" —")
 
 
 # ---------------------------------------------------------------------------

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -4049,7 +4049,7 @@ def _register_routes(app: FastAPI) -> None:
         # Costs one read per file on top of the comparison, which is affordable
         # on a page the user asked for and is exactly why the Library's own
         # render cannot do this for every tile.
-        plan = gardener.refresh_flag(album, release)
+        plan = gardener.refresh_flag(album, release).plan
         ctx = _ctx(
             request,
             album=album,

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -14,7 +14,7 @@ import re
 import sys
 import threading
 import unicodedata
-from collections.abc import AsyncIterator, Callable, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager, suppress
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -199,12 +199,59 @@ def _is_actionable_incomplete(a: Album) -> bool:
     )
 
 
-_LIBRARY_FILTERS: dict[str, tuple[str, Callable[[Album], bool]]] = {
-    "incomplete": ("Incomplete", _is_actionable_incomplete),
-    "partial": ("Partially tagged", lambda a: a.partial_tag_count is not None),
-    "no-artwork": ("No artwork", lambda a: not a.has_cover),
-    "update-available": ("Update available", lambda a: a.update_available),
+def _library_filters(
+    ignored: Mapping[str, activity_store.IgnoredUpdate],
+) -> dict[str, tuple[str, Callable[[Album], bool]]]:
+    """The filter chips, in the order the control offers them.
+
+    A function of this render's ignored updates rather than a constant, because
+    one of the four is: an album whose update the user has ignored (#271) is not
+    listed as work until MusicBrainz moves the release again.
+
+    Only the FILTER subtracts them. The tile keeps its Update badge, exactly as
+    an album accepted with `tracks_unavailable` keeps its Incomplete one — the
+    difference is still a true fact about the album, and hiding a fact is a
+    different act from not presenting it as something to do.
+    """
+    return {
+        "incomplete": ("Incomplete", _is_actionable_incomplete),
+        "partial": ("Partially tagged", lambda a: a.partial_tag_count is not None),
+        "no-artwork": ("No artwork", lambda a: not a.has_cover),
+        "update-available": (
+            "Update available",
+            lambda a: a.update_available and not gardener.is_ignored(a, ignored),
+        ),
+    }
+
+
+#: The slugs the filter control accepts, and the label each one renders under.
+#: Split out because two readers need only this half — validating a query
+#: parameter and titling a filtered grid — and neither has an ignore map to
+#: hand, nor any use for one.
+_LIBRARY_FILTER_LABELS: dict[str, str] = {
+    slug: label for slug, (label, _) in _library_filters({}).items()
 }
+
+
+def _ignored_updates() -> dict[str, activity_store.IgnoredUpdate]:
+    """The user's ignored updates, or an empty map when the store cannot answer.
+
+    **Falls open**, and the direction is the whole of the judgement. An empty map
+    lists albums the user has asked to be left alone, which is annoying and
+    visible and recoverable by pressing Ignore again; a map that wrongly said
+    "ignored" would hide real work with no symptom at all. So the failure that
+    shows too much is the one to take.
+
+    Loud in the log rather than on the page: the surface it degrades is a filter
+    count, and a banner over the Library saying a table could not be read is a
+    worse answer than the Library simply being complete.
+    """
+    try:
+        return activity_store.ignored_updates()
+    except activity_store.StoreUnavailableError:
+        log.exception("could not read which updates are ignored — listing them all this time")
+        return {}
+
 
 # When reading one album's tags is slow enough to say so (#300). Generous: this
 # is every file in the album opened and parsed, so a long album on a modest NAS
@@ -1139,6 +1186,18 @@ def _completeness_oob(request: Request, album: Album) -> str:
     return template.render(_ctx(request, album=album, oob=True))
 
 
+def _update_ignore_oob(request: Request, album: Album, *, ignored: bool) -> str:
+    """The album page's Ignore block, as an out-of-band swap (#271).
+
+    The album passed in must carry the flag and the version as they are AFTER
+    whatever just changed, since that is what the block reads. Renders to an
+    empty wrapper when there is no update to act on, which is what clears the
+    block after a re-tag has taken one.
+    """
+    template = _templates(request).env.get_template("partials/_update_ignore.html")
+    return template.render(_ctx(request, album=album, update_ignored=ignored))
+
+
 def _update_check_oob(request: Request, outcome: str, *, ok: bool) -> str:
     """The background update check's note + Check now button, as an out-of-band
     swap carrying what the press just produced (#312).
@@ -1218,7 +1277,7 @@ def _library_filter(value: str | None) -> str | None:
     is. An unrecognised value degrades to All rather than to an empty grid: a slug
     from an older build, or a mangled link, should show the reader their library.
     """
-    return value if value in _LIBRARY_FILTERS else None
+    return value if value in _LIBRARY_FILTER_LABELS else None
 
 
 def _library_search(value: str | None) -> str | None:
@@ -1341,12 +1400,16 @@ def _library_page_vars(
     # different population than selecting it would show. Computed on every render,
     # filtered or not — an option worth 0 albums should say so before it's picked
     # rather than answering with an empty grid.
+    # One read for the whole render, so the chip's count and the grid it yields
+    # are drawn from the same answer — two reads either side of a press would let
+    # the count and the grid disagree by one.
+    library_filters = _library_filters(_ignored_updates())
     filters = [
         {"slug": slug, "label": label, "count": sum(1 for a in done if pred(a))}
-        for slug, (label, pred) in _LIBRARY_FILTERS.items()
+        for slug, (label, pred) in library_filters.items()
     ]
     if filter_ is not None:
-        done = [a for a in done if _LIBRARY_FILTERS[filter_][1](a)]
+        done = [a for a in done if library_filters[filter_][1](a)]
     limit = max(1, min(limit, _LIBRARY_LIMIT_MAX))  # clamp; defensive
     total_pages = max(1, -(-len(done) // limit))  # ceil; always at least one page
     # `anchor` is the 1-based position of the first album on screen at the moment
@@ -1394,7 +1457,7 @@ def _library_page_vars(
         # Its human label, for the sentence the search box uses to say what it is
         # searching over. Resolved here so the template doesn't have to hunt through
         # `filters` for the active one (#180).
-        "filter_label": _LIBRARY_FILTERS[filter_][0] if filter_ else None,
+        "filter_label": _LIBRARY_FILTER_LABELS[filter_] if filter_ else None,
         "filters": filters,
         # The search query, normalised — None means no search. Rides in every URL
         # this page builds, and is echoed back into the box (#180).
@@ -3038,7 +3101,17 @@ def _tag_with_release(
         video_media=mb_lookup.video_media_of(release),
     )
     sidecar_mod.write(album_path, new)
+    # The files now carry what MusicBrainz says, so there is nothing left to be
+    # waiting for and an Ignore has nothing to mute (#271). Left behind, it would
+    # mute the NEXT divergence on this album if MusicBrainz happened not to have
+    # moved in between — an external re-tag in Picard is the way that happens.
+    #
+    # Under BOTH ids, because a merge moves the album's identity right here: the
+    # bookmark was written under the id the user was looking at, which is the one
+    # that was requested rather than the one that came back.
+    activity_store.unignore_update(mbid)
     if mbid != requested_mbid:
+        activity_store.unignore_update(requested_mbid)
         _record_merge(album_path, requested_mbid, mbid)
     _claim_pending_by_store_url(store_url)
 
@@ -4053,6 +4126,10 @@ def _register_routes(app: FastAPI) -> None:
         ctx = _ctx(
             request,
             album=album,
+            # Read AFTER `refresh_flag`, which is what sets `album.mb_version` —
+            # the thing an ignore is compared against. Reading it before would
+            # ask whether the ignore holds for the payload we had a moment ago.
+            update_ignored=gardener.is_ignored(album, _ignored_updates()),
             comparison=comparison,
             tracklist=tracks,
             absent_media=_absent_media_summary(album, release),
@@ -4908,6 +4985,81 @@ def _register_routes(app: FastAPI) -> None:
             "Accepted as complete" if accept else "Back in the Incomplete list",
             album=album,
             oob=_completeness_oob(request, replace(album, sidecar=updated)),
+        )
+
+    @app.post("/library/{album_id}/ignore-update", response_class=HTMLResponse)
+    def ignore_update(request: Request, album_id: str) -> Response:
+        """Stop listing this album's update until MusicBrainz changes the release.
+
+        A bookmark, not a refusal, and the wording of every surface says so
+        (#271). MusicBrainz is canonical — Harmonist keeps no local exception to
+        what it says — so the answer to an update you disagree with is to edit
+        the release, and this is how you stop being asked about it in the
+        meantime. The edit landing is exactly what brings the album back.
+
+        Recorded against `album.mb_version`, which is the version of the cached
+        payload the flag was last computed from. Refused when there isn't one:
+        nothing has compared this album yet, so there is no update on offer and
+        nothing to be ignoring — and a bookmark against no version could never
+        lapse, which would make the mute permanent.
+
+        Writes nothing to the album. The files, the sidecar and the derived state
+        are all untouched; the flag stays true, because it is a fact about the
+        files against MusicBrainz rather than a piece of work. Only the Library's
+        filter and this block change.
+        """
+        album = _find_album(request, album_id)
+        if not album.update_available or album.mb_version is None:
+            return _flash_response(
+                "Nothing to ignore",
+                "no update is outstanding for this album",
+                level=Level.WARNING,
+                album=album,
+                tasks_changed=False,
+            )
+        activity_store.ignore_update(album.id, release_version=album.mb_version)
+        # The Library's filter counts change and nothing else does — no state
+        # moved, so there is no `live_counts` adjustment to make. Refresh the
+        # snapshot in one render rather than letting the async rescan dim the
+        # page (#11).
+        runner = request.app.state.scan_runner
+        if runner.is_engaged():
+            runner.refresh_now()
+        request.state.skip_rescan = True
+        return _flash_response(
+            "Ignored",
+            "listed again when MusicBrainz next changes the release",
+            album=album,
+            oob=_update_ignore_oob(request, album, ignored=True),
+        )
+
+    @app.post("/library/{album_id}/unignore-update", response_class=HTMLResponse)
+    def unignore_update(request: Request, album_id: str) -> Response:
+        """Take back an Ignore — the escape hatch out of the one state this
+        feature can put an album in (#271).
+
+        Unconditional, unlike its opposite. Ignoring needs an update on offer to
+        bookmark; un-ignoring is undoing a bookmark, and refusing it on an album
+        whose flag happens to read False right now would leave the row in place
+        with no control anywhere that could remove it.
+        """
+        album = _find_album(request, album_id)
+        if not activity_store.unignore_update(album.id):
+            return _flash_response(
+                "Not ignored",
+                "this album's updates were already being listed",
+                level=Level.WARNING,
+                album=album,
+                tasks_changed=False,
+            )
+        runner = request.app.state.scan_runner
+        if runner.is_engaged():
+            runner.refresh_now()
+        request.state.skip_rescan = True
+        return _flash_response(
+            "Listing updates again",
+            album=album,
+            oob=_update_ignore_oob(request, album, ignored=False),
         )
 
     @app.post("/surrender/{album_id}/keep", response_class=HTMLResponse)

--- a/templates/partials/_update_ignore.html
+++ b/templates/partials/_update_ignore.html
@@ -1,0 +1,63 @@
+{# What to do about an update, other than take it (#271).
+
+   Sits directly under the MusicBrainz note, which is the sentence it answers:
+   the note says the files and the release differ, **Re-tag from MB** in the
+   panel's actions row takes the change, and this offers the other two things a
+   person might reasonably want instead.
+
+   THE FIRST IS THE POINT, and it is a link rather than a button. MusicBrainz is
+   canonical here (docs/design.md §1) — Harmonist applies what it says and does
+   not keep local exceptions to it — so "this update is wrong" is not a fact
+   about the album, it is MusicBrainz being wrong, and the fix is upstream where
+   it benefits everyone and comes back on the next check for free.
+
+   THE SECOND IS IGNORE, and it is deliberately a bookmark rather than a
+   refusal. It mutes this album until MusicBrainz moves, which is what makes it
+   safe to offer at all: the edit the user goes off to make is exactly what
+   brings the album back, and nothing here has to remember a decision about a
+   diff that will not exist next week. See the 7->8 migration in
+   `activity_store` for why the refusal version could not be built.
+
+   Out of band, and empty at page build, for the same reason as the note above
+   it: whether there is an update at all comes from the /compare fetch that
+   lands after the page. An empty wrapper is also how a block that no longer
+   applies gets cleared — after a re-tag, or after MusicBrainz moved and the
+   difference went away. #}
+<div id="album-update-ignore-{{ album.id }}" hx-swap-oob="true">
+    {% if album.update_available and album.sidecar and album.sidecar.mb_release_id %}
+    <div class="mt-2 text-2xs text-muted">
+        {% if update_ignored %}
+        {# Stated as the promise rather than as the state, because the promise is
+           the part that is hard to guess: "ignored" alone reads as "silenced",
+           and someone who believed that would have no reason ever to press it. #}
+        <span>
+            Ignored — this won't be listed as an update again until MusicBrainz
+            changes the release.
+        </span>
+        <button hx-post="/library/{{ album.id }}/unignore-update"
+                hx-swap="none" hx-disabled-elt="this"
+                class="ml-1 underline hover:text-ink transition"
+                title="List this album's update again, whether or not MusicBrainz has changed since"
+                aria-label="Stop ignoring this update">Stop ignoring</button>
+        {% else %}
+        <span>
+            Not what MusicBrainz should say?
+            <a href="https://musicbrainz.org/release/{{ album.sidecar.mb_release_id }}/edit"
+               target="_blank" rel="noopener"
+               class="text-mb-purple hover:underline"
+               title="Edit this release on MusicBrainz. Harmonist takes what MusicBrainz says, so a correction made there is what reaches your files.">Edit the release</a>,
+            and the next check will pick your edit up.
+        </span>
+        {# Subtle, per web-ui rule 4: this is the rarer of the two answers, and
+           the common one — Re-tag from MB — is already the panel's primary
+           action. No hx-confirm: nothing is written, and Stop ignoring puts it
+           back. #}
+        <button hx-post="/library/{{ album.id }}/ignore-update"
+                hx-swap="none" hx-disabled-elt="this"
+                class="ml-1 underline hover:text-ink transition"
+                title="Stop listing this album as having an update. It comes back by itself when MusicBrainz next changes the release — so this is how you wait for an edit to land, not how you refuse one."
+                aria-label="Ignore this update until MusicBrainz changes the release">Ignore for now</button>
+        {% endif %}
+    </div>
+    {% endif %}
+</div>

--- a/templates/partials/library_compare.html
+++ b/templates/partials/library_compare.html
@@ -17,6 +17,7 @@
    re-read (#355). #}
 {% include 'partials/_tracks_section.html' %}
 {% include 'partials/_mb_note.html' %}
+{% include 'partials/_update_ignore.html' %}
 {% with oob = true %}{% include 'partials/_checked_at.html' %}{% endwith %}
 
 {# The part of a waiting re-tag that has nowhere else on this page to appear

--- a/templates/partials/library_detail.html
+++ b/templates/partials/library_detail.html
@@ -244,6 +244,11 @@
                note is a finding, and an empty space says "not yet" where "Checking
                tags…" in the panel's middle would read as the album's state. #}
             <div id="album-mb-note-{{ album.id }}"></div>
+            {# What to do about an update other than take it (#271) — edit the
+               release upstream, or ignore it until MusicBrainz moves. Empty here
+               for the same reason the note above is: both halves of whether
+               there IS an update come from the /compare fetch. #}
+            <div id="album-update-ignore-{{ album.id }}"></div>
         </div>
     </div>
 

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -994,3 +994,95 @@ def test_clear_empties_the_release_cache_too():
 
     assert activity_store.cached_release("rel-4", "media") is None
     assert activity_store.cached_release("rel-4", "url-rels") is None
+
+
+# ---------------------------------------------------------------------------
+# Ignored updates (#271)
+# ---------------------------------------------------------------------------
+
+
+def test_an_ignored_update_reads_back_with_the_version_it_was_ignored_at():
+    """The version is the whole of the record. Without it an ignore could never
+    lapse, and muting an album forever is precisely what this must not do."""
+    activity_store.ignore_update("rel-1", release_version="v1")
+
+    stored = activity_store.ignored_updates()["rel-1"]
+
+    assert stored.album_id == "rel-1"
+    assert stored.release_version == "v1"
+    assert stored.ignored_at is not None
+
+
+def test_ignoring_again_moves_the_bookmark_rather_than_adding_one():
+    """MusicBrainz moved and the user ignored the new state of things too. One
+    album is ignored at one version — a second row would leave the older
+    bookmark able to mute an update that has already been superseded."""
+    activity_store.ignore_update("rel-1", release_version="v1")
+
+    activity_store.ignore_update("rel-1", release_version="v2")
+
+    stored = activity_store.ignored_updates()
+    assert list(stored) == ["rel-1"]
+    assert stored["rel-1"].release_version == "v2"
+
+
+def test_un_ignoring_removes_the_bookmark():
+    """Both the undo and what a re-tag uses: once the files carry what
+    MusicBrainz says there is nothing left to be waiting for."""
+    activity_store.ignore_update("rel-1", release_version="v1")
+
+    assert activity_store.unignore_update("rel-1") is True
+    assert activity_store.ignored_updates() == {}
+    assert activity_store.unignore_update("rel-1") is False
+
+
+def test_a_failed_read_says_so_rather_than_reporting_nothing_ignored():
+    """It would show more than it should rather than less — but it would state
+    "nothing is ignored" as a fact, which is the confident lie #104 is about.
+    The surface can say it doesn't know instead."""
+    activity_store.ignore_update("rel-1", release_version="v1")
+    activity_store._conn.close()  # as a locked or corrupt database presents
+
+    with pytest.raises(activity_store.StoreUnavailableError):
+        activity_store.ignored_updates()
+
+
+def test_clear_drops_ignored_updates_too():
+    """They name albums by id in the library being torn down, so one left
+    behind would mute an update on an album that no longer exists — or, after a
+    re-seed, on a different one."""
+    activity_store.ignore_update("rel-1", release_version="v1")
+
+    activity_store.clear()
+
+    assert activity_store.ignored_updates() == {}
+
+
+def test_migrates_a_v7_database_in_place_keeping_its_rows(tmp_path):
+    """7 -> 8 (gardener_ignores): gains the table in place and keeps existing
+    rows. Nothing is back-filled — nobody could have ignored an update before
+    there was a button for it, and a library upgrading into this simply has
+    none until someone presses one."""
+    db = tmp_path / "v7.db"
+    conn = sqlite3.connect(db, isolation_level=None)
+    for step in activity_store._MIGRATIONS[:7]:
+        for stmt in step:
+            conn.execute(stmt)
+    conn.execute(
+        "INSERT INTO events (ts, level, source, message, album_id) VALUES (?, ?, ?, ?, ?)",
+        ("2026-07-01T00:00:00+00:00", "info", "activity", "written by v7", "rel-old"),
+    )
+    conn.execute(
+        "INSERT INTO mb_release_cache (mbid, inc, fetched_at, payload) VALUES (?, ?, ?, ?)",
+        ("rel-old", "media", "2026-07-01T00:00:00+00:00", '{"id": "rel-old"}'),
+    )
+    conn.execute("PRAGMA user_version = 7")
+    conn.close()
+
+    activity_store.init(db)
+
+    assert _user_version(db) == activity_store.SCHEMA_VERSION
+    events = activity_store.recent()
+    assert [e.message for e in events] == ["written by v7"]  # pre-existing data intact
+    assert activity_store.cached_release("rel-old", "media") is not None
+    assert activity_store.ignored_updates() == {}

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -1616,3 +1616,159 @@ def test_the_pass_keeps_asking_about_an_ignored_album(tmp_path, monkeypatch):
     assert asked == ["rel-aaa"]  # it went and looked ...
     assert album.mb_version == gardener.release_version(expanded)  # ... and moved on
     assert gardener.is_ignored(album, activity_store.ignored_updates()) is False
+
+
+# ---------------------------------------------------------------------------
+# Ignore, from the outside (#271)
+# ---------------------------------------------------------------------------
+
+
+def _flagged(runner, title: str = "Test Album") -> Album:
+    """The scanned album by that title, as the app holds it."""
+    return next(a for a in runner.albums() if a.title == title)
+
+
+def test_the_album_page_offers_ignore_and_the_way_to_fix_it_upstream(engaged, monkeypatch):
+    """Both halves of the answer to an update you disagree with, and the order
+    matters: MusicBrainz is canonical, so editing the release is the real
+    remedy and ignoring is only how you wait for it to land."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda *a, **k: _release("Test Album (remastered)")
+    )
+    client, runner = engage()
+
+    body = client.get(f"/library/{_flagged(runner).id}/compare").text
+
+    assert "musicbrainz.org/release/rel-aaa/edit" in body
+    assert "Ignore for now" in body
+
+
+def test_an_album_with_nothing_outstanding_is_offered_neither(engaged, monkeypatch):
+    """The block is about an update, so an album that has none must not carry
+    it. The same template renders both, so this is the condition being tested
+    and not a string that happens to be missing."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    monkeypatch.setattr(mb_lookup, "fetch_release", lambda *a, **k: _release())
+    client, runner = engage()
+
+    body = client.get(f"/library/{_flagged(runner).id}/compare").text
+
+    assert "Ignore for now" not in body
+
+
+def test_ignoring_takes_the_album_out_of_the_update_filter(engaged, monkeypatch):
+    """What the user asked Ignore to do: stop being listed as work."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda *a, **k: _release("Test Album (remastered)")
+    )
+    client, runner = engage()
+    album_id = _flagged(runner).id
+    client.get(f"/library/{album_id}/compare")  # the look that raises the flag
+    assert "Test Album" in client.get("/library?filter=update-available").text
+
+    r = client.post(f"/library/{album_id}/ignore-update")
+
+    assert r.status_code == 200
+    assert "Test Album" not in client.get("/library?filter=update-available").text
+
+
+def test_ignoring_leaves_the_flag_and_the_files_alone(engaged, monkeypatch):
+    """Ignoring is about what gets presented as work, never about what is true.
+    The difference is still there, the tile still says so, and nothing has been
+    written to the album — so nothing has to be recomputed when the ignore
+    lapses."""
+    cfg, engage = engaged
+    album_dir = _tagged(cfg.paths.music_dir, _release()).path
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda *a, **k: _release("Test Album (remastered)")
+    )
+    client, runner = engage()
+    album_id = _flagged(runner).id
+    client.get(f"/library/{album_id}/compare")
+    before = {p: p.read_bytes() for p in sorted(album_dir.iterdir())}
+
+    client.post(f"/library/{album_id}/ignore-update")
+
+    assert _flagged(runner).update_available is True
+    assert {p: p.read_bytes() for p in sorted(album_dir.iterdir())} == before
+
+
+def test_an_ignored_album_says_so_and_offers_the_way_back(engaged, monkeypatch):
+    """The escape hatch, and it has to be on the page rather than only in the
+    press that set it — the user comes back to this album a week later."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda *a, **k: _release("Test Album (remastered)")
+    )
+    client, runner = engage()
+    album_id = _flagged(runner).id
+    client.get(f"/library/{album_id}/compare")
+    client.post(f"/library/{album_id}/ignore-update")
+
+    body = client.get(f"/library/{album_id}/compare").text
+
+    assert "Stop ignoring" in body
+    # The promise, not just the state: "ignored" alone reads as "silenced", and
+    # someone who believed that would never press it.
+    assert "listed as an update again" in body
+
+
+def test_stopping_ignoring_lists_the_album_again(engaged, monkeypatch):
+    """The undo, end to end."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda *a, **k: _release("Test Album (remastered)")
+    )
+    client, runner = engage()
+    album_id = _flagged(runner).id
+    client.get(f"/library/{album_id}/compare")
+    client.post(f"/library/{album_id}/ignore-update")
+
+    client.post(f"/library/{album_id}/unignore-update")
+
+    assert "Test Album" in client.get("/library?filter=update-available").text
+
+
+def test_ignoring_an_album_nothing_has_compared_is_refused(engaged):
+    """There is no version to bookmark, so the mute could never lapse — which
+    is the one way this feature could silence an album for good."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    client, runner = engage()
+    album = _flagged(runner)
+    assert album.mb_version is None
+
+    r = client.post(f"/library/{album.id}/ignore-update")
+
+    assert r.status_code == 200
+    assert "Nothing to ignore" in r.text
+    assert activity_store.ignored_updates() == {}
+
+
+def test_taking_the_update_clears_the_ignore(engaged, monkeypatch):
+    """The files now say what MusicBrainz says, so there is nothing to wait for.
+    A bookmark left behind would mute the NEXT divergence on this album if
+    MusicBrainz happened not to move in between — which is what an external
+    re-tag in Picard produces."""
+    cfg, engage = engaged
+    _tagged(cfg.paths.music_dir, _release())
+    monkeypatch.setattr(
+        mb_lookup, "fetch_release", lambda *a, **k: _release("Test Album (remastered)")
+    )
+    # The re-tag path asks the Cover Art Archive, which a test must not.
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    client, runner = engage()
+    album_id = _flagged(runner).id
+    client.get(f"/library/{album_id}/compare")
+    client.post(f"/library/{album_id}/ignore-update")
+    assert album_id in activity_store.ignored_updates()
+
+    assert client.post(f"/retag/{album_id}").status_code == 200
+    assert activity_store.ignored_updates() == {}

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -527,7 +527,7 @@ def test_the_plan_renders_the_same_rows_as_a_history_entry(tmp_path):
     from harmonist import tag_history
 
     album = _tagged(tmp_path, _release())
-    plan = gardener.refresh_flag(album, _release("Test Album (remastered)"))
+    plan = gardener.refresh_flag(album, _release("Test Album (remastered)")).plan
     assert plan is not None
 
     rows = tag_history.from_plan(plan, album.path, sorted(album.path.glob("*.m4a")))
@@ -553,7 +553,7 @@ def test_reach_counts_every_file_not_just_the_changed_ones(tmp_path):
     f[ATOM_TITLE] = ["Trak 2"]
     f.save()
 
-    plan = gardener.refresh_flag(album, release)
+    plan = gardener.refresh_flag(album, release).plan
     assert plan is not None
     rows = tag_history.from_plan(plan, album.path, sorted(album.path.glob("*.m4a")))
 
@@ -1468,3 +1468,151 @@ def test_turning_the_check_on_takes_effect_without_a_restart(engaged, monkeypatc
         tick()
 
         assert done.wait(5) is True
+
+
+# ---------------------------------------------------------------------------
+# The verdict, and Ignore (#271)
+# ---------------------------------------------------------------------------
+#
+# The flag says an album diverges; the significance says how far the difference
+# reaches, so a review list can sort and summarise without reading a file. Both
+# are derived and neither is stored. The one stored thing is Ignore, which is a
+# bookmark against a release version rather than a rejection of a diff — see the
+# 7->8 migration in `activity_store` for why that distinction is the design.
+
+
+def _ignore(album: Album) -> None:
+    """Ignore `album`'s update at the version the last look reached.
+
+    What the Ignore button does, with the assertion the button gets from having
+    a release in hand: a look must have happened, or there is no version to
+    bookmark and nothing to be ignoring.
+    """
+    assert album.mb_version is not None
+    activity_store.ignore_update(album.id, release_version=album.mb_version)
+
+
+def test_the_verdict_is_the_furthest_reaching_change_in_the_diff(tmp_path):
+    """An enrichment arriving beside a retitle does not make the retitle an
+    enrichment. The verdict decides how much of the album is in question, so it
+    has to be the loudest thing in the diff — not the first, the last, or the
+    most numerous."""
+    album = _tagged(tmp_path, _release())
+    both = _release("Test Album (remastered)")
+    both["barcode"] = "5051234567890"
+
+    gardener.refresh_flag(album, both)
+
+    assert album.update_significance == "identity"
+
+
+def test_an_enrichment_on_its_own_is_recorded_as_one(tmp_path):
+    """The other half of the test above: without it, a verdict hard-coded to
+    "identity" would pass. This is also the level #273 will let a user trust,
+    so it has to be reachable and it has to be right."""
+    album = _tagged(tmp_path, _release())
+    enriched = _release()
+    enriched["barcode"] = "5051234567890"
+
+    gardener.refresh_flag(album, enriched)
+
+    assert album.update_significance == "enrichment"
+
+
+def test_a_tracklist_that_no_longer_fits_is_a_structural_verdict(tmp_path):
+    """No plan can be built for this one, so the verdict cannot come from a
+    diff — but "MusicBrainz has changed how many tracks this release has" is
+    among the loudest things it can say, and reporting no verdict at all would
+    leave the album flagged with nothing to show for it."""
+    album = _tagged(tmp_path, _release(tracks=1))
+
+    assert _flag(album, _release(tracks=3)) is True
+    assert album.update_significance == "structure"
+
+
+def test_an_album_with_nothing_outstanding_has_no_verdict(tmp_path):
+    """The verdict is about an outstanding change, so an album that has none
+    must not carry one — otherwise a review list built by significance would
+    show every album in the library."""
+    release = _release()
+    album = _tagged(tmp_path, release)
+
+    gardener.refresh_flag(album, release)
+
+    assert (album.update_available, album.update_significance) == (False, None)
+
+
+def test_the_verdict_and_the_version_come_from_one_look(tmp_path):
+    """They are read together and must be true of the same payload. An album
+    carrying a verdict from one release beside a version from another would be
+    muted by an Ignore that answered a different change."""
+    album = _tagged(tmp_path, _release())
+    moved = _release("Test Album (remastered)")
+
+    gardener.refresh_flag(album, moved)
+
+    assert album.mb_version == gardener.release_version(moved)
+    assert album.update_significance == "identity"
+
+
+def test_an_ignore_holds_while_musicbrainz_sits_still(tmp_path):
+    """What the user asked for: they have gone off to fix the release upstream,
+    and until something lands they do not want to be asked about it again."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    gardener.refresh_flag(album, _release("Test Album (remastered)"))
+    _ignore(album)
+
+    assert gardener.is_ignored(album, activity_store.ignored_updates()) is True
+    assert album.update_available is True  # the flag stays a plain fact
+
+
+def test_an_ignore_lapses_the_moment_musicbrainz_moves(tmp_path):
+    """The point of ignoring rather than dismissing, and the reason the version
+    is stored: an edit landing upstream is exactly the news the user was waiting
+    for, and Harmonist cannot tell whether it was their own."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    gardener.refresh_flag(album, _release("Test Album (remastered)"))
+    _ignore(album)
+    ignored = activity_store.ignored_updates()
+
+    gardener.refresh_flag(album, _release("Test Album (remastered, expanded)"))
+
+    assert gardener.is_ignored(album, ignored) is False
+
+
+def test_an_album_nobody_has_looked_at_is_not_ignored(tmp_path):
+    """A stored bookmark plus an album with no version must not compare equal
+    to anything. It is not flagged either, so there is nothing to mute — but a
+    None matching a None would mute every unlooked-at album at once."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    assert album.mb_version is None
+    activity_store.ignore_update(album.id, release_version="whatever")
+
+    assert gardener.is_ignored(album, activity_store.ignored_updates()) is False
+
+
+def test_the_pass_keeps_asking_about_an_ignored_album(tmp_path, monkeypatch):
+    """Ignoring mutes the surfaces, never the check. Asking is the only thing
+    that can ever un-mute an album, so a pass that skipped ignored albums would
+    make Ignore permanent — the failure this whole design is arranged to
+    avoid."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    _store(_release(), age=_stale())
+    moved = _release("Test Album (remastered)")
+    _serving(monkeypatch, moved)
+    gardener.sweep([album])
+    _ignore(album)
+
+    gardener._asked.clear()
+    _store(moved, age=_stale())
+    expanded = _release("Test Album (remastered, expanded)")
+    asked = _serving(monkeypatch, expanded)
+    gardener.sweep([album])
+
+    assert asked == ["rel-aaa"]  # it went and looked ...
+    assert album.mb_version == gardener.release_version(expanded)  # ... and moved on
+    assert gardener.is_ignored(album, activity_store.ignored_updates()) is False


### PR DESCRIPTION
Adds the two answers to an outstanding update that are not "take it": edit the
release on MusicBrainz, or ignore it until MusicBrainz next changes.

### The design changed from what the issue specified

#271 asked for a *finding* with a lifecycle — raised / applied / dismissed — in
`activity.db`. That did not survive contact, and [the issue now carries the long
version](https://github.com/randomphrase/harmonist/issues/271#issuecomment-5530097270).
The short version: a dismissal cannot be keyed. Key it to the release version and
any later unrelated edit brings back what the user rejected, attached to a change
they have never seen; key it to the fields and it stops being a decision and
becomes a permanent per-album override of the canonical source. There is no third
key, because a divergence is not a thing — it is a diff between two moving sides,
so it merges and splits as MusicBrainz is edited and as the files change.

**Ignore** is a different object and keys cleanly: mute this album until
MusicBrainz moves. The property the issue treated as a hazard is the feature —
an upstream edit lapsing the ignore is exactly the notification the user wanted,
and it is what happens when the edit they went off to make lands.

So `docs/design.md` §1 now states outright that **MusicBrainz is canonical** and
that Harmonist keeps no per-album exception to it. It settles a class of question
rather than only this one, and it was previously left to be inferred from "source
of truth".

### What is stored

`gardener_ignores(album_id, release_version, ignored_at)` and nothing else. The
diff and its significance are recomputed from the cached release plus the files,
exactly as the issue argued; the verdict now lives in memory beside
`update_available` and is rebuilt at startup from stored payloads at the cost of
no MusicBrainz requests.

### What the user sees

Under the MusicBrainz note on the album page: **Edit the release** (a link out,
and the one that matters) and **Ignore for now**. Ignoring takes the album out of
the `Update available` filter and does nothing else — no file is touched, the
flag stays true because it is still true, and the tile keeps its **Update**
badge. That follows the `tracks_unavailable` precedent, where an album accepted
as finished keeps its Incomplete badge and only leaves the filter: hiding a true
fact and not presenting it as work are different acts.

Three ways out, so the state is never a dead end — **Stop ignoring** on the
album's page, a re-tag (the files then carry what MusicBrainz says), or
MusicBrainz moving the release.

### Notes for review

- The pass deliberately **keeps asking** about ignored albums. #271 said the
  opposite; that rule existed to protect a stored verdict, and there is no stored
  verdict.
- `refresh_flag` now returns an `Assessment` rather than a plan, because a
  missing plan has two meanings — the release no longer fits the files, or the
  files could not be read — and only one of them is an answer.
- Driven in a browser as well as pytest: the OOB swap and the filter are the half
  the Python suite cannot see. Four mutations of the surface each turned their own
  test red.

Fixes #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdkdB2TNTMYTdCL2QGYGes
