### PR TITLE
Ask the files which track they are before comparing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **A suggested release is now lined up against your files the same way the
+  album page and the tagger line them up.** The matcher paired the two lists by
+  position alone, so an album whose files don't sort into track order — a
+  Bandcamp download whose tracks credit different artists sorts by the credit,
+  not the number — was compared against its own tracks in the wrong order:
+  rows of differences that were nobody's, a match downgraded from exact to
+  approximate, and an album parked awaiting a decision it never needed. Existing
+  suggestions are re-paired by Refresh from MB or the next recheck (#395).
+
 - **A re-tag that changes nothing no longer repeats the note about keeping
   per-track artwork.** The note now rides on an actual write, so a compilation's
   History doesn't collect the same sentence once per re-tag (#272).

--- a/docs/design.md
+++ b/docs/design.md
@@ -710,6 +710,8 @@ A URL → MBID match from [MusicBrainz](https:://musicbrainz.org) is exact, but 
 
 Track lengths compared are the per-release **track** lengths, not the recording lengths (which can differ by seconds across releases).
 
+Which file is compared against which track is **not** positional — it goes through `compare.assign` like everywhere else (see *Which file is which track* below). The durations above are what the confidence is derived from and what `best_match` ranks competing releases on, so pairing the two lists by position alone did not merely describe an album badly: an album whose files don't sort into track order was measured against its own tracks in the wrong order, downgraded from exact to approximate, and parked awaiting a decision it never needed (#395).
+
 Confirm → promote candidate to `mb_release_id`, clear candidate, run tagger.
 Dismiss suggestion → clear candidate; the album stays in Needs MBID so a different release can be assigned.
 
@@ -893,9 +895,9 @@ The current code's `MUSICBRAINZ_RELEASEID` atom is **non-Picard** and gets remov
 ### Which file is which track
 
 One ladder, `compare.assign`, answers this for everything — the album page's
-tracklist and the tagger both — and it is tried in order: the file's
-**MusicBrainz Release Track Id**, then its **disc-and-track number**, then
-**file order** (#232).
+tracklist, the tagger, and the match assessment above — and it is tried in
+order: the file's **MusicBrainz Release Track Id**, then its
+**disc-and-track number**, then **file order** (#232, #395).
 
 Only the first rung is an identity. Harmonist writes that id on everything it
 tags and Picard writes the same one, so for any album either tool has touched

--- a/src/harmonist/formats/m4a.py
+++ b/src/harmonist/formats/m4a.py
@@ -319,7 +319,11 @@ def read_tags(path: Path) -> TrackTags:
         artist=_text_atom(audio, ATOM_ARTIST),
         track_num=trkn[0][0] if trkn and trkn[0] else None,
         disc_num=disk[0][0] if disk and disk[0] else None,
-        duration_ms=int(audio.info.length * 1000) if audio.info else None,
+        # Rounded, like `read_duration_ms` above and like every other format
+        # module: truncating made this reader disagree with that one by a
+        # millisecond on the same file, which the matcher then showed as a
+        # per-track delta on an album that matches exactly (#395).
+        duration_ms=round(audio.info.length * 1000) if audio.info else None,
         comment=_text_atom(audio, ATOM_COMMENT),
         release_track_id=_binary_atom_str(audio, ATOM_MB_RELEASE_TRACK_ID),
         # Every owned field too, off the handle already open — so the album

--- a/src/harmonist/match.py
+++ b/src/harmonist/match.py
@@ -10,13 +10,12 @@ the suggestion inline until the user Confirms or Dismisses it.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from itertools import zip_longest
 from pathlib import Path
 
-from . import album_files, formats
+from . import album_files, compare, formats
 from .compare import LENGTH_TOLERANCE_MS
 from .models import MatchCandidate, MatchConfidence, Release, Track, TrackComparison
-from .tagger import _flatten_tracks, _track_title
+from .tagger import _flatten_tracks, _identity_of, _track_title
 
 __all__ = ["LENGTH_TOLERANCE_MS", "assess_match", "best_match", "mb_track_lengths"]
 
@@ -31,6 +30,25 @@ def assess_match(album_dir: Path, release: Release) -> MatchCandidate:
       - "approximate": file count matches but at least one track is unknown
         or out of tolerance.
       - "no_match": file count differs from MB track count.
+
+    Which file is which track is decided by `compare.assign` (#395) — the same
+    ladder the album page and the tagger use, so the three cannot answer it
+    differently (#232). This used to pair the two lists **positionally**, which
+    is only the ladder's bottom rung and reaches it without asking the files
+    anything.
+
+    *cv313 — live [w/japan exclusive album]* is what that cost. Bandcamp names
+    a file `<track artist> - <album> - NN <title>`, and the credits vary across
+    that release — `cv313`, `deepchord`, `echospace` — so the prefix decided
+    the sort and the number in the middle of the name never got a vote. Ten
+    correctly-numbered files whose durations matched MusicBrainz to the
+    millisecond were compared against each other's tracks: nine rows of
+    differences, a verdict of "approximate" instead of "exact", and an album
+    parked in NEEDS_MBID waiting on a decision it never needed.
+
+    So the deltas here are not merely displayed. They are what the confidence
+    is derived from, and `best_match` ranks releases on their total — a
+    mis-pairing can pick the wrong release, not just describe one badly.
     """
     files = album_files.audio_files(album_dir)
     tracks = list(_flatten_tracks(release))
@@ -39,17 +57,37 @@ def assess_match(album_dir: Path, release: Release) -> MatchCandidate:
     track_count = len(tracks)
     notes: list[str] = []
 
+    # One open per file, where the durations and titles alone took two. The
+    # ladder needs the numbers and the release track id from the same read.
+    tags = [formats.read_tags(f) for f in files]
+    slots = compare.assign(
+        [compare.identity_of(t) for t in tags],
+        [_identity_of(t) for t in tracks],
+    )
+    file_of = {slot: i for i, slot in enumerate(slots) if slot is not None}
+
+    # Rows run down the RELEASE's tracklist — so the panel numbers them the way
+    # MusicBrainz does — and then whatever files found no slot in it. Both
+    # halves are padded, because a row with nothing on one side is a finding
+    # worth showing: a track that isn't on disk, a file the release has no
+    # place for.
+    rows: list[tuple[int | None, int | None]] = [(file_of.get(t), t) for t in range(track_count)]
+    rows += [(f, None) for f, slot in enumerate(slots) if slot is None]
+
     comparisons: list[TrackComparison] = []
     any_significant_delta = False
     any_unknown_length = False
 
-    for f, mb_entry in zip_longest(files, tracks, fillvalue=None):
-        track = mb_entry[2] if mb_entry is not None else None
+    for file_i, track_i in rows:
+        track = tracks[track_i][2] if track_i is not None else None
 
-        if f is not None:
-            file_name = f.name
-            file_dur_ms = _file_duration_ms(f)
-            file_title = _file_title(f) or f.stem
+        if file_i is not None:
+            file_name = files[file_i].name
+            # `or 0` as reading the duration on its own did: a file Harmonist
+            # cannot open has no length, and calling that a match would be a
+            # claim it never made.
+            file_dur_ms = tags[file_i].duration_ms or 0
+            file_title = tags[file_i].title or files[file_i].stem
         else:
             file_name = None
             file_dur_ms = None
@@ -141,15 +179,6 @@ def _rank_key(c: MatchCandidate) -> tuple[int, int, int]:
     count_gap = abs(c.file_count - c.track_count)
     total_delta = sum(abs(tc.delta_ms) for tc in c.track_comparisons if tc.delta_ms is not None)
     return (confidence, -count_gap, -total_delta)
-
-
-def _file_duration_ms(file_path: Path) -> int:
-    return formats.read_duration_ms(file_path) or 0
-
-
-def _file_title(file_path: Path) -> str | None:
-    """Read the track title tag from the file, if present."""
-    return formats.read_track_title(file_path)
 
 
 def mb_track_lengths(release: Release) -> list[int | None]:

--- a/test/test_match.py
+++ b/test/test_match.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+from mutagen.mp4 import MP4
+
 from harmonist.match import _mb_track_length_ms, assess_match, best_match
 from harmonist.models import MatchCandidate, TrackComparison
-from harmonist.tagger import ATOM_TITLE
+from harmonist.tagger import ATOM_MB_RELEASE_TRACK_ID, ATOM_TITLE, ATOM_TRACK_NUM
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 SINE_M4A = FIXTURES_DIR / "sine.m4a"
@@ -381,3 +383,92 @@ def test_title_differs_still_sees_punctuation_that_says_something():
         ("Dawn Chorus", "Dawn Chorus (Alt. Take)"),
     ]:
         assert _tc(on_disk, from_mb).title_differs is True, on_disk
+
+
+# -- which file is which track: the matcher climbs the same ladder (#395) --
+
+
+def _bandcamp_named_album(tmp_path: Path, credits: list[str]) -> Path:
+    """An album whose filename order is not its track order.
+
+    Bandcamp names a downloaded file `<track artist> - <album> - NN <title>`,
+    so on a release whose tracks credit different artists the prefix decides
+    the sort and the number in the middle of the name never gets a vote:
+
+        cv313 …01, cv313 …03, deepchord …02
+
+    Every file still carries its real track number as a tag, so nothing here is
+    ambiguous — the order on disk simply isn't the order of the release. This
+    is *cv313 — live [w/japan exclusive album]* in miniature: ten files across
+    three credits, every duration matching MusicBrainz to the millisecond, and
+    nine of the ten rows reported as differences.
+    """
+    d = tmp_path / "Artist" / "Album"
+    d.mkdir(parents=True)
+    for i, credit in enumerate(credits, start=1):
+        path = d / f"{credit} - Album - {i:02d} Track {i}.m4a"
+        shutil.copy(SINE_M4A, path)
+        audio = MP4(path)
+        audio[ATOM_TITLE] = [f"Track {i}"]
+        audio[ATOM_TRACK_NUM] = [(i, len(credits))]
+        audio.save()
+    return d
+
+
+def test_matcher_pairs_by_track_number_not_by_filename_order(tmp_path):
+    """The rows the suggestion panel is built from, and the verdict with them:
+    a mis-pairing invents per-track deltas that are nobody's real difference,
+    drops the confidence from exact to approximate, and parks an album that
+    needed no decision at all.
+
+    (The fixtures all share one duration, so what this pins is the pairing —
+    the arithmetic from deltas to confidence is covered above.)
+    """
+    album_dir = _bandcamp_named_album(tmp_path, ["cv313", "deepchord", "cv313"])
+
+    result = assess_match(album_dir, _release([FIXTURE_DURATION_MS] * 3))
+
+    # Rows run down the release's tracklist, so the panel numbers them the way
+    # MusicBrainz does — and each carries the file that is actually that track.
+    assert [tc.mb_track_title for tc in result.track_comparisons] == [
+        "Track 1",
+        "Track 2",
+        "Track 3",
+    ]
+    assert [tc.file_name for tc in result.track_comparisons] == [
+        "cv313 - Album - 01 Track 1.m4a",
+        "deepchord - Album - 02 Track 2.m4a",
+        "cv313 - Album - 03 Track 3.m4a",
+    ]
+
+
+def test_matcher_prefers_the_release_track_id_to_a_stale_number(tmp_path):
+    """The top rung, and the one that is not a guess (#232).
+
+    The TISM shape: MusicBrainz renumbered the release after these files were
+    tagged, so their numbers point at the wrong slots while their ids still
+    name the right ones. Both the number rung and plain file order get this
+    album exactly backwards, so only reading the id can produce the pairing
+    asserted here.
+    """
+    d = tmp_path / "Artist" / "Album"
+    d.mkdir(parents=True)
+    # The file MusicBrainz now calls track 1 still says it is track 3, and
+    # vice versa. Every id is current; only the numbers went stale.
+    for stale, real in ((3, 1), (1, 3), (2, 2)):
+        path = d / f"{stale:02d} Renumbered.m4a"
+        shutil.copy(SINE_M4A, path)
+        audio = MP4(path)
+        audio[ATOM_TITLE] = [f"Track {real}"]
+        audio[ATOM_TRACK_NUM] = [(stale, 3)]
+        audio[ATOM_MB_RELEASE_TRACK_ID] = [f"rt-{real}".encode()]
+        audio.save()
+
+    result = assess_match(d, _release([FIXTURE_DURATION_MS] * 3))
+
+    assert [tc.file_title for tc in result.track_comparisons] == [
+        "Track 1",
+        "Track 2",
+        "Track 3",
+    ]
+    assert result.title_mismatch_count == 0


### PR DESCRIPTION
The match assessment paired files against a release's tracklist with a bare positional zip over filename order, so it reached the bottom rung of #232's ladder without asking the files anything. It is the third decider of "which file is which track", and the one #232 missed.

cv313's *live [w/japan exclusive album]* is what that cost. Bandcamp names a file `<track artist> - <album> - NN <title>` and that release's credits vary, so the prefix decided the sort and the number in the middle of the name never got a vote — `cv313 …01/03/05/06/08/10`, `deepchord …02/07`, `echospace …04/09`. Ten correctly-numbered files whose durations match MusicBrainz to the millisecond were compared against each other's tracks.

The deltas are not merely displayed. They are what the confidence is derived from, so a release that fits exactly was reported as approximate and the album sat in Needs MBID awaiting a decision it never needed; and `best_match` ranks competing releases on their total, so a mis-pairing can pick the wrong release outright. Tagging was never at risk — `tagger._assign_files_to_tracks` has gone through `compare.assign` since #232.

Rows now run down the release's tracklist with the file that is actually each track beside it, and unplaced files follow. Reading tags once per file rather than a duration and a title separately halves the opens, and drops the m4a reader's lone `int()` for the `round()` its three siblings already use — the two disagreed by a millisecond on the same file, which showed up as a per-track delta on an album that matches exactly.

**Verified on the album that raised it.** Run through the new `assess_match` against its own release:

```
confidence: exact | notes: [] | title mismatches: 0
deltas: [0, 0, 0, 0, 0, 0, 0, 0, 0, 2]
```

Ten of ten paired correctly; the lone 2ms is the difference MusicBrainz actually records on the bonus disc. It would have been tagged on sync with no panel and no decision.

**Tests** — pure-logic rung, since `assess_match`'s only I/O is the directory listing and the tag read:

- `test_matcher_pairs_by_track_number_not_by_filename_order` — the reproduction, written red first; failed on `At index 1 diff: 'cv313 …03 Track 3.m4a' != 'deepchord …02 Track 2.m4a'`.
- `test_matcher_prefers_the_release_track_id_to_a_stale_number` — the top rung, where both the number rung and plain file order get the album backwards, so only reading the id can produce the asserted pairing.

Both mutation-checked: forcing `slots` back to positional turns them red.

#136 stays wanted — it is the escape hatch for a pairing the ladder itself gets wrong, which this album was never an instance of.

Fixes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdkdB2TNTMYTdCL2QGYGes