### PR TITLE
Say the artwork was kept only when something was written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **A re-tag that changes nothing no longer repeats the note about keeping
+  per-track artwork.** The note now rides on an actual write, so a compilation's
+  History doesn't collect the same sentence once per re-tag (#272).
+
 - **A collaboration missing its album-artists tag now reads as Enrichment
   rather than Identity.** The list arriving where there was none is MusicBrainz
   filling in a detail — no library predating last week's Picard carries the tag

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -191,27 +191,13 @@ def tag_album(
         overwrite_art=overwrite_art,
         files=files,
     )
-    # Read before the artwork guard as well as before the loop: the guard's
-    # warning names the album it is about, and this is where that name comes
-    # from. Tagging can still move the id afterwards (temp_uid -> MBID), which is
-    # why `album_history` unions an album's alias chain — the same reason the
-    # `tag.album` line below gets away with the pre-write id.
+    # Read before the loop, and before anything can move it: tagging drops a
+    # sidecar's `temp_uid` for the MBID afterwards, which is why `album_history`
+    # unions an album's alias chain — the same reason the `tag.album` line below
+    # gets away with the pre-write id. The artwork notice at the end of this
+    # function reuses it rather than re-reading, so both records name the album
+    # the same way even if the id moves in between.
     album_id = sidecar_mod.album_id_for(album_dir)
-    if prep.preserves_per_track_art:
-        # Attributed to the album (#260). This is a decision Harmonist made on
-        # the user's behalf about their files, so it has to reach that album's
-        # own History — and the feed's log mirror drops any record that doesn't
-        # say which album it means. The `art=preserved` token on the `tag.album`
-        # line below is not a substitute: it shows only under "Show details".
-        #
-        # The album's name is NOT repeated into the message; it rides in its own
-        # column, which is where the feed and the History both render it.
-        log.warning(
-            "tracks have per-track embedded artwork — keeping it, NOT embedding "
-            "the album cover (folder cover.* is still written). Re-tag with "
-            "'replace artwork' to override.",
-            extra={"album_id": album_id, "album_label": _album_label(release, album_dir)},
-        )
 
     # Tag writing replaces information in every audio file, so it belongs in the
     # audit log — it was the one core mutation with no record at all. The album
