### PR TITLE
Let the larger local image win

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A re-tag no longer shrinks an album's artwork.** Where the image your tracks
+  already carry is larger than the folder `cover.jpg`, the folder file is
+  updated from it instead of being embedded over it — five of sixty albums
+  sampled from a real library were losing resolution this way, in one case
+  5700px replaced by 2000px. The replaced `cover.jpg` is kept, so it can be put
+  back from the album's History (#410).
+
 ### Changed
 
 - **The last five artwork changes to any album can always be undone**, whatever

--- a/src/harmonist/artwork.py
+++ b/src/harmonist/artwork.py
@@ -28,6 +28,7 @@ from enum import StrEnum
 
 from .formats import TrackTags
 from .formats.types import EmbeddedArt
+from .images import Size
 
 
 def has_per_track_art(digests: Iterable[str | None]) -> bool:
@@ -45,6 +46,24 @@ def has_per_track_art(digests: Iterable[str | None]) -> bool:
     wrong answer, not about this being the wrong reading of it.
     """
     return len({d for d in digests if d is not None}) > 1
+
+
+def beats(mine: Size | None, theirs: Size | None) -> bool:
+    """Whether `mine` is the better image: strictly larger on both axes (#410).
+
+    The one comparison, asked by the tagger when it decides what to write and by
+    the album page when it says what a re-tag would do. Two spellings of it would
+    let the page promise one thing and the button do another — the class of bug
+    #283 and #346 closed for the album title and country rows.
+
+    An unreadable header measures as None (see `images.dimensions`) and loses:
+    "leave it alone" is the safe answer, and today's behaviour is not a bad one
+    to fall back to. Equal sizes lose too — a re-encode of the same dimensions is
+    not an improvement worth overwriting a user's file for.
+    """
+    if mine is None or theirs is None:
+        return False
+    return mine.width > theirs.width and mine.height > theirs.height
 
 
 class Outcome(StrEnum):
@@ -114,6 +133,10 @@ class ArtRow:
     total_tracks: int = 0
     multi_disc: bool = False
     on_cover: str | None = None
+    #: What a re-tag would put here, named — the folder cover for a track row,
+    #: and the album's own artwork for the folder cover's row when that is the
+    #: better image (#410). None where nothing is written.
+    written_from: str | None = None
 
     @property
     def is_gap(self) -> bool:
@@ -330,6 +353,7 @@ def summarise(
         refs: tuple[TrackRef, ...],
         outcome: Outcome,
         on_cover: str | None = None,
+        written_from: str | None = None,
     ) -> ArtRow:
         return ArtRow(
             image=image,
@@ -338,21 +362,35 @@ def summarise(
             total_tracks=len(tracks),
             multi_disc=multi_disc,
             on_cover=on_cover,
+            written_from=written_from,
         )
 
     def carried_by_cover(digest: str) -> str | None:
         return cover.name if cover is not None and cover.image.digest == digest else None
+
+    # The album's own image may be the better one, in which case the folder file
+    # is what changes and the tracks are left alone (#410). Asked through the
+    # same `beats` the tagger asks, so the page cannot promise a different
+    # outcome from the one the button produces.
+    album_image = next(iter(art_of.values())) if len(art_of) == 1 else None
+    promote = (
+        not preserved
+        and cover is not None
+        and album_image is not None
+        and beats(album_image.size, cover.image.size)
+    )
 
     rows = [
         row(
             art_of[digest],
             tuple(refs),
             Outcome.KEPT
-            if preserved
+            if preserved or promote
             else Outcome.SAME
             if carried_by_cover(digest)
             else Outcome.REPLACED,
             on_cover=carried_by_cover(digest),
+            written_from=None if preserved or promote or carried_by_cover(digest) else cover.name,  # type: ignore[union-attr]
         )
         for digest, refs in by_digest.items()
     ]
@@ -361,9 +399,26 @@ def summarise(
     # tracks carry, and a reader deciding what a re-tag would do needs to see it
     # beside the rest rather than only as something arriving from outside.
     if cover is not None and cover.image.digest not in by_digest:
-        rows.append(row(cover.image, (), Outcome.SAME, on_cover=cover.name))
+        rows.append(
+            row(
+                cover.image,
+                (),
+                Outcome.REPLACED if promote else Outcome.SAME,
+                on_cover=cover.name,
+                # Named as the thing it is rather than by a filename: the image
+                # replacing it lives in the tracks, and the row above is it.
+                written_from="the album's own artwork" if promote else None,
+            )
+        )
     if gap:
-        rows.append(row(None, tuple(gap), Outcome.KEPT if preserved else Outcome.FILLED))
+        rows.append(
+            row(
+                None,
+                tuple(gap),
+                Outcome.KEPT if preserved or promote else Outcome.FILLED,
+                written_from=None if preserved or promote else cover.name,  # type: ignore[union-attr]
+            )
+        )
 
     return ArtworkView(
         rows=tuple(rows),

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -11,6 +11,7 @@ constants are re-exported here.
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -217,6 +218,23 @@ def tag_album(
     )
     if prep.art_after is not None:
         _keep_doomed_art(prep.art_before, prep.art_after)
+
+    # The album's own image is the better one, so the folder file catches up
+    # rather than the tracks being dragged down to it (#410). Recorded as a
+    # change to `cover.jpg` in the same shape a tagged file's artwork change
+    # takes, which is what puts an Undo on it: `tag_history.artwork_replaced`
+    # reads that pair, and `restore_artwork` writes it back.
+    if prep.promote_cover_from is not None and cover_path is not None:
+        promoted = _promote_album_image(album_dir, cover_path, prep.promote_cover_from, album_id)
+        if promoted is not None:
+            was, now = promoted
+            event_id = audit.record(
+                "tag.track", album_id=album_id, album=album_dir, file=cover_path.name
+            )
+            if event_id is not None:
+                activity_store.record_tag_changes(
+                    event_id, file=cover_path.name, changes={owned.ARTWORK: [was, now]}
+                )
 
     wrote_something = False
     for file_path, (medium, track_pos_in_medium, track) in prep.pairs:
@@ -478,6 +496,11 @@ class _Prepared:
     #: not MusicBrainz's scalar `country` and is not stale either. Album-constant
     #: for the reason above.
     accepted_countries: frozenset[str]
+    #: The album's own embedded image, when it is BETTER than the folder cover
+    #: and should be promoted to it instead of being overwritten by it (#410).
+    #: The file to read it from, so `_prepare` stays free of image bytes and of
+    #: side effects — `plan_album` runs this same code and must write nothing.
+    promote_cover_from: Path | None = None
 
 
 def _prepare(
@@ -549,6 +572,21 @@ def _prepare(
     if preserves_per_track_art:
         cover = None
 
+    # The folder cover is not automatically the better image (#410). A re-tag
+    # embedded it regardless, which on a real library shrank one album in twelve
+    # — 3000px replaced by 2000px, in one case 5700px by 2000px — and the
+    # Artwork section has been reporting exactly that as "Replaced by
+    # cover.jpg". Where the album's own image is larger, the folder file catches
+    # up instead, and the tracks keep what they have.
+    #
+    # `overwrite_art` still means what it says: the user asking for the folder
+    # cover to be embedded is not asking for it to be judged.
+    promote_cover_from = None
+    if cover is not None and not overwrite_art:
+        promote_cover_from = _better_album_image(art_before, cover)
+        if promote_cover_from is not None:
+            cover = None
+
     return _Prepared(
         files=files,
         pairs=pairs,
@@ -558,6 +596,7 @@ def _prepare(
         # per-track-art guard above may have cancelled it.
         art_after=images.digest(cover) if cover is not None else None,
         preserves_per_track_art=preserves_per_track_art,
+        promote_cover_from=promote_cover_from,
         media_total=len(release.get("medium-list", [])) or 1,
         accepted_album_title=title_with_disambiguation(
             release.get("title"), release.get("disambiguation")
@@ -673,6 +712,95 @@ def _art_digests(files: list[Path]) -> dict[Path, str | None]:
     #131 stores the images content-addressed under it, so the two must agree.
     """
     return {f: images.digest(art[0]) if (art := formats.read_cover(f)) else None for f in files}
+
+
+def _mime_for(path: Path) -> str:
+    """The image type of a folder cover, from its name — the store uses it only
+    to give the kept file a real extension."""
+    return "image/png" if path.suffix.lower() == ".png" else "image/jpeg"
+
+
+def _better_album_image(digests: dict[Path, str | None], cover: bytes) -> Path | None:
+    """The file whose embedded image beats the folder cover, or None (#410).
+
+    Only when the album speaks with one voice: exactly one distinct embedded
+    image, carried by at least one track — so in practice the count guards the
+    album with NO embedded art at all, since per-track artwork has already set
+    `cover` to None upstream and this is never reached for it. Stated as the
+    positive condition anyway: what makes a promotion safe is that the album has
+    one image, and a reader should not have to trace an outer guard to see it.
+    (A compilation's first sleeve is not the album's cover however large it is.)
+
+    Strictly larger, by width and height together, and only when BOTH images
+    state a size. An unreadable header measures as None (see `images.dimensions`)
+    and the answer is then "leave it alone": today's behaviour is not a bad one,
+    and it is not worth overwriting a user's cover on a guess.
+    """
+    distinct = {d for d in digests.values() if d is not None}
+    if len(distinct) != 1:
+        return None
+    source = next((path for path, d in digests.items() if d is not None), None)
+    if source is None:
+        return None
+    art = formats.read_cover(source)
+    if art is None:
+        return None
+    # `artwork.beats` is the comparison, not a second copy of it: the album page
+    # asks the same question of the same sizes when it says what a re-tag would
+    # do, and the two must not be able to answer differently (#410).
+    mine, theirs = images.dimensions(art[0]), images.dimensions(cover)
+    return source if artwork.beats(mine, theirs) else None
+
+
+def _promote_album_image(
+    album_dir: Path, cover_path: Path, source: Path, album_id: str | None
+) -> tuple[str, str] | None:
+    """Write the album's own image over the folder cover, keeping what was there.
+
+    Returns `(was, now)` as digests so the caller can record the change the way a
+    tagged file's artwork change is recorded — which is what puts an Undo on it,
+    since `tag_history.artwork_replaced` reads exactly that pair.
+
+    Best-effort, like every other artwork operation: a promotion that cannot be
+    written is a reason to warn, not to abandon the re-tag the user asked for.
+    """
+    art = formats.read_cover(source)
+    if art is None:  # vanished between the two passes
+        return None
+    try:
+        was = cover_path.read_bytes()
+    except OSError:
+        log.exception("could not read %s to keep it before replacing it", cover_path)
+        return None
+    # Kept BEFORE the write, and the write is abandoned if it can't be: this is
+    # the first thing in Harmonist that overwrites a folder cover, so it is the
+    # first that could destroy one irrecoverably (#408).
+    if artwork_store.keep(was, mime=_mime_for(cover_path)) is None:
+        log.warning(
+            "not replacing %s with the album's larger image: its current cover "
+            "could not be kept, and the change would not be undoable",
+            cover_path.name,
+        )
+        return None
+    try:
+        tmp = cover_path.with_suffix(cover_path.suffix + ".tmp")
+        tmp.write_bytes(art[0])
+        os.replace(tmp, cover_path)
+    except OSError:
+        log.exception("could not write the album's larger image to %s", cover_path)
+        return None
+    audit.record(
+        "cover.write",
+        album_id=album_id,
+        album=album_dir,
+        file=cover_path.name,
+        source="album",
+        bytes=len(art[0]),
+        overwrote=True,
+        was=images.digest(was),
+        digest=images.digest(art[0]),
+    )
+    return images.digest(was), images.digest(art[0])
 
 
 def _keep_doomed_art(digests: dict[Path, str | None], incoming: str) -> None:
@@ -977,7 +1105,7 @@ def restore_artwork(album_dir: Path, digests: dict[str, str]) -> int:
 
     restored = 0
     for path, data in resolved.items():
-        current = formats.read_cover(path)
+        current = _image_at(path)
         if current is not None and images.digest(current[0]) == images.digest(data):
             continue  # already correct — restoring twice is a no-op
         # Keep what we are about to overwrite, exactly as a tagging would: an
@@ -985,7 +1113,7 @@ def restore_artwork(album_dir: Path, digests: dict[str, str]) -> int:
         # thing it undoes.
         if current is not None:
             artwork_store.keep(current[0], mime=current[1])
-        formats.write_cover(path, data)
+        _write_image_at(path, data)
         audit.record(
             "artwork.restore",
             album=album_dir,
@@ -994,6 +1122,38 @@ def restore_artwork(album_dir: Path, digests: dict[str, str]) -> int:
         )
         restored += 1
     return restored
+
+
+def _image_at(path: Path) -> tuple[bytes, str] | None:
+    """The image `path` currently holds, whether it is a track or the folder
+    cover (#410).
+
+    A restore target is no longer always an audio file: since the album's own
+    image can be promoted to `cover.jpg`, that write is undoable too, and the
+    stored record names `cover.jpg` exactly as it names a track. The file IS the
+    image there, rather than carrying one.
+    """
+    if formats.is_supported(path):
+        return formats.read_cover(path)
+    try:
+        return path.read_bytes(), _mime_for(path)
+    except OSError:
+        return None
+
+
+def _write_image_at(path: Path, data: bytes) -> None:
+    """Put `data` back, into a track's tags or over the folder cover itself.
+
+    The folder file is replaced through a temp file and a rename, like every
+    other write Harmonist makes to the user's directory: a crash mid-restore
+    must not leave a half-image where a cover was.
+    """
+    if formats.is_supported(path):
+        formats.write_cover(path, data)
+        return
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(data)
+    os.replace(tmp, path)
 
 
 def tagsets_for(release: Release) -> list[TagSet]:

--- a/templates/partials/_artwork.html
+++ b/templates/partials/_artwork.html
@@ -78,10 +78,14 @@
                 {% for t in r.tracks %}{{ t.name }}{% if not loop.last %}<br>{% endif %}{% endfor %}
             </span>
             {% endif %}
-            {% if r.writes %}
+            {# What replaces this image is named by the row, not assumed to be
+               the folder cover: when the album's own artwork is the better
+               image it is the FOLDER file that changes, and the arrow points
+               the other way (#410). #}
+            {% if r.writes and r.written_from %}
             <span class="art-row__outcome">
                 {{ 'Replaced by' if r.outcome == 'replaced' else 'Filled from' }}
-                {{ artwork.cover.name }}
+                {{ r.written_from }}
             </span>
             {% endif %}
         </div>

--- a/test/test_artwork.py
+++ b/test/test_artwork.py
@@ -335,3 +335,55 @@ class TestHeadingCount:
 
     def test_no_count_when_there_is_no_image_anywhere(self) -> None:
         assert artwork.summarise(album(None, None), None).count is None
+
+
+class TestLargerLocalImageWins:
+    """The page must reach the same verdict as `tagger._prepare` (#410)."""
+
+    def test_a_bigger_album_image_replaces_the_folder_cover_not_the_tracks(self) -> None:
+        big = art_of(1, width=1000, height=1000)
+        small = art_of(2, width=400, height=400)
+
+        view = artwork.summarise(album(big, big), cover_of(small))
+
+        tracks_row, cover_row = view.rows
+        assert tracks_row.outcome is artwork.Outcome.KEPT
+        assert cover_row.outcome is artwork.Outcome.REPLACED
+        assert cover_row.written_from == "the album's own artwork"
+
+    def test_a_bigger_folder_cover_still_replaces_the_tracks(self) -> None:
+        small = art_of(1, width=400, height=400)
+        big = art_of(2, width=1000, height=1000)
+
+        view = artwork.summarise(album(small, small), cover_of(big))
+
+        assert view.rows[0].outcome is artwork.Outcome.REPLACED
+        assert view.rows[0].written_from == "cover.jpg"
+
+    def test_an_unmeasurable_image_never_wins(self) -> None:
+        """A guess is not worth overwriting a user's cover for, in either
+        direction — `beats` says no when either size is unknown."""
+        unknown = EmbeddedArt.of(b"not an image at all", "image/jpeg")
+        assert unknown.size is None
+
+        view = artwork.summarise(album(unknown, unknown), cover_of(art_of(2, width=40, height=40)))
+
+        # Falls back to today's behaviour: the folder cover is embedded.
+        assert view.rows[0].outcome is artwork.Outcome.REPLACED
+
+    def test_equal_sizes_change_nothing(self) -> None:
+        mine = art_of(1, width=500, height=500)
+        theirs = art_of(2, width=500, height=500)
+
+        view = artwork.summarise(album(mine, mine), cover_of(theirs))
+
+        assert view.rows[0].outcome is artwork.Outcome.REPLACED
+        assert view.rows[1].outcome is artwork.Outcome.SAME
+
+    def test_per_track_art_is_never_promoted(self) -> None:
+        view = artwork.summarise(
+            album(art_of(1, width=900, height=900), art_of(2, width=900, height=900)),
+            cover_of(art_of(3, width=100, height=100)),
+        )
+
+        assert not any(r.writes for r in view.rows)

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -2137,3 +2137,133 @@ def test_release_events_is_empty_when_musicbrainz_records_none():
     """No events is a fact, not a failure: the page shows the Country row alone,
     with nothing extra to explain."""
     assert tagger.release_events({"id": "rel-1", "country": "GB"}) == ()
+
+
+# ---------- the larger local image wins (#410) ----------
+
+
+def _sized_jpeg(width: int, height: int) -> bytes:
+    """A JPEG whose frame header states a real size, so `images.dimensions` can
+    read it — `_minimal_jpeg` has no SOF and measures as unknown."""
+    from test.test_artwork import jpeg_bytes
+
+    return jpeg_bytes(width, height)
+
+
+def test_a_larger_embedded_image_is_promoted_to_the_folder_cover(album_with_tracks, tmp_path):
+    """A re-tag used to shrink these albums: it embedded the folder cover over
+    art that was better than it. Five of sixty albums sampled from a real
+    library were in this state, one of them 5700px replaced by 2000px (#410)."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(2)
+    big = _sized_jpeg(1000, 1000)
+    _embed_cover(album_dir / "01 Track 1.m4a", big)
+    _embed_cover(album_dir / "02 Track 2.m4a", big)
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(_sized_jpeg(400, 400))
+
+    tagger.tag_album(album_dir, _release_2_tracks(), cover_path=cover)
+
+    # The tracks keep the better image…
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == big
+    # …and the folder cover catches up, rather than dragging them down.
+    assert cover.read_bytes() == big
+
+
+def test_the_replaced_folder_cover_can_be_undone(album_with_tracks, tmp_path):
+    """The first thing in Harmonist that overwrites a cover.jpg, so it is also
+    the first that has to keep one (#408)."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(1)
+    _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(1000, 1000))
+    cover = tmp_path / "cover.jpg"
+    small = _sized_jpeg(400, 400)
+    cover.write_bytes(small)
+
+    tagger.tag_album(album_dir, _single_track_release(), cover_path=cover)
+
+    kept = artwork_store.path_for(artwork_store.digest(small))
+    assert kept is not None, "the overwritten folder cover was not kept"
+    assert kept.read_bytes() == small
+
+
+def test_a_larger_folder_cover_is_still_embedded(album_with_tracks, tmp_path):
+    """The other direction is unchanged: the cover wins when it is the better
+    image, which is what a re-tag has always done."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(1)
+    _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(400, 400))
+    cover = tmp_path / "cover.jpg"
+    big = _sized_jpeg(1000, 1000)
+    cover.write_bytes(big)
+
+    tagger.tag_album(album_dir, _single_track_release(), cover_path=cover)
+
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big
+    assert cover.read_bytes() == big
+
+
+def test_per_track_artwork_never_promotes_one_track_to_the_album_cover(album_with_tracks, tmp_path):
+    """A compilation's first track's sleeve is not the album's, however large it
+    is — promoting it would invent a cover the album never had."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(2)
+    _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(1000, 1000))
+    _embed_cover(album_dir / "02 Track 2.m4a", _sized_jpeg(1200, 1200))
+    cover = tmp_path / "cover.jpg"
+    small = _sized_jpeg(400, 400)
+    cover.write_bytes(small)
+
+    tagger.tag_album(album_dir, _release_2_tracks(), cover_path=cover)
+
+    assert cover.read_bytes() == small
+
+
+def test_a_promoted_cover_can_be_put_back(album_with_tracks, tmp_path):
+    """End to end: the promotion is undoable, and Undo targets the folder file
+    rather than the tracks — a different write from restoring a track's art."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(1)
+    big = _sized_jpeg(1000, 1000)
+    _embed_cover(album_dir / "01 Track 1.m4a", big)
+    cover = album_dir / "cover.jpg"
+    small = _sized_jpeg(400, 400)
+    cover.write_bytes(small)
+
+    tagger.tag_album(album_dir, _single_track_release(), cover_path=cover)
+    assert cover.read_bytes() == big  # promoted
+
+    restored = tagger.restore_artwork(album_dir, {"cover.jpg": artwork_store.digest(small)})
+
+    assert restored == 1
+    assert cover.read_bytes() == small
+    # …and the undo is itself undoable: what it overwrote was kept in turn.
+    assert artwork_store.path_for(artwork_store.digest(big)) is not None
+
+
+def test_restoring_a_folder_cover_twice_is_a_no_op(album_with_tracks, tmp_path):
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(1)
+    cover = album_dir / "cover.jpg"
+    small = _sized_jpeg(400, 400)
+    cover.write_bytes(small)
+    artwork_store.keep(small, mime="image/jpeg")
+
+    first = tagger.restore_artwork(album_dir, {"cover.jpg": artwork_store.digest(small)})
+    second = tagger.restore_artwork(album_dir, {"cover.jpg": artwork_store.digest(small)})
+
+    assert (first, second) == (0, 0)  # already correct both times
+    assert cover.read_bytes() == small


### PR DESCRIPTION
A re-tag embedded the folder cover on every track whenever the album was not
carrying per-track art, without ever asking which of the two images was better.

**On a real library that shrinks one album in twelve.** Sixty albums sampled:

| | albums |
|---|---|
| a re-tag would **shrink** the tracks' art | **5** |
| the folder cover is larger (a re-tag improves them) | 8 |
| identical | 47 |

3000px replaced by 2000px, and *Dancing Galaxy* replacing **5700px with
2000px**. The Artwork section from #155 has been reporting it faithfully all
along — "Replaced by cover.jpg", with the smaller dimensions beside it.

## The rule

The larger of the two wins. A bigger folder cover is embedded, as before; a
bigger embedded image is written to the folder file instead, and the tracks keep
what they have. Equal sizes change nothing, and an image whose header will not
measure loses in both directions — today's behaviour is not a bad one to fall
back to, and it is not worth overwriting a user's cover on a guess.
`overwrite_art` still means what it says: asking for the folder cover to be
embedded is not asking for it to be judged. Per-track artwork is untouched.

`artwork.beats` is the comparison — asked by the tagger when it decides what to
write, and by the album page when it says what a re-tag would do. Two spellings
of it would let the page promise one thing and the button do another, which is
the bug #283 and #346 closed for the album title and country rows.

## It carries #408's other half

This is the first thing in Harmonist that overwrites a `cover.jpg`, so it is the
first that can destroy one — which is exactly why the backup and restore belong
here rather than ahead of it, where they would have had no caller:

- the old cover is kept in the store **before** the write, and the write is
  abandoned if it cannot be;
- the change is recorded as an artwork change against `cover.jpg` in the same
  shape a tagged file's takes, so History offers an Undo through the machinery
  that already exists;
- `restore_artwork` grew the other half: a restore target is no longer always an
  audio file, and for the folder cover the file *is* the image rather than
  carrying one. The undo is itself undoable, and restoring twice is a no-op.

## Verified against the real albums

Read-only dry run over the albums the sample named:

```
Trans Canada Highway   tracks  600px -> replaced from cover.jpg   (unchanged)
Dancing Galaxy         tracks 5700px -> kept
                       cover.png 2000px -> replaced from the album's own artwork
Premiers Symptomes     tracks 2808px -> kept
Blackbox Life Recorder tracks 3000px -> kept
```

## Testing

`make check` green (1740 passed). The reproduction was written first and failed
for the right reason. Mutation-checked: neutering `beats` turns four tests red.
One mutation did **not** go red — removing the single-image guard in
`_better_album_image` — and that proved to be semantically equivalent rather
than an escape, because per-track art already sets `cover = None` upstream; the
docstring claimed that guard was doing work it isn't, and has been corrected.

Fixes #410, #408. Refs #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
