### PR TITLE
Promise the last five artwork changes per album, not 500 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- **The last five artwork changes to any album can always be undone**, whatever
+  else Harmonist has been tagging. Kept artwork used to be bounded only by a
+  total size, so a busy night's re-tagging could quietly evict the copy behind
+  an Undo a different album was still offering. The size cap remains as a
+  backstop, and Settings now states the promise rather than only the number.
+  Configurable as `artwork_store.keep_per_album` (#408).
+
 ### Added
 
 - **An Artwork section on the album page** — what artwork your files actually

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -488,9 +488,12 @@ point:
 
 The undo is itself recorded, so it can be undone in turn.
 
-**Cover art has its own Undo.** Artwork that a re-tag overwrites is kept in a
-bounded store (500 MB) and can be put back from the Artwork row in History.
-Settings shows what's held under **Kept artwork**.
+**Cover art has its own Undo.** Artwork that a re-tag overwrites is kept, and can
+be put back from the Artwork row in History. **The last five artwork changes to
+any album are kept**, however many albums you tag — so a busy library can't cost
+you the undo on the one album you were working on. A 500 MB ceiling sits under
+that as a backstop; both numbers are `harmonist.toml` settings, and Settings
+shows what's held under **Kept artwork**.
 
 ## Activity
 
@@ -535,7 +538,8 @@ What makes the record worth reading rather than just kept:
   MusicBrainz user agent, log level. Saved to `harmonist.toml` and applied right
   away; see [installation.md](installation.md#configuration) for the file itself.
 - **Won't download** — the purchases you've set aside, each with **Restore**.
-- **Kept artwork** — the images re-tags have overwritten, still recoverable.
+- **Kept artwork** — the images re-tags have overwritten, still recoverable:
+  the last five changes per album, and how much room they take.
 - **Maintenance** — erase all `.harmonist.json` sidecars. Audio files aren't
   touched, but every match and sync link is removed; this is the uninstall step,
   not a routine one.

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -33,6 +33,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from .formats.owned import ARTWORK
+
 log = logging.getLogger(__name__)
 
 
@@ -681,6 +683,79 @@ def version() -> str:
 #: The audit type written when the scanner first meets an album (#107). Also
 #: serves as the "have we met?" marker — see `already_discovered`.
 DISCOVERY_EVENT = "album.discovered"
+
+
+@dataclass(frozen=True)
+class ArtworkBackup:
+    """One tagging that replaced artwork, and the images it replaced.
+
+    The unit is the TAGGING, not the file: a compilation whose four per-track
+    covers are overwritten in one go is one thing the user would undo, and
+    retention counts it once (#408).
+    """
+
+    album_id: str
+    event_id: int
+    digests: frozenset[str]
+
+
+def artwork_backups() -> list[ArtworkBackup]:
+    """Every tagging that replaced artwork, newest first.
+
+    Facts, not policy: how many an album keeps is `artwork_store`'s decision.
+    This answers only "which images were replaced by which tagging, on which
+    album", which is the same question `_restorable_anchors` asks per album — so
+    retention protects exactly what the UI offers an Undo for, rather than a
+    second opinion about it that could disagree.
+
+    Grouped by event because `tag_changes` holds a row per FILE: an album's
+    tagging contributes as many rows as it wrote files, and all of them belong
+    to the one change.
+
+    Album id is the one stored on the event, NOT resolved through the alias
+    chain. That is correct here and worth stating: an album re-identified since
+    the tagging has its old id on these rows and its new one today, and both
+    sets are still its own backups — they are protected under whichever id they
+    were written with, so a re-identification cannot orphan them.
+    """
+    try:
+        conn = _ensure()
+        with _LOCK:
+            rows = conn.execute(
+                "SELECT e.album_id, c.event_id, c.changes "
+                "FROM tag_changes c JOIN events e ON e.id = c.event_id "
+                "WHERE e.album_id IS NOT NULL "
+                "ORDER BY c.event_id DESC"
+            ).fetchall()
+    except sqlite3.Error:
+        log.exception("activity_store artwork_backups failed", extra=_QUIET_MIRROR)
+        return []
+
+    by_event: dict[int, tuple[str, set[str]]] = {}
+    order: list[int] = []
+    for album_id, event_id, payload in rows:
+        try:
+            parsed = json.loads(payload)
+        except (TypeError, ValueError):
+            log.warning("tag_changes row %s has unreadable JSON — skipping", event_id)
+            continue
+        pair = parsed.get(ARTWORK) if isinstance(parsed, dict) else None
+        # `[before, after]`, and only a real `before` is a backup: a track that
+        # GAINED art it never had has nothing kept for it, exactly as
+        # `tag_history.artwork_replaced` reads the same pair.
+        if not isinstance(pair, list) or len(pair) != 2 or not isinstance(pair[0], str):
+            continue
+        if not pair[0]:
+            continue
+        key = int(event_id)
+        if key not in by_event:
+            by_event[key] = (str(album_id), set())
+            order.append(key)
+        by_event[key][1].add(pair[0])
+    return [
+        ArtworkBackup(album_id=by_event[e][0], event_id=e, digests=frozenset(by_event[e][1]))
+        for e in order
+    ]
 
 
 def already_discovered(album_ids: list[str]) -> set[str]:

--- a/src/harmonist/artwork_store.py
+++ b/src/harmonist/artwork_store.py
@@ -18,11 +18,24 @@ needs its own index. The digest in the record IS the lookup key.
 
 **Bounded, and honest about it.** Nothing prunes `activity.db` today, which is
 fine for text and is not fine for images: unattended re-tagging on a NAS would
-fill the disk. So the store has a size cap and evicts oldest-first, and a
-restore is therefore best-effort — an old enough change becomes unrevertable and
-the UI has to say so. That is the deliberate trade against unbounded growth,
-made where the user can see it (a Settings figure) rather than discovered when a
-volume fills up.
+fill the disk. So the store is bounded — but by a promise rather than only by a
+number (#408).
+
+**The promise is per album: the last `keep_per_album` artwork changes on any
+album can be undone.** A global byte cap alone could not make that promise, and
+broke it in the way that matters least visibly — a background pass backing up
+five hundred albums overnight would evict the copy behind the Undo button your
+album was still offering, on a schedule nobody can predict. Retention is
+therefore computed from the same records the UI reads (`activity_store`'s
+artwork backups, grouped per tagging), so what is protected is exactly what the
+page offers to restore rather than a second opinion about it.
+
+The byte cap remains as a **backstop**, not the policy: it only bites once every
+album is already down to its protected set, and when it does it takes the oldest
+change first and says so loudly. A restore is still best-effort — an old enough
+change becomes unrevertable and the UI says so — but "old enough" now means
+"you have changed this album's artwork five times since", which a user can
+reason about, rather than "someone else's albums needed the room".
 """
 
 from __future__ import annotations
@@ -38,21 +51,35 @@ log = logging.getLogger(__name__)
 
 #: Default cap. Around a thousand typical covers — enough that undoing a
 #: re-tagging session weeks later still works, small enough to be unremarkable
-#: beside a music library. Configurable; see `config.ArtworkConfig`.
+#: beside a music library. Configurable; see `config.ArtworkStoreConfig`.
 DEFAULT_MAX_BYTES = 500 * 1024 * 1024
+
+#: How many artwork changes an album keeps. Five is enough to cover a session of
+#: experimenting on one album and still be reasoning a user can hold: "the last
+#: five artwork changes to any album can be undone". Counted in TAGGINGS, not
+#: images, so a compilation whose four per-track covers are replaced in one go
+#: spends one of its five rather than four.
+DEFAULT_KEEP_PER_ALBUM = 5
 
 #: Set at startup, like `audit.set_library_root`. None means no store is
 #: configured — every call becomes a no-op rather than an error, because a
 #: failure to keep a backup must never stop the tagging it was backing up.
 _root: Path | None = None
 _max_bytes: int = DEFAULT_MAX_BYTES
+_keep_per_album: int = DEFAULT_KEEP_PER_ALBUM
 
 
-def configure(root: Path | None, *, max_bytes: int = DEFAULT_MAX_BYTES) -> None:
-    """Point the store at `root` (created on demand), with a size cap."""
-    global _root, _max_bytes
+def configure(
+    root: Path | None,
+    *,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    keep_per_album: int = DEFAULT_KEEP_PER_ALBUM,
+) -> None:
+    """Point the store at `root` (created on demand), with its retention."""
+    global _root, _max_bytes, _keep_per_album
     _root = root
     _max_bytes = max_bytes
+    _keep_per_album = keep_per_album
 
 
 def digest(data: bytes) -> str:
@@ -155,13 +182,58 @@ def _is_digest(key: str) -> bool:
     return len(key) == 64 and all(c in "0123456789abcdef" for c in key)
 
 
-def _evict_if_over_cap() -> None:
-    """Drop the least recently referenced images until the store is under cap.
+def protected_digests() -> frozenset[str]:
+    """The images the retention promise covers: every digest replaced by each
+    album's `keep_per_album` most recent artwork changes.
 
-    Least recently *referenced*, not stored: `keep` touches an image it already
-    holds, so an image shared by several albums is as fresh as its newest use.
-    The oldest changes are the least likely to be undone, which is what makes
-    this the right thing to lose first.
+    Read from `activity_store`'s own records rather than from anything this
+    module keeps, so the set is exactly what the album page offers an Undo for —
+    `_restorable_anchors` walks the same taggings. A separate ledger here would
+    be free to disagree with the page, and the symptom would be a button that
+    vanishes or one that fails.
+
+    Grouped per album under the id the tagging was RECORDED with, which is what
+    makes a re-identified album keep its older backups: those rows carry its old
+    id, and both sets are protected on their own terms.
+
+    Empty when the store is unreachable — and that is the safe direction. An
+    empty protected set makes eviction fall back to oldest-first over
+    everything, which is the behaviour before #408; a spuriously *full* one
+    would let the store grow past its cap on a broken read.
+    """
+    if _keep_per_album <= 0:
+        return frozenset()
+    # Imported here rather than at module scope: `audit` already reaches the
+    # store, and a top-level import would make the artwork store depend on the
+    # event store to be *loaded* — which it does not need in order to keep a file.
+    from . import activity_store
+
+    seen: dict[str, int] = {}
+    out: set[str] = set()
+    # Newest first, so an album's allowance is spent on its most recent changes.
+    for backup in activity_store.artwork_backups():
+        count = seen.get(backup.album_id, 0)
+        if count >= _keep_per_album:
+            continue
+        seen[backup.album_id] = count + 1
+        out |= backup.digests
+    return frozenset(out)
+
+
+def _evict_if_over_cap() -> None:
+    """Drop images until the store is under cap, protected ones last.
+
+    Two passes, and the order is the whole point (#408). The first spends the
+    overage on images NO album's retention promise covers — a change already
+    superseded five times over, which nothing on any page offers to undo. Only
+    if that is not enough does the second pass touch protected images, oldest
+    first, and it says so at WARNING: at that point the store is breaking a
+    promise the UI has been making, and on an unattended box the log is the only
+    place that can say so.
+
+    Within each pass, least recently *referenced* rather than stored: `keep`
+    touches an image it already holds, so an image shared by several albums is
+    as fresh as its newest use.
     """
     root = _root
     if root is None or not root.is_dir():
@@ -174,15 +246,31 @@ def _evict_if_over_cap() -> None:
     total = sum(st.st_size for _, st in entries)
     if total <= _max_bytes:
         return
-    for path, st in sorted(entries, key=lambda e: e[1].st_mtime):
-        if total <= _max_bytes:
-            break
-        try:
-            path.unlink()
-        except OSError:
-            continue
-        total -= st.st_size
-        # Audited: this is Harmonist deleting the only remaining copy of one of
-        # the user's images, which is exactly what the audit log is for — even
-        # though it is deleting it by a policy the user set.
-        audit.record("artwork.evict", digest=path.stem[:12], bytes=st.st_size)
+
+    protected = protected_digests()
+    by_age = sorted(entries, key=lambda e: e[1].st_mtime)
+    passes = (
+        [e for e in by_age if e[0].stem not in protected],
+        [e for e in by_age if e[0].stem in protected],
+    )
+    for guarded, group in zip((False, True), passes, strict=True):
+        for path, st in group:
+            if total <= _max_bytes:
+                return
+            try:
+                path.unlink()
+            except OSError:
+                continue
+            total -= st.st_size
+            if guarded:
+                log.warning(
+                    "artwork store is over its cap with nothing spare: dropped %s, "
+                    "which an album could still have undone",
+                    path.stem[:12],
+                )
+            # Audited: this is Harmonist deleting the only remaining copy of one
+            # of the user's images, which is exactly what the audit log is for —
+            # even though it is deleting it by a policy the user set.
+            audit.record(
+                "artwork.evict", digest=path.stem[:12], bytes=st.st_size, protected=guarded
+            )

--- a/src/harmonist/config.py
+++ b/src/harmonist/config.py
@@ -84,6 +84,12 @@ class ArtworkStoreConfig(BaseModel):
     """
 
     max_bytes: int = Field(default=500 * 1024 * 1024, ge=0)
+    # How many artwork changes each album keeps a copy of (#408). The promise
+    # the store actually makes; `max_bytes` is only the backstop under it.
+    # Zero keeps nothing per album, leaving the byte cap as the sole policy —
+    # the pre-#408 behaviour, where a busy library could evict the copy behind
+    # an Undo another album was still offering.
+    keep_per_album: int = Field(default=5, ge=0)
 
 
 class LibraryConfig(BaseModel):

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -431,7 +431,11 @@ def create_app(
     # Copies of artwork a re-tag overwrote, so replacing it can be undone (#131).
     # `artwork_dir` sandboxes itself in demo mode rather than switching off, so
     # the demo exercises the real path.
-    artwork_store.configure(cfg.artwork_dir, max_bytes=cfg.artwork_store.max_bytes)
+    artwork_store.configure(
+        cfg.artwork_dir,
+        max_bytes=cfg.artwork_store.max_bytes,
+        keep_per_album=cfg.artwork_store.keep_per_album,
+    )
     # Audit paths are recorded relative to the library (#98). Demo mode already
     # has its sandbox substituted into cfg, so this follows it automatically.
     audit.set_library_root(cfg.paths.music_dir)
@@ -3593,6 +3597,9 @@ def _register_routes(app: FastAPI) -> None:
             sidecar_count=sidecar_mod.count_all(cfg.paths.music_dir),
             ignored=_read_user_ignores(cfg.ignores_file),
             artwork_usage=artwork_store.usage(),
+            # The promise the figure sits under (#408) — what a user
+            # can rely on being undoable, as opposed to how full it is.
+            keep_per_album=cfg.artwork_store.keep_per_album,
             **extra,
         )
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -166,14 +166,24 @@
     {% set used, cap = artwork_usage %}
     <section class="border border-line rounded-lg p-4 space-y-2">
         <h2 class="text-sm font-bold text-ink uppercase tracking-widest">Kept artwork</h2>
+        {# Says the PROMISE first and the number second (#408). The number alone
+           was the old text, and it left the reader to guess what running out
+           would cost them — which was also the wrong guess, since it is no
+           longer simply the oldest copies that go. #}
         <p class="text-sm text-muted">
-            Harmonist keeps a copy of any embedded artwork a re-tag overwrites, so
-            replacing it can be undone from the album's History.
+            Harmonist keeps a copy of any artwork a re-tag overwrites, so replacing
+            it can be undone from the album's History.
+            {% if keep_per_album %}
+            The last <span class="font-bold text-ink">{{ keep_per_album }}</span>
+            artwork {{ 'change' if keep_per_album == 1 else 'changes' }} to any album
+            {{ 'is' if keep_per_album == 1 else 'are' }} kept, however many albums
+            you tag.
+            {% endif %}
             Using <span class="font-bold text-ink">{{ (used / 1048576) | round(1) }} MB</span>
             of {{ (cap / 1048576) | round(0) | int }} MB.
             {% if used > cap * 0.9 and cap %}
-            The oldest copies are removed first, so the oldest artwork changes are
-            no longer undoable.
+            Close to the limit: past it, copies are dropped oldest first — the ones
+            no album still needs before any it does.
             {% endif %}
         </p>
     </section>

--- a/test/test_artwork_store.py
+++ b/test/test_artwork_store.py
@@ -174,3 +174,127 @@ def test_a_partial_write_is_never_visible_under_its_digest(tmp_path):
     # And a stray .tmp is never served as if it were the image.
     (tmp_path / "artwork" / f"{artwork_store.digest(PNG)}.jpg.tmp").write_bytes(b"half")
     assert artwork_store.path_for(artwork_store.digest(PNG)) is None
+
+
+# ---------------------------------------------------------------------------
+# Per-album retention (#408) — the promise the store actually makes
+# ---------------------------------------------------------------------------
+
+
+def _replaced(album_id: str, before: bytes, after: bytes = b"new") -> int:
+    """Record a tagging on `album_id` that replaced `before` with `after`, the
+    way `tagger` does — an audit row plus its per-file change detail."""
+    event_id = activity_store.append(
+        message="tag.track file=01.m4a",
+        level=activity_store.Level.INFO,
+        source=activity_store.Source.AUDIT,
+        album_id=album_id,
+    )
+    assert event_id is not None
+    activity_store.record_tag_changes(
+        event_id,
+        file="01.m4a",
+        changes={"artwork": [artwork_store.digest(before), artwork_store.digest(after)]},
+    )
+    return event_id
+
+
+def _image(seed: int) -> bytes:
+    return b"\xff\xd8\xff" + bytes([seed]) * 4000
+
+
+class TestProtectedDigests:
+    def test_an_albums_recent_changes_are_protected(self):
+        one, two = _image(1), _image(2)
+        _replaced("album-a", one)
+        _replaced("album-a", two)
+
+        protected = artwork_store.protected_digests()
+
+        assert artwork_store.digest(one) in protected
+        assert artwork_store.digest(two) in protected
+
+    def test_only_the_last_n_per_album(self):
+        artwork_store.configure(artwork_store._root, keep_per_album=2)
+        images = [_image(i) for i in range(4)]
+        for img in images:  # oldest first
+            _replaced("album-a", img)
+
+        protected = artwork_store.protected_digests()
+
+        # The two most recent survive; the two before them are spendable.
+        assert {artwork_store.digest(i) for i in images[2:]} <= protected
+        assert not {artwork_store.digest(i) for i in images[:2]} & protected
+
+    def test_each_album_gets_its_own_allowance(self):
+        """A busy album must not spend another album's protection — the whole
+        failure the global byte cap had."""
+        artwork_store.configure(artwork_store._root, keep_per_album=1)
+        mine = _image(1)
+        _replaced("album-mine", mine)
+        for i in range(5):
+            _replaced("album-busy", _image(10 + i))
+
+        assert artwork_store.digest(mine) in artwork_store.protected_digests()
+
+    def test_art_a_track_gained_is_not_a_backup(self):
+        """Nothing was replaced, so nothing was kept — `artwork_replaced` reads
+        the same pair the same way."""
+        event_id = activity_store.append(
+            message="tag.track file=01.m4a",
+            level=activity_store.Level.INFO,
+            source=activity_store.Source.AUDIT,
+            album_id="album-a",
+        )
+        assert event_id is not None
+        activity_store.record_tag_changes(
+            event_id, file="01.m4a", changes={"artwork": [None, "abc"]}
+        )
+
+        assert artwork_store.protected_digests() == frozenset()
+
+
+class TestEviction:
+    def test_a_protected_image_outlives_an_unprotected_older_one(self):
+        """The point of the two passes: being old is not what decides."""
+        old_unprotected, protected = _image(1), _image(2)
+        artwork_store.keep(old_unprotected)
+        time.sleep(0.01)
+        artwork_store.keep(protected)
+        _replaced("album-a", protected)
+        # A cap that forces exactly one of the two out.
+        artwork_store.configure(artwork_store._root, max_bytes=len(protected) + 100)
+
+        artwork_store.keep(_image(3))  # any keep triggers the sweep
+
+        assert artwork_store.path_for(artwork_store.digest(protected)) is not None
+        assert artwork_store.path_for(artwork_store.digest(old_unprotected)) is None
+
+    def test_the_cap_still_wins_when_everything_is_protected(self):
+        """The backstop. A promise the disk cannot keep is not kept — but it is
+        said out loud, because the UI has been offering that Undo."""
+        first, second = _image(1), _image(2)
+        artwork_store.keep(first)
+        _replaced("album-a", first)
+        time.sleep(0.01)
+        _replaced("album-b", second)
+        artwork_store.configure(artwork_store._root, max_bytes=len(second) + 100)
+
+        artwork_store.keep(second)
+
+        assert artwork_store.path_for(artwork_store.digest(first)) is None
+        assert artwork_store.path_for(artwork_store.digest(second)) is not None
+
+    def test_an_unreadable_store_evicts_oldest_first_rather_than_nothing(self, monkeypatch):
+        """Empty protection is the safe direction: eviction falls back to what it
+        did before #408 instead of letting the store grow past its cap."""
+        monkeypatch.setattr(activity_store, "artwork_backups", list)
+        old, new = _image(1), _image(2)
+        artwork_store.keep(old)
+        time.sleep(0.01)
+        _replaced("album-a", old)
+        artwork_store.configure(artwork_store._root, max_bytes=len(new) + 100)
+
+        artwork_store.keep(new)
+
+        assert artwork_store.path_for(artwork_store.digest(old)) is None


### PR DESCRIPTION
The artwork store's bound was a total size, and a total size cannot make the
promise the UI was already making. A background pass backing up five hundred
albums overnight would evict the copy behind the Undo button *your* album was
still offering — nothing errors, `_restorable_anchors` simply stops offering it,
on a schedule nobody can predict.

That is the wrong failure for a feature whose whole job is that a change can be
taken back, and it is why replacing artwork could not be treated as reversible —
the reason `Significance.COVER_ART` sits outside the ordinary severity rank, and
the reason #276 could only ever be a proposal.

## What changes

**The last five artwork changes to any album are kept**, whatever else has been
tagged. The byte cap stays as a backstop under that: it only bites once every
album is already down to its protected set, and when it does it takes the oldest
first and says so at WARNING — at that point the store is breaking a promise the
page has been making, and on an unattended box the log is the only place that
can say so.

Configurable as `artwork_store.keep_per_album` (default 5).

## The records already existed

This turned out to need no new field and no schema migration.
`record_tag_changes` has stored each tagging's artwork before/after digests
since #86, and `_restorable_anchors` already walks them to decide whether to
offer an Undo. So `activity_store.artwork_backups()` reads **the same rows the
page trusts**, and retention protects exactly what the page offers to restore. A
ledger of its own would have been a second opinion, free to disagree, and the
symptom would be a button that vanishes or one that fails.

It also settles what "one change" is without having to ask: the unit is the
**tagging**, because that is what an Undo acts on — so a compilation whose four
per-track covers go in one re-tag spends one of its five rather than four.

Backups are grouped under the album id each tagging was *recorded* with,
deliberately: an album re-identified since carries its old id on those rows and
its new one now, and both sets stay protected on their own terms rather than the
older ones being orphaned by the rename.

An unreachable store yields an empty protected set, which falls back to
oldest-first over everything — the pre-#408 behaviour, and the safe direction. A
spuriously *full* set would let the store grow past its cap.

## Also

Settings led with a fill gauge and a sentence that is now simply wrong ("the
oldest copies are removed first"). It leads with the promise instead, and
`docs/usage.md` matches.

## Testing

`make check` green (1729 passed). Both retention behaviours mutation-checked:
ignoring protection, and sharing one allowance across albums, each turn the
right test red.

## Still open before #276 can use this

`restore_artwork` puts images back into audio files; restoring a folder
`cover.jpg` is a different operation on a different target, and the History
entry will have to say which of the two it is offering. That belongs with the
overwrite itself.

Refs #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
