### PR TITLE
Ask MusicBrainz too whether a tag reads one way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ versions follow [semantic versioning](https://semver.org).
   Activity entry instead of two** — the second was unlinked from the album and
   repeated its name in the message (#342).
 
+- **A tag MusicBrainz holds on only some tracks is shown on the tracks that have
+  it.** An ISRC MusicBrainz had on one track of twenty-four earned no column, so
+  it fell to the line under the tracklist that speaks for tags every track agrees
+  on — which then reported the addition as a removal from all of them. A tag
+  MusicBrainz reads two ways across a release now gets a column, and that line
+  only speaks for one both sides read a single way (#374).
+
 ## [1.13.0] - 2026-09-01
 
 ### Added

--- a/src/harmonist/compare.py
+++ b/src/harmonist/compare.py
@@ -1714,12 +1714,23 @@ def _earns_column(candidate: _Candidate, present: Sequence[_Present], multi_disc
     pairs = {(d, v) for d, v in zip(disk, mb, strict=True) if v is not None}
     if len(pairs) > 1 and any(d != v for d, v in pairs):
         return True
-    # 2. The tracks disagree with each other. None counts as a value here: a tag
-    #    on six of eight tracks is uneven tagging, and the unevenness IS the
-    #    finding — the same fact `consensus` reports for the album panel. Except
-    #    for the medium-derived tags on a multi-disc release, where disagreeing
-    #    is the release's shape rather than a defect — see `_MEDIUM_DERIVED`.
-    if len(set(disk)) > 1 and not (multi_disc and candidate.owned in _MEDIUM_DERIVED):
+    # 2. The tracks disagree with each other — ON EITHER SIDE. None counts as a
+    #    value here: a tag on six of eight tracks is uneven tagging, and the
+    #    unevenness IS the finding — the same fact `consensus` reports for the
+    #    album panel. Except for the medium-derived tags on a multi-disc release,
+    #    where disagreeing is the release's shape rather than a defect — see
+    #    `_MEDIUM_DERIVED`.
+    #
+    #    The MusicBrainz half was missing until #374, and rule 1's None filter
+    #    could not stand in for it: an ISRC MusicBrainz holds on one track of 24
+    #    leaves a single pair once the 23 it says nothing about drop out, so
+    #    "which track" was ruled unanswerable on an album where the answer is
+    #    track 3. Both halves together are also the band's whole claim — one
+    #    reading, on both sides — which is why `_collapsed` asks the same pair.
+    shaped_by_the_discs = multi_disc and candidate.owned in _MEDIUM_DERIVED
+    one_reading = _one_reading_on_disk(candidate, present)
+    one_answer = _one_reading_in_mb(candidate, present)
+    if not (one_reading and one_answer) and not shaped_by_the_discs:
         return True
     # 3. Differs from the album-level counterpart, on either side. Per track and
     #    per side, never across: a file's own `album_artist` is what its `artist`
@@ -1778,6 +1789,27 @@ def _one_reading_on_disk(candidate: _Candidate, present: Sequence[_Present]) -> 
     """
     key = candidate.owned.value
     return len({_disk_value(t, key) for t, _ in present}) <= 1
+
+
+def _one_reading_in_mb(candidate: _Candidate, present: Sequence[_Present]) -> bool:
+    """Whether MusicBrainz says the same thing about this tag on every track (#374).
+
+    The other half of the band's claim, and the half that went unchecked. A band
+    line is one reading and one arrow, so it can only be drawn over a field both
+    sides read one way; where MusicBrainz reads two ways the line has to pick one
+    of them, which is how an ISRC being ADDED to track 3 came out as an ISRC
+    being removed from all 24.
+
+    Over the tracks MusicBrainz has a counterpart for, and only those. A track it
+    has never heard of offers no reading to vary — a video track (#226), and every
+    row of the disk-only view (#228), where this is vacuously true and nothing can
+    earn a column on MusicBrainz's account. A counterpart that simply has NO value
+    for the tag is a reading like any other, and the one this rule turns on: it is
+    MusicBrainz saying "not here", which is what the tracks that do have one part
+    company with.
+    """
+    key = candidate.owned.value
+    return len({_as_display(getattr(m.tags, key)) for _, m in present if m is not None}) <= 1
 
 
 def _matches_everywhere(candidate: _Candidate, present: Sequence[_Present]) -> bool:
@@ -1900,15 +1932,20 @@ def _collapsed(candidate: _Candidate, present: Sequence[_Present]) -> CollapsedF
     nobody offered. That is the same exclusion `FieldComparison.differs` makes,
     for the same reason.
 
-    Second, it takes ONE reading on disk. Rule 2 gives a column to any tag whose
-    tracks disagree, so that holds for nearly everything here — except the
-    medium-derived tags on a multi-disc release, which rule 2 exempts because
-    varying by disc is the release's shape. `media` can therefore arrive reading
-    CD on one disc and Digital Media on another, and a single "X → Y" line would
-    be asserting one reading and one change where there are two of each. Such a
-    field is still named — #112's distinction between a tag that agreed and one
-    nobody looked at is what the band exists for — but it states its value only,
-    exactly as it did before #360.
+    Second, it takes ONE reading on EACH SIDE. Rule 2 gives a column to any tag
+    whose tracks disagree on either — so that holds for nearly everything here —
+    except the medium-derived tags on a multi-disc release, which rule 2 exempts
+    because varying by disc is the release's shape. `media` can therefore arrive
+    reading CD on one disc and Digital Media on another, and a single "X → Y"
+    line would be asserting one reading and one change where there are two of
+    each. Such a field is still named — #112's distinction between a tag that
+    agreed and one nobody looked at is what the band exists for — but it states
+    its value only, exactly as it did before #360.
+
+    The MusicBrainz half of that is #374's: it was assumed rather than asked, and
+    `mb` was taken from the first track regardless. On a release whose one ISRC
+    sits on track 3, track 1's silence became the whole album's MusicBrainz
+    reading, and the band drew an addition as a removal.
     """
     key = candidate.owned.value
     disk = [_disk_value(t, key) for t, _ in present]
@@ -1917,7 +1954,7 @@ def _collapsed(candidate: _Candidate, present: Sequence[_Present]) -> CollapsedF
         for d, (_, m) in zip(disk, present, strict=True)
         if m is not None
     ]
-    uniform = _one_reading_on_disk(candidate, present)
+    uniform = _one_reading_on_disk(candidate, present) and _one_reading_in_mb(candidate, present)
     differs = uniform and any(d != v for d, v in comparable)
     # On a DIFFERENCE `value` is what the files carry, even when that is nothing:
     # it is the "before" of a change, and the row is about to state MusicBrainz's

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -1226,6 +1226,50 @@ def test_a_change_that_reads_the_same_on_every_track_goes_to_the_band():
     assert "ISRC" in _headings(album("FRZ109800001", "FRZ109800002"))
 
 
+def test_a_tag_musicbrainz_holds_on_only_some_tracks_earns_a_column():
+    """#374. The other half of rule 1's question, from the side nobody asked.
+
+    MusicBrainz has one ISRC on the release and it is on track 2; no file carries
+    one. Rule 1 used to count only the tracks whose MusicBrainz value was set, so
+    the twenty-three tracks MusicBrainz says nothing about dropped out, one pair
+    was left, and "which track" was ruled to have no answer — when it has a
+    perfectly good one. The field fell to a band captioned "The same on every
+    track", which is exactly what it is not.
+    """
+    tl = tracklist(
+        [_file(1, "Nightcall"), _file(2, "Odd Look")],
+        [_mb_track(1, "Nightcall"), _mb_track(2, "Odd Look", isrcs=["FRZ109800002"])],
+    )
+
+    assert "ISRC" in _headings(tl), "the column that answers 'which track'"
+    assert "ISRC" not in {c.label for c in tl.collapsed}
+    cells = [next(f for f in t.fields if f.label == "ISRC") for t in tl.tracks]
+    assert [f.differs for f in cells] == [False, True]
+    assert cells[1].mb == "FRZ109800002"
+    # An identifier column starts hidden (#319), so the row that differs only
+    # there opens the control itself rather than showing the reader nothing.
+    assert tl.reveal_identifiers
+
+
+def test_a_field_musicbrainz_reads_two_ways_is_never_stated_as_one_band_line():
+    """#374's second half: what `_collapsed` said about the album above.
+
+    MusicBrainz's side of a band row was taken from the FIRST track on the
+    strength of a uniformity flag that only ever looked at the disk. Track 1 had
+    no ISRC, so the row read `mb=None` with `differs=True` — which the band draws
+    as a removal, the exact opposite of the addition MusicBrainz was offering.
+
+    Stated over the collapsed set as a whole rather than over ISRC alone: any
+    field that reaches the band must read one way on BOTH sides, because a single
+    line is all the band can say.
+    """
+    tl = tracklist(
+        [_file(1, "Nightcall"), _file(2, "Odd Look")],
+        [_mb_track(1, "Nightcall"), _mb_track(2, "Odd Look", isrcs=["FRZ109800002"])],
+    )
+    assert not any(c.differs and c.mb is None and c.value is None for c in tl.collapsed)
+
+
 def test_identifier_columns_are_off_the_cap_and_named_by_their_control():
     """#319. An MBID and an ISRC are correct to keep and correct to link, and not
     what anyone opens this page to look at — so they start hidden, and a hidden


### PR DESCRIPTION
The line under the tracklist speaks for the tags every track agrees on, and `_one_reading_on_disk` was named for the half of that claim it checked. The other half was assumed: `_collapsed` took MusicBrainz's side from the **first** track, and `_earns_column`'s rule 1 counted only the tracks MusicBrainz had a value for.

On `Various Artists/15 - 1` that made an addition read as a removal. One ISRC, on track 3 of 24, in a library where no file carries one: the 23 tracks MusicBrainz says nothing about dropped out of rule 1's pairs, one pair was left, "which track" was ruled to have no answer, and the field fell to a band captioned *"The same on every track"* — where track 1's silence became the whole album's MusicBrainz reading and the row rendered as ISRC *removed*.

## The change

`_one_reading_in_mb` is the counterpart, over the tracks MusicBrainz has a counterpart for — so a video track (#226) and the disk-only view (#228) still offer no reading to vary, and a counterpart with no value for the tag is a reading like any other, which is the case this turns on. Rule 2 asks both halves, keeping the exemption that lets the medium-derived tags vary by disc, and `_collapsed` asks the same pair. A field only reaches the band when a single line can honestly carry it.

No new reveal machinery: ISRC is an identifier column, and `reveal_identifiers` (#319) opens it for a row whose only difference is one.

## Tests

Two, both red first — the column absent, and the band stating `differs` with `mb=None` over a value no file carries.

Fixes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdkdB2TNTMYTdCL2QGYGes