### PR TITLE
Leave a followed merge at the address the album moved to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **Re-tagging an album whose release was merged away now takes you to the
+  surviving release's page**, instead of leaving the address bar on the release
+  the album has just stopped naming (#375).
+
 - **A purchase a sync couldn't finish with is no longer lost for good.** The
   sync remembered where it got to as "the newest purchase I saw", not "the
   newest one I finished with" — so a pre-order Bandcamp wasn't serving yet, or

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -4408,7 +4408,7 @@ def _register_routes(app: FastAPI) -> None:
         # Reload the open detail modal so its disk-vs-MB comparison + metadata
         # reflect the just-written tags (tasks-changed only refreshes the tiles).
         return _flash_response(
-            "Re-tagged", details, extra_triggers={"album-retagged": True}, album=album
+            "Re-tagged", details, extra_triggers=_retagged_trigger(album), album=album
         )
 
     @app.post("/artwork/restore/{album_id}", response_class=HTMLResponse)
@@ -4457,7 +4457,7 @@ def _register_routes(app: FastAPI) -> None:
         return _flash_response(
             "Artwork restored",
             f"{restored} file{'s' if restored != 1 else ''}",
-            extra_triggers={"album-retagged": True},
+            extra_triggers=_retagged_trigger(album),
             album=album,
         )
 
@@ -4521,7 +4521,7 @@ def _register_routes(app: FastAPI) -> None:
         return _flash_response(
             "Tags put back",
             _revert_detail(outcome, unlinked=unlinked),
-            extra_triggers={"album-retagged": True},
+            extra_triggers=_retagged_trigger(album),
             album=album,
         )
 
@@ -5334,6 +5334,26 @@ def _live_album_ref(album: Album) -> tuple[str | None, str]:
     # No sidecar (still NEW, or it was just erased): the registry id the caller
     # already holds is the best available handle, and it IS resolvable.
     return album.id, label
+
+
+def _retagged_trigger(album: Album) -> dict[str, Any]:
+    """The `album-retagged` event, carrying where the album lives NOW (#375).
+
+    The album page listens for this and refreshes itself, because a tagging
+    rewrites everything on it. It used to be a bare `true`, so the only refresh
+    the page could perform was a reload of the address it was already on — and a
+    re-tag can MOVE the album's id out from under that address: MusicBrainz
+    redirects a merged release, so following the merge (#268) leaves the page at
+    an id the album has just stopped claiming. The alias chain still resolves it,
+    so the reload came back correct and looked settled; the address bar, a
+    bookmark taken from it and every later refresh stayed on the dead id.
+
+    The id is re-derived from the sidecar on disk — see `_live_album_ref`, for
+    exactly the reason it does: the caller's `Album` was resolved before the
+    mutation, so its `id` is the one that may have just been superseded.
+    """
+    album_id, _ = _live_album_ref(album)
+    return {"album-retagged": {"album_id": album_id}}
 
 
 def _flash_response(

--- a/templates/album.html
+++ b/templates/album.html
@@ -213,9 +213,27 @@
    would be more machinery for a worse guarantee. It also means the tagging
    overlay covering the panel doesn't have to reach the sections beside it:
    nothing outside the panel is interactive while a re-tag is in flight, and
-   what they show is replaced wholesale the moment it finishes. #}
+   what they show is replaced wholesale the moment it finishes.
+
+   …at the album's address as it is AFTERWARDS, which is not always the one this
+   page was opened at (#375). A re-tag follows a merge, and a merge MOVES the
+   album's id (#268) — so an in-place reload lands back on an id the album has
+   just stopped claiming. That still renders (the alias chain resolves it), which
+   is what made this so quiet: the page came back correct while the address bar,
+   any bookmark taken from it and every later refresh stayed on the superseded
+   release. The event carries the id the album now has, so the page can go there.
+
+   `replace`, not `assign`: the address behind us names a release this album no
+   longer claims, and Back should reach the Library rather than step through it.
+   The query string rides along — `from_page` / `from_filter` / `from_q` are what
+   Back is built out of, and a re-tag is not a reason to lose the way home. #}
 <script>
-    document.body.addEventListener('album-retagged', function () {
+    document.body.addEventListener('album-retagged', function (event) {
+        var now = event.detail && event.detail.album_id;
+        if (now && now !== {{ album.id | tojson }}) {
+            window.location.replace('/album/' + encodeURIComponent(now) + window.location.search);
+            return;
+        }
         window.location.reload();
     });
 </script>

--- a/test/e2e/test_merge_retag.py
+++ b/test/e2e/test_merge_retag.py
@@ -1,0 +1,69 @@
+"""Where the browser ends up after a re-tag that followed a merge (#375).
+
+MusicBrainz merged the release this album names, so the re-tag writes the
+SURVIVING release's id — and the page was opened at the old one. The page
+refreshes itself off `album-retagged`, and refreshing in place left the browser
+on an address the album had just stopped claiming: still resolvable through the
+alias chain, so what came back was right and nothing looked wrong, while the
+address bar and any bookmark taken from it named a superseded release.
+
+This rung and no lower. `test_mb_merge.py` covers the header — that the response
+names the album's new id — and that is exactly as far as pytest can see: whether
+the page then *goes* there is a listener reading an event detail, which is the
+#40 blind spot in its purest form. A rendered-HTML assertion would pass against a
+handler that ignored the detail entirely.
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlsplit
+
+import pytest
+
+# Opt-in like every other module here: `make check` stays browser-free.
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1", reason="e2e disabled (set RUN_E2E=1)"
+)
+playwright_sync = pytest.importorskip("playwright.sync_api")
+
+# Seeded COMPLETE, tagged as a release demo's MusicBrainz has merged away — its
+# id is absent from MB_RELEASES and present in MERGED_INTO, which is the whole of
+# what makes it a merge (demo.py). Its page therefore states one, and offers the
+# re-tag that follows it.
+MERGED_AWAY = "demo-rel-folksmen-dupe"
+SURVIVOR = "demo-rel-folksmen"
+
+
+def test_re_tagging_a_merged_release_leaves_the_browser_on_the_surviving_one(
+    demo_server: str,
+) -> None:
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+
+        page.goto(f"{demo_server}/album/{MERGED_AWAY}?from_page=2")
+        # The merge is discovered by the /compare fetch that lands after the
+        # paint — a redirect is something MusicBrainz does, not something the
+        # page can know at render time — so the note is what says it has arrived.
+        page.wait_for_selector("text=merged this release", timeout=20_000)
+
+        page.get_by_role("button", name="Re-tag from MB").first.click()
+
+        # The address the album now lives at, not the one it was opened at.
+        #
+        # On the PATH, compared whole. A glob would not do here and the near miss
+        # is worth naming: the surviving id is a PREFIX of the merged-away one, so
+        # `**/album/demo-rel-folksmen*` matches the address this page started at
+        # and the test passes with the bug reintroduced.
+        page.wait_for_url(lambda url: urlsplit(url).path == f"/album/{SURVIVOR}", timeout=20_000)
+        # …and the way back survives the move: `from_page` is the Library page
+        # this album was opened from, and it is the only thing carrying it.
+        assert "from_page=2" in page.url, page.url
+        # The re-tag settled the merge, so the page it landed on says nothing
+        # about one. Asserted after `wait_for_url` rather than instead of it: the
+        # note is absent on a page still mid-fetch too.
+        page.wait_for_selector("#album-tracks table", timeout=20_000)
+        assert page.locator("text=merged this release").count() == 0
+
+        browser.close()

--- a/test/test_mb_merge.py
+++ b/test/test_mb_merge.py
@@ -15,6 +15,7 @@ settled, and its History has to say why its identity moved.
 
 from __future__ import annotations
 
+import json
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
@@ -339,3 +340,48 @@ def test_a_merge_arriving_with_a_tag_update_is_answered_by_one_button(client, cf
     assert "merged this release" in html, html
     assert "Re-tag from MB" in html, html
     assert html.count(f'hx-post="/retag/{_scanned(cfg, d).id}"') == 1, html
+
+
+# ---------- where the album lives once the re-tag has followed the merge (#375) ----------
+#
+# A merge MOVES the album's id, and the page the re-tag was pressed on is at the
+# old one. `album-retagged` used to be a bare `true`, so the only thing the page
+# could do with it was reload itself — at the address it was already on, which
+# names a release the album no longer claims. The alias chain still resolves it,
+# so what came back was right; the address bar, a bookmark taken from it and a
+# refresh afterwards all stayed pointed at the superseded release.
+#
+# The event carries the album's live id now, and the page navigates when it has
+# moved. This rung sees the header; whether the browser then goes there is
+# `test/e2e/test_merge_retag.py`.
+
+
+def _retagged(response) -> dict:
+    """The `album-retagged` event the re-tag came back with."""
+    triggers = json.loads(response.headers["HX-Trigger"])
+    assert "album-retagged" in triggers, triggers
+    return triggers["album-retagged"]
+
+
+def test_a_retag_following_a_merge_says_which_album_the_page_should_go_to(client, cfg, monkeypatch):
+    """The id the album has AFTER the tagging, which is the surviving release —
+    not the one the request was addressed to."""
+    d = _album(cfg)
+    _redirects_to(monkeypatch, NEW_MBID)
+
+    r = client.post(f"/retag/{_scanned(cfg, d).id}")
+
+    assert _retagged(r) == {"album_id": NEW_MBID}
+
+
+def test_an_ordinary_retag_says_the_album_is_where_it_was(client, cfg, monkeypatch):
+    """The control, and what stops the page navigating on every re-tag: an album
+    whose release has not moved comes back naming the id it already had, so the
+    page reloads in place. Read off the sidecar rather than assumed, which is why
+    this can disagree with the test above."""
+    d = _album(cfg)
+    _redirects_to(monkeypatch, OLD_MBID)
+
+    r = client.post(f"/retag/{_scanned(cfg, d).id}")
+
+    assert _retagged(r) == {"album_id": OLD_MBID}


### PR DESCRIPTION
**Symptom**

MusicBrainz merged the release an album names, the album page says so, and re-tagging follows the merge — but the browser stays at `/album/<merged-away-id>`. Typing the surviving id by hand shows the album correctly, which was the only remedy available.

**Root cause**

The album page refreshes itself on the `album-retagged` event, and the event was a bare `true` — so the only refresh available was `window.location.reload()`, at the address the page was already on. #268 moves the album's id during the re-tag, so that address names a release the album has just stopped claiming. The alias chain still resolves it, which is what kept this quiet: the reload came back correct and looked settled, while the address bar, any bookmark taken from it and every later refresh stayed on the superseded id.

**Fix**

The event carries the album's live id, re-derived from the sidecar on disk for the reason `_live_album_ref` does it — the `Album` the handler holds was resolved before the tagging, so its id is precisely the one that may have just been superseded. The page compares that with its own and navigates when they differ, reloading in place when they don't, so an ordinary re-tag behaves exactly as before. `replace` rather than `assign`, since the address behind us names a release the album no longer claims; the query string rides along, because `from_page` / `from_filter` / `from_q` are what Back is built out of.

All three `album-retagged` emitters send the same shape. Undoing a tagging can move an album's identity too — a revert that unlinks it drops the MBID for its `temp_uid` — and an event whose payload is sometimes a boolean and sometimes an object is worse to read than one that always answers the same question.

**Tests**

Two at the web-route rung (`test_mb_merge.py`), written red-first: the response names the surviving release after a merge, and names the unchanged id after an ordinary re-tag — the control that stops the page navigating on every re-tag.

Whether the page then *goes* there is a listener reading an event detail, which no pytest rung can see, so there is a browser test (`test/e2e/test_merge_retag.py`). It nearly could not fail: the surviving demo id is a *prefix* of the merged-away one, so the obvious URL glob matched the address the page started at and passed with the bug reintroduced. It compares the whole path now, and the mutation check goes red.

One caveat carried over from the issue: the *warning reappearing* did not reproduce at either rung — the reloaded old-URL page came back with the merge note gone, and only the address was stale. This fixes the cause the issue names; if the note itself was seen to come back, that is a second mechanism and wants its own issue.

Fixes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdkdB2TNTMYTdCL2QGYGes