@@ -231,6 +217,7 @@ def tag_album(
     if prep.art_after is not None:
         _keep_doomed_art(prep.art_before, prep.art_after)
 
+    wrote_something = False
     for file_path, (medium, track_pos_in_medium, track) in prep.pairs:
         tagset = _build_tagset(release, medium, track_pos_in_medium, track, prep.media_total)
         before = formats.read_owned(file_path)
@@ -253,6 +240,7 @@ def tag_album(
             # rather than one that merely records nothing.
             continue
         formats.write_tags(file_path, tagset, prep.cover)
+        wrote_something = True
         # The `tag.track` line comes AFTER the write, and the detail hangs off
         # it: a record claiming a change that never landed would make a future
         # revert restore a value that was never overwritten.
@@ -269,6 +257,35 @@ def tag_album(
         )
         if event_id is not None:
             _record_changes(event_id, album_dir, file_path, tagset, changes)
+
+    if prep.preserves_per_track_art and wrote_something:
+        # Attributed to the album (#260). This is a decision Harmonist made on
+        # the user's behalf about their files, so it has to reach that album's
+        # own History — and the feed's log mirror drops any record that doesn't
+        # say which album it means. The `art=preserved` token on the `tag.album`
+        # line above is not a substitute: it shows only under "Show details".
+        #
+        # AFTER the loop, and only if it wrote (#272). The decision recurs
+        # identically on every re-tag — preserving the user's artwork is the
+        # outcome every time — so announcing it unconditionally reports a
+        # decision rather than a change, and under #32's nightly pass that is one
+        # warning per night forever on every compilation. `_record_changes`
+        # already takes this position for the per-field detail; this line joins
+        # it rather than being demoted back to an audit-only token, which is the
+        # state #260 was filed against.
+        #
+        # A crash part-way through the loop therefore loses it — acceptable,
+        # because the `tag.album` line records `art=preserved` before the first
+        # write, so the forensic record of the decision is already down.
+        #
+        # The album's name is NOT repeated into the message; it rides in its own
+        # column, which is where the feed and the History both render it.
+        log.warning(
+            "tracks have per-track embedded artwork — keeping it, NOT embedding "
+            "the album cover (folder cover.* is still written). Re-tag with "
+            "'replace artwork' to override.",
+            extra={"album_id": album_id, "album_label": _album_label(release, album_dir)},
+        )
 
     return len(prep.files)
 

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -811,6 +811,52 @@ def test_preserved_per_track_artwork_reaches_the_album_history(album_with_tracks
     assert entry.album_label == "Test Artist — Test Album"
 
 
+def test_the_preserved_artwork_notice_is_not_repeated_by_a_no_op_re_tag(
+    album_with_tracks, tmp_path
+):
+    """#272: the notice reports a decision that recurs identically, not a change,
+    so a re-tag that finds the files already correct used to say it again — and
+    under #32's nightly pass that is one warning per night forever on every
+    compilation, which is a History nobody can read.
+
+    It rides on the write instead: `_record_changes` already takes the position
+    that "a re-tag that finds MusicBrainz unchanged is a no-op the user should
+    not have to scroll past", and this line joins it.
+    """
+    from datetime import UTC, datetime
+
+    from harmonist import activity, activity_store
+    from harmonist import sidecar as sidecar_mod
+    from harmonist.models import Sidecar
+
+    activity_store.init(tmp_path / "activity.db")
+    activity.install_log_handler()
+    album_dir = album_with_tracks(2)
+    sidecar_mod.write(
+        album_dir, Sidecar(mb_release_id="rel-aaa", tagged_at=datetime(2026, 1, 1, tzinfo=UTC))
+    )
+    _embed_cover(album_dir / "01 Track 1.m4a", _minimal_jpeg())
+    _embed_cover(album_dir / "02 Track 2.m4a", _minimal_jpeg() + b"_different")
+    new_cover = tmp_path / "cover.jpg"
+    new_cover.write_bytes(b"\xff\xd8\xff\xe0NEW_ALBUM_COVER\xff\xd9")
+
+    def notices() -> int:
+        return sum(
+            "per-track embedded artwork" in e.message
+            for e in activity_store.album_history("rel-aaa")
+        )
+
+    # The first pass writes the tags, so it reports the decision it made on the
+    # way — that is #260, and it stays.
+    tagger.tag_album(album_dir, _release_2_tracks(), cover_path=new_cover)
+    assert notices() == 1
+
+    # The second finds every file already carrying what MusicBrainz says and
+    # writes nothing at all. Silence is the feature.
+    tagger.tag_album(album_dir, _release_2_tracks(), cover_path=new_cover)
+    assert notices() == 1
+
+
 def test_tag_album_overwrite_art_forces_replacement(album_with_tracks, tmp_path):
     """overwrite_art=True is the explicit override: embed the album cover even over
     differing per-track art."""


### PR DESCRIPTION
The per-track-artwork notice fired *before* the write loop, so it reported a decision rather than a change. Preserving the user's images is the outcome every re-tag reaches, so a re-tag that found the files already correct said it again anyway — and under #32's nightly pass that becomes one warning per night, forever, on every compilation, leaving a History made mostly of one repeated sentence.

The line now sits after the loop and only speaks when a file was actually written. That is the position `_record_changes` already takes for the per-field detail — *"a re-tag that finds MusicBrainz unchanged is a no-op the user should not have to scroll past"* — and #272 asked for this line to join it rather than be demoted back to an audit-only token, which is the state #260 was filed against.

**The trade.** A crash part-way through the loop now loses the feed line. That is acceptable: the `tag.album` audit record carries `art=preserved` and is still written before the first write, so the forensic half of the decision is down either way.

**Test.** `test_the_preserved_artwork_notice_is_not_repeated_by_a_no_op_re_tag` tags a per-track-art album twice and counts the notices in its History. Written red-first: it failed on `assert 2 == 1`, with the first assertion passing — which also confirmed the second pass genuinely writes nothing.

I also swept the rest of the write path for the same shape, as the issue asks. The tagger's only other logging is genuine-failure warnings in `artwork_store`, and `_keep_doomed_art` runs only when art really is about to be overwritten. The `tag.album` record itself still fires on a no-op, deliberately: it is the intent record written before a destructive loop, it is forensics rather than feed, and the gardener only reaches `tag_album` with a non-empty plan.

Fixes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdkdB2TNTMYTdCL2QGYGes