### PR TITLE
Leave one line for a pass, and none for a quiet one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- **A background update check that finds something now says so in Activity** —
+  one line per pass ("Update check: 3 albums now have an update available"),
+  never one per album, and nothing at all from a pass that found nothing (#274).
+
 ### Fixed
 
 - **A re-tag that changes nothing no longer repeats the note about keeping

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -231,16 +231,23 @@ you tagged it — each with its count:
   You can have Harmonist go and look instead of waiting to be asked. Set
   **Background update checks** to *Look and report* on the **Settings** page and
   a small background pass works through the library, checking the albums it has
-  looked at least recently against MusicBrainz — roughly a hundred an hour while
-  nothing else is happening, so every album comes round about weekly. It only
-  ever *looks*: taking an update is still a button you press. It waits for any
-  sync, reconcile or scan to finish rather than competing with them, and it is
-  off until you turn it on.
+  looked at least recently against MusicBrainz — a few of them every ten minutes
+  while nothing else is happening, so whatever is due gets through in about a day
+  and every album comes round about weekly. It only ever *looks*: taking an
+  update is still a button you press. It waits for any sync, reconcile or scan to
+  finish rather than competing with them, and it is off until you turn it on.
+
+  When a pass turns something up it leaves one line in **Activity** —
+  *"Update check: 3 albums now have an update available"* — one line per pass
+  rather than one per album, and nothing at all from a pass that found nothing.
+  Only albums that didn't already have an update waiting are counted, so an
+  update you haven't got round to yet isn't announced again every time
+  MusicBrainz touches the release.
 
   The setting applies straight away — no restart — but the first pass is
-  otherwise up to an hour off, which looks like nothing happened. **Check now**,
-  beside the setting, runs one immediately; what it finds turns up here and as
-  the purple **Update** badge on the tiles. (`level` under `[gardener]` in
+  otherwise up to ten minutes off, which looks like nothing happened. **Check
+  now**, beside the setting, runs one immediately; what it finds turns up here
+  and as the purple **Update** badge on the tiles. (`level` under `[gardener]` in
   `harmonist.toml` is the same setting, for a config-managed install.)
 
 ### When you don't want the update

--- a/src/harmonist/gardener.py
+++ b/src/harmonist/gardener.py
@@ -66,7 +66,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from . import activity_store, album_files, formats, mb_cache, mb_lookup, tagger
+from . import activity, activity_store, album_files, formats, mb_cache, mb_lookup, tagger
 from .formats import owned
 from .models import Album, AlbumState, Release
 
@@ -468,6 +468,13 @@ class PassResult:
     examined: int
     #: Of those, the ones that turned out to have an update outstanding.
     flagged: int
+    #: Of those, the ones that did NOT have one before this pass looked. The
+    #: digest counts these and not `flagged`, and the difference is the whole of
+    #: #274's discipline: an album the user has been sitting on for a fortnight
+    #: is still outstanding every time MusicBrainz touches the release, so
+    #: `flagged` would announce it again on an edit that changed nothing for
+    #: them. A transition is news; a standing state is not (#272).
+    newly_flagged: int
     #: Releases MusicBrainz no longer has (#194/#210).
     gone: int
     #: Fetches that failed — a network error, a 503. Not an answer either way.
@@ -561,7 +568,7 @@ def sweep(
     log.debug(
         "update check: %d album(s) due, asking MusicBrainz about up to %d", len(due), slice_size
     )
-    asked = examined = flagged = gone = failed = 0
+    asked = examined = flagged = newly_flagged = gone = failed = 0
     gave_up = False
     reported = time.monotonic()
     for mbid, group in due[:slice_size]:
@@ -631,21 +638,43 @@ def sweep(
             continue  # MusicBrainz has said nothing new; read no files
         examined += len(group)
         for album in group:
+            # Read BEFORE the refresh, because the refresh is what overwrites
+            # it. This is the only moment the two are both knowable, and the
+            # digest is a statement about the difference between them.
+            #
+            # The flag is in-memory and rebuilt by `warm_from_cache` after a
+            # restart, so a pass that overtakes the warm-up can read False for
+            # an album that was already flagged and announce it a second time.
+            # Bounded — it needs an album that is due, whose payload has moved,
+            # that was flagged before the restart and that the warm-up has not
+            # reached yet — and the only cure would be persisting the flag,
+            # which is exactly the stored state this module refuses to keep
+            # (see the header). A repeated line is the cheaper failure.
+            was_flagged = album.update_available
             refresh_flag(album, release)
             if album.update_available:
                 flagged += 1
+                if not was_flagged:
+                    newly_flagged += 1
         if time.monotonic() - reported >= _PROGRESS_EVERY.total_seconds():
             reported = time.monotonic()
             log.info("update check: %d asked, %d with something new", asked, examined)
     result = PassResult(
-        asked=asked, examined=examined, flagged=flagged, gone=gone, failed=failed, gave_up=gave_up
+        asked=asked,
+        examined=examined,
+        flagged=flagged,
+        newly_flagged=newly_flagged,
+        gone=gone,
+        failed=failed,
+        gave_up=gave_up,
     )
+    _record_digest(result)
     # INFO only when the tick has something to report (#349). At an hourly tick
     # asking about a hundred albums this line was always worth reading; at one
     # every ten minutes asking about two it is 144 lines a day saying nothing
     # happened, which is how a log stops being read. A tick that found something
     # — a payload that moved, a release gone, a fetch that failed — still says
-    # so; #274's digest is what turns the rest into something a user sees.
+    # so; the digest above is what turns the rest into something a user sees.
     notable = bool(result.examined or result.gone or result.failed or result.gave_up)
     log.log(
         logging.INFO if notable else logging.DEBUG,
@@ -659,6 +688,45 @@ def sweep(
         result.failed,
     )
     return result
+
+
+def _record_digest(result: PassResult) -> None:
+    """Leave one Activity entry for what the pass found, or none at all (#274).
+
+    One row per pass, never one per album: a tick that wrote a line for each
+    album it looked at would bury the feed under its own bookkeeping, which is
+    the failure mode that makes people stop reading it. The per-album account
+    lives on the album — its History, its tile badge, the Update available
+    filter — and this is the global feed's summary of it.
+
+    **Only the transition.** `newly_flagged`, not `flagged`: an album whose
+    update the user has yet to take is outstanding on every pass, so counting
+    the standing state would re-announce it whenever MusicBrainz touched the
+    release at all — the same "narrating a state rather than a change" #272 took
+    out of the tagger.
+
+    **Silence is a valid digest**, and the common one. Nothing else the pass can
+    report belongs to the user:
+
+    * a release MusicBrainz no longer has is a standing fact, not tonight's news
+      — it is still gone next week, and the album's own page has said so since
+      #194/#210;
+    * a failed fetch is a MusicBrainz wobble the next pass retries, kept out of
+      the feed on purpose (`_diagnostic`);
+    * a pass that gave up already posts its own warning, once per episode.
+
+    So the digest speaks exactly when a person has something new to look at. No
+    action scope: it is a summary of many albums, nothing hangs off it, and
+    there is nothing to correlate or revert — the same shape as reconcile's
+    closing line.
+    """
+    if not result.newly_flagged:
+        return
+    n = result.newly_flagged
+    activity.record(
+        f"Update check: {n} album{'' if n == 1 else 's'} now {'has' if n == 1 else 'have'} "
+        "an update available — see the Library's Update available filter"
+    )
 
 
 def _due(

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -945,6 +945,99 @@ def test_a_pass_finds_an_update_nobody_went_looking_for(tmp_path, monkeypatch):
     assert (result.examined, result.flagged) == (1, 1)
 
 
+def _digest() -> list[str]:
+    """The pass's own entries in the Activity feed (#274), newest first."""
+    return [
+        e.message
+        for e in activity_store.recent(source=activity_store.Source.ACTIVITY)
+        if e.message.startswith("Update check:")
+    ]
+
+
+def test_a_pass_leaves_one_digest_for_everything_it_found(tmp_path, monkeypatch):
+    """#274: one entry per pass, not one per album. Two albums, one row — and the
+    row counts them, so the feed says how much is waiting without becoming the
+    thing that buries everything else in it."""
+    activity_store.init(tmp_path / "activity.db")
+    other = _release("Other Album", mbid="rel-bbb")
+    albums = [
+        _tagged(tmp_path, _release()),
+        _tagged(tmp_path, other, name="Other Album"),
+    ]
+    _store(_release(), age=_stale())
+    _store(other, age=_stale())
+    _serving(
+        monkeypatch,
+        _release("Test Album (remastered)"),
+        _release("Other Album (remastered)", mbid="rel-bbb"),
+    )
+
+    # `limit`, because the paced slice is 1/144th of what's due (#349) and would
+    # take one album a tick — the digest's shape is what's under test here, not
+    # the rate.
+    gardener.sweep(albums, limit=2)
+
+    expected = (
+        "Update check: 2 albums now have an update available — "
+        "see the Library's Update available filter"
+    )
+    assert _digest() == [expected]
+
+
+def test_the_digest_reads_in_the_singular_for_one_album(tmp_path, monkeypatch):
+    """The count is the whole content of the line, so "1 albums now have" is the
+    one way it can read wrong (#384 for the same trap in the outlier popover)."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    _store(_release(), age=_stale())
+    _serving(monkeypatch, _release("Test Album (remastered)"))
+
+    gardener.sweep([album])
+
+    expected = (
+        "Update check: 1 album now has an update available — "
+        "see the Library's Update available filter"
+    )
+    assert _digest() == [expected]
+
+
+def test_a_pass_that_finds_nothing_writes_nothing_to_the_feed(tmp_path, monkeypatch):
+    """Silence is a valid digest, and the common one. A tick fires every ten
+    minutes; one that announced itself either way would be 144 rows a day saying
+    nothing happened, which is how a feed stops being read."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    _store(_release(), age=_stale())
+    _serving(monkeypatch, _release())
+
+    gardener.sweep([album])
+
+    assert album.update_available is False
+    assert _digest() == []
+
+
+def test_an_album_already_flagged_is_not_announced_a_second_time(tmp_path, monkeypatch):
+    """The digest counts the transition, not the standing state. An album whose
+    update the user has yet to take is outstanding on every pass, so counting
+    `flagged` would re-announce it every time MusicBrainz touched the release —
+    an edit that changed nothing for them. Same discipline as #272."""
+    activity_store.init(tmp_path / "activity.db")
+    album = _tagged(tmp_path, _release())
+    moved = _release("Test Album (remastered)")
+    _store(moved, age=_stale())
+    gardener.refresh_flag(album, moved)
+    assert album.update_available is True
+
+    # MusicBrainz edits the release AGAIN, so the payload really has moved and
+    # the early exit does not get a turn: the pass reads the files and finds the
+    # update still outstanding, which is not news.
+    _serving(monkeypatch, _release("Test Album (remastered, again)"))
+    result = gardener.sweep([album])
+
+    assert (result.examined, result.flagged, result.newly_flagged) == (1, 1, 0)
+    assert _digest() == []
+
+
 def test_an_unchanged_release_never_reaches_the_files(tmp_path, monkeypatch):
     """The early exit, which is what makes a nightly pass over an unchanged
     library cost its requests and nothing else. Asserted as *no plan was built*
@@ -1348,7 +1441,9 @@ def _sweep_signal(monkeypatch) -> threading.Event:
 
     def _sweep(albums, **kwargs):
         done.set()
-        return gardener.PassResult(asked=0, examined=0, flagged=0, gone=0, failed=0)
+        return gardener.PassResult(
+            asked=0, examined=0, flagged=0, newly_flagged=0, gone=0, failed=0
+        )
 
     monkeypatch.setattr(gardener, "sweep", _sweep)
     return done

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -5373,7 +5373,9 @@ def test_check_now_starts_a_pass(client, cfg, monkeypatch):
 
     def _sweep(albums, **kw):
         swept.set()
-        return gardener.PassResult(asked=0, examined=0, flagged=0, gone=0, failed=0)
+        return gardener.PassResult(
+            asked=0, examined=0, flagged=0, newly_flagged=0, gone=0, failed=0
+        )
 
     monkeypatch.setattr(client.app.state.scan_runner, "has_completed", lambda: True, raising=False)
     monkeypatch.setattr(gardener, "sweep", _sweep)
@@ -5402,7 +5404,9 @@ def test_check_now_says_why_when_it_declines(client, cfg, monkeypatch):
 
     def _sweep(albums, **kw):
         swept.set()
-        return gardener.PassResult(asked=0, examined=0, flagged=0, gone=0, failed=0)
+        return gardener.PassResult(
+            asked=0, examined=0, flagged=0, newly_flagged=0, gone=0, failed=0
+        )
 
     monkeypatch.setattr(gardener, "sweep", _sweep)
 


### PR DESCRIPTION
The update check found things and told nobody. Its results lived in the log and in the Library's filter, so the Activity feed — where a user goes to read what Harmonist has been doing — said nothing at all about the one part of it that runs unattended.

`gardener.sweep` now ends with `_record_digest`: one line per pass saying how many albums it turned up, and nothing at all from a pass that found nothing. Never one line per album — the per-album account already has three homes (the album's History, its tile badge, the Update available filter), and a row per album is precisely the shape that makes a feed unreadable. With #349's ten-minute tick, silence has to be the default rather than a nicety.

**It counts the transition, not the standing state.** A new `PassResult.newly_flagged` counts albums that did *not* have an update outstanding before this pass looked. An album whose update the user has yet to take is outstanding on every pass, so counting `flagged` would re-announce it whenever MusicBrainz touched the release at all — an edit that changed nothing for them. That is #272's discipline one module along, and it is what makes a nightly timer bearable.

**Nothing else the pass knows belongs to the user**, and each exclusion has its reason in the docstring: a release MusicBrainz no longer has is a standing fact the album page has carried since #194/#210; a failed fetch is a wobble the next pass retries, deliberately kept out of the feed; a pass that gives up already posts its own warning, once per episode.

**Tests** (`test_gardener.py`, four): two albums → one row reading "2 albums"; one album → the singular; a quiet pass → an empty feed; an already-flagged album whose release moves again → silence. Written after the code, so all three plausible mutations were run — counting `flagged`, recording unconditionally, recording once per album — and each went red on the right test.

**Two notes.**

The issue asks for a digest "that links through to the albums involved". This is words, not a link: the feed escapes messages and links only the album name via `album_id`, which a multi-album digest hasn't got, so a real link means a new store column and feed-template work for one reader. It matches the existing "Reconcile done: …" summary instead, and points at the filter (#287/#293) that is one tab away.

The usage guide's account of the rate ("roughly a hundred an hour", "the first pass is up to an hour off") went stale when #349 replaced the hand-set cap with a goal window. It is corrected here, in the same paragraph the new sentence lands in.

Fixes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdkdB2TNTMYTdCL2QGYGes