### PR TITLE
Let one release id on every file settle whose album it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A multi-disc rip whose discs are named no longer lands in the Inbox as
+  Inconsistent.** XLD writes MusicBrainz's disc title into the album tag, so
+  disc 2 of *U.F.Orb* reads `U.F.Orb - bonus disc` and the folder looked like
+  two albums; one MusicBrainz release id on every file now settles it, whatever
+  the titles say (#381).
+
 ## [1.14.0] - 2026-09-04
 
 ### Added

--- a/docs/design.md
+++ b/docs/design.md
@@ -1728,9 +1728,16 @@ or MB Album Id. Common cause: messy filesystem; user dumped multiple
 albums into one folder.
 
 **Detection:** scanner reads album title + MB Album Id from every file in
-each album dir. If either varies across files, derive state `INCONSISTENT`.
-Compilations (same album title + MBID, varying track artists) are NOT
-flagged — that's legitimate.
+each album dir. Varying MB Album Ids are always `INCONSISTENT`. A varying
+album title is `INCONSISTENT` only when some file lacks an MB Album Id —
+**a release id every file agrees on settles it, and the titles are not
+consulted at all.** The MBID is the release identity; the album title is a
+display string each ripper derives its own way, and XLD folds a named medium
+into it (disc 2 of *U.F.Orb* reads `U.F.Orb - bonus disc`), which the old
+title-or-MBID rule accused of being two albums (#381). One file without an
+MBID puts the titles back in charge: nothing vouches for a stray dropped into
+the dir, so its own title has to. Compilations (same album title + MBID,
+varying track artists) are NOT flagged — that's legitimate.
 
 **State:** new `INCONSISTENT`. **Purely derived from on-disk file tags;
 no sidecar field involved.** Auto-reconcile skips these (they're not

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -63,8 +63,9 @@ MatchConfidence = Literal["exact", "approximate", "no_match"]
 class InconsistentTrack:
     """One row in the INCONSISTENT card's per-file summary table.
 
-    Surfaced when files in a single album dir disagree on album title
-    (`©alb`) or MB Album Id (`----:com.apple.iTunes:MusicBrainz Album Id`).
+    Surfaced when files in a single album dir disagree on MB Album Id
+    (`----:com.apple.iTunes:MusicBrainz Album Id`), or on album title
+    (`©alb`) without one release id on every file to settle it (§13.2).
     Compilations (varying artist, consistent album+MBID) don't appear here
     — they're legitimate, not inconsistent.
     """

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -847,6 +847,14 @@ def _check_consistency(
     Files missing either field don't vote — partial tagging is handled
     separately (§15.1). Returns one row per file when inconsistent,
     empty list when consistent.
+
+    A release id every file agrees on settles the question on its own, and the
+    titles are not consulted at all (§13.2): the MBID *is* the release identity,
+    while the album title is a display string each ripper derives its own way —
+    XLD folds a named medium into it, so disc 2 of U.F.Orb says "U.F.Orb - bonus
+    disc" and the dir was accused of holding two albums (#381). One file without
+    an MBID is enough to put the titles back in charge: nothing vouches for a
+    stray dropped into the dir, so its own title has to.
     """
     if len(audio_files) < 2:
         return []  # single-file album can't be inconsistent
@@ -856,9 +864,14 @@ def _check_consistency(
         for f, sf in zip(audio_files, fields, strict=True)
     ]
 
-    titles = {r.album_title for r in rows if r.album_title is not None}
     mbids = {r.mb_album_id for r in rows if r.mb_album_id is not None}
-    if len(titles) > 1 or len(mbids) > 1:
+    if len(mbids) > 1:
+        return rows
+    if len(mbids) == 1 and all(r.mb_album_id is not None for r in rows):
+        return []  # one release id, on every file: whatever the titles say
+
+    titles = {r.album_title for r in rows if r.album_title is not None}
+    if len(titles) > 1:
         return rows
     return []
 

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -841,3 +841,60 @@ def test_a_new_video_file_invalidates_the_scan_cache(tmp_path):
     _video_disc(album_dir, disc=2, disc_total=2, n=9, track_total=9)
 
     assert scan(tmp_path, album_cache=cache)[0].state == AlbumState.COMPLETE
+
+
+def _write_disc(album_dir: Path, *, disc: int, n: int, album: str, mbid: str | None) -> None:
+    """Write one disc's files into a flat album dir, XLD-style: `2-01 …` names,
+    the disc's own album title, and the MB Album Id when there is one."""
+    from mutagen.mp4 import MP4
+
+    for i in range(1, n + 1):
+        f = album_dir / f"{disc}-{i:02d} Track {i}.m4a"
+        shutil.copy(SINE_M4A, f)
+        audio = MP4(f)
+        audio[ATOM_ALBUM] = [album]
+        audio["trkn"] = [(i, n)]
+        audio["disk"] = [(disc, 2)]
+        if mbid is not None:
+            audio[ATOM_MB_ALBUM_ID] = [mbid.encode()]
+        audio.save()
+
+
+def test_a_disc_title_folded_into_the_album_tag_is_not_inconsistent(tmp_path):
+    """XLD folds MusicBrainz's medium title into `©alb`, so disc 2 of U.F.Orb
+    says "U.F.Orb - bonus disc" (#381). Every file still names one release id,
+    which is what says whose tracks these are — the title is a display string
+    each ripper derives its own way, and it cannot outvote the MBID."""
+    album_dir = _make_album_dir(tmp_path, "The Orb", "U.F.Orb", n_tracks=0)
+    _write_disc(album_dir, disc=1, n=2, album="U.F.Orb", mbid="rel-ufo")
+    _write_disc(album_dir, disc=2, n=2, album="U.F.Orb - bonus disc", mbid="rel-ufo")
+    _tagged_sidecar(album_dir, mbid="rel-ufo")
+
+    album = scan(tmp_path)[0]
+    assert album.inconsistent_tracks == []
+    assert album.state == AlbumState.COMPLETE
+
+
+def test_two_releases_in_one_dir_are_still_inconsistent(tmp_path):
+    """The other half of the same rule: agreeing titles don't excuse
+    disagreeing release ids, which is two albums in one folder."""
+    album_dir = _make_album_dir(tmp_path, "Artist", "Album", n_tracks=0)
+    _write_disc(album_dir, disc=1, n=2, album="Album", mbid="rel-aaa")
+    _write_disc(album_dir, disc=2, n=2, album="Album", mbid="rel-bbb")
+
+    album = scan(tmp_path)[0]
+    assert album.state == AlbumState.INCONSISTENT
+    assert len(album.inconsistent_tracks) == 4
+
+
+def test_a_stray_untagged_track_with_its_own_title_is_still_inconsistent(tmp_path):
+    """A file dropped into an album dir carrying a different album title and no
+    release id at all. Nothing vouches for it, so the title still votes and the
+    dir is flagged — the narrowing in #381 must not swallow this."""
+    album_dir = _make_album_dir(tmp_path, "Artist", "Album", n_tracks=0)
+    _write_disc(album_dir, disc=1, n=2, album="Album", mbid="rel-aaa")
+    _write_disc(album_dir, disc=2, n=1, album="Somebody Else's Album", mbid=None)
+
+    album = scan(tmp_path)[0]
+    assert album.state == AlbumState.INCONSISTENT
+    assert len(album.inconsistent_tracks) == 3


### PR DESCRIPTION
A correct 2CD rip of The Orb's *U.F.Orb*, made with XLD against the release the user had already picked, landed in the Inbox as **Inconsistent** and was told to go sort itself out with Picard. There was nothing to sort: all 11 files carry the one MB Album Id and the discs are numbered `(1,2)` and `(2,2)`. XLD folds MusicBrainz's *medium* title into the album tag, so disc 2's files say `U.F.Orb - bonus disc`, and `_check_consistency` gave that title the same authority as the release id.

The two fields were never equal. The MBID is the release identity; the album title is a display string each ripper derives its own way — Harmonist's own tagger puts a medium's name in `discsubtitle` and leaves `album` alone (#218), which is why only imported rips hit this, i.e. exactly the adoption path.

**The rule now:**

- disagreeing MB Album Ids → `INCONSISTENT`, unchanged;
- one MB Album Id, on *every* file → consistent, and the titles are not consulted at all;
- any file without an MB Album Id → the titles vote again, exactly as before, so a stray track dropped into a Complete dir is still flagged and a mixed folder of untagged files behaves as it always did.

`docs/design.md` §13.2 specified the title-or-MBID rule, so it is rewritten here too rather than left contradicting the code.

**Tests** (`test/test_scanner.py`, pure-logic rung — this is state derivation, nothing HTTP): the U.F.Orb case written red first, failing on its assertion before the fix; plus two guards that keep the narrowing honest — two release ids in one folder, and a stray untagged track carrying its own album title.

Verified against the real library with a read-only scan: the album derives `NEW` with 11 of 11 tracks expected, so auto-reconcile picks it up.

Fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdkdB2TNTMYTdCL2QGYGes