### PR TITLE
Fill a gap without rewriting the tracks that are right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **A track missing its artwork no longer costs the other tracks theirs.** A gap
+  is filled from the image the rest of the album already carries, and those
+  tracks are left alone — where a re-tag used to overwrite every one of them
+  with the folder cover to fill the one that was empty. The folder cover is
+  still embedded where it is genuinely the better image (#397).
+
 - **A re-tag no longer shrinks an album's artwork.** Where the image your tracks
   already carry is larger than the folder `cover.jpg`, the folder file is
   updated from it instead of being embedded over it — five of sixty albums

--- a/src/harmonist/artwork.py
+++ b/src/harmonist/artwork.py
@@ -373,24 +373,36 @@ def summarise(
     # same `beats` the tagger asks, so the page cannot promise a different
     # outcome from the one the button produces.
     album_image = next(iter(art_of.values())) if len(art_of) == 1 else None
-    promote = (
+    ours = album_image.size if album_image else None
+    theirs = cover.image.size if cover else None
+    # What goes on the tracks: the folder cover has to actually be better to be
+    # written over what the album already carries, and both sizes have to be
+    # readable for that to be established at all (#397, #410).
+    keep_ours = (
         not preserved
-        and cover is not None
         and album_image is not None
-        and beats(album_image.size, cover.image.size)
+        and ours is not None
+        and theirs is not None
+        and not beats(theirs, ours)
     )
+    # …and the folder file catches up only when ours is strictly better (#410).
+    promote = keep_ours and beats(ours, theirs)
+    #: What fills a track carrying nothing — the winner, whichever that is.
+    fills_gaps = "the album's own artwork" if keep_ours else (cover.name if cover else None)
 
     rows = [
         row(
             art_of[digest],
             tuple(refs),
             Outcome.KEPT
-            if preserved or promote
+            if preserved or keep_ours
             else Outcome.SAME
             if carried_by_cover(digest)
             else Outcome.REPLACED,
             on_cover=carried_by_cover(digest),
-            written_from=None if preserved or promote or carried_by_cover(digest) else cover.name,  # type: ignore[union-attr]
+            written_from=(
+                None if preserved or keep_ours or carried_by_cover(digest) else cover.name  # type: ignore[union-attr]
+            ),
         )
         for digest, refs in by_digest.items()
     ]
@@ -410,13 +422,18 @@ def summarise(
                 written_from="the album's own artwork" if promote else None,
             )
         )
+    # A gap is filled whenever there is anything to fill it with — including
+    # when the tracks' own image is the one being kept (#397). "Left alone" is
+    # the right answer for a track that has art; for one that has none it just
+    # means left empty.
     if gap:
+        fillable = not preserved and fills_gaps is not None
         rows.append(
             row(
                 None,
                 tuple(gap),
-                Outcome.KEPT if preserved or promote else Outcome.FILLED,
-                written_from=None if preserved or promote else cover.name,  # type: ignore[union-attr]
+                Outcome.FILLED if fillable else Outcome.KEPT,
+                written_from=fills_gaps if fillable else None,
             )
         )
 

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -572,20 +572,42 @@ def _prepare(
     if preserves_per_track_art:
         cover = None
 
-    # The folder cover is not automatically the better image (#410). A re-tag
-    # embedded it regardless, which on a real library shrank one album in twelve
-    # — 3000px replaced by 2000px, in one case 5700px by 2000px — and the
-    # Artwork section has been reporting exactly that as "Replaced by
-    # cover.jpg". Where the album's own image is larger, the folder file catches
-    # up instead, and the tracks keep what they have.
+    # The folder cover is not automatically the better image (#410), and a track
+    # with no art is not a reason to rewrite the tracks that have it (#397). A
+    # re-tag used to do both: on a real library it shrank one album in twelve —
+    # 3000px replaced by 2000px, in one case 5700px by 2000px — and it replaced
+    # every correct image on an album to fill the one track that had none.
     #
-    # `overwrite_art` still means what it says: the user asking for the folder
+    # `overwrite_art` still means what it says: a user asking for the folder
     # cover to be embedded is not asking for it to be judged.
     promote_cover_from = None
-    if cover is not None and not overwrite_art:
-        promote_cover_from = _better_album_image(art_before, cover)
-        if promote_cover_from is not None:
-            cover = None
+    own = _album_image(art_before) if cover is not None and not overwrite_art else None
+    if own is not None and cover is not None:
+        source, mine = own
+        ours, theirs = images.dimensions(mine), images.dimensions(cover)
+        # Two decisions, related and not the same.
+        #
+        # 1. WHAT GOES ON THE TRACKS. The folder cover has to be genuinely
+        #    better to be written over an image the album already carries: a
+        #    same-sized different picture is not an improvement, and replacing
+        #    ten correct images to fill two gaps is what #397 was filed for. So
+        #    unless the cover beats ours, OURS is what gets embedded — which
+        #    fills the empty tracks and is a no-op on the rest, whose art
+        #    already is this image, so `_changes_for` records an artwork change
+        #    for the gaps alone and `_keep_doomed_art` finds nothing to back up.
+        #
+        #    Both sizes have to be readable for any of it to apply. An
+        #    unmeasurable header is not evidence that the album's image is worth
+        #    keeping — it is no evidence at all — so the fallback is what a
+        #    re-tag has always done: embed the folder cover, gaps included.
+        if ours is not None and theirs is not None and not artwork.beats(theirs, ours):
+            cover = mine
+            # 2. WHETHER THE FOLDER FILE CATCHES UP. Only when ours is strictly
+            #    better (#410). Equal is not a reason to overwrite a user's
+            #    cover, and this is the one write here that could not be undone
+            #    from the tracks themselves.
+            if artwork.beats(ours, theirs):
+                promote_cover_from = source
 
     return _Prepared(
         files=files,
@@ -720,21 +742,17 @@ def _mime_for(path: Path) -> str:
     return "image/png" if path.suffix.lower() == ".png" else "image/jpeg"
 
 
-def _better_album_image(digests: dict[Path, str | None], cover: bytes) -> Path | None:
-    """The file whose embedded image beats the folder cover, or None (#410).
+def _album_image(digests: dict[Path, str | None]) -> tuple[Path, bytes] | None:
+    """The album's own artwork and the file to read it from, when it has exactly
+    one — or None.
 
-    Only when the album speaks with one voice: exactly one distinct embedded
-    image, carried by at least one track — so in practice the count guards the
-    album with NO embedded art at all, since per-track artwork has already set
-    `cover` to None upstream and this is never reached for it. Stated as the
-    positive condition anyway: what makes a promotion safe is that the album has
+    "Exactly one distinct embedded image, carried by at least one track" is what
+    makes the album speak with one voice. In practice this guards the album with
+    NO embedded art at all, since per-track artwork has already set `cover` to
+    None upstream and this is never reached for it. Stated as the positive
+    condition anyway: what makes the decisions below safe is that the album has
     one image, and a reader should not have to trace an outer guard to see it.
-    (A compilation's first sleeve is not the album's cover however large it is.)
-
-    Strictly larger, by width and height together, and only when BOTH images
-    state a size. An unreadable header measures as None (see `images.dimensions`)
-    and the answer is then "leave it alone": today's behaviour is not a bad one,
-    and it is not worth overwriting a user's cover on a guess.
+    (A compilation's first sleeve is not the album's cover, however large it is.)
     """
     distinct = {d for d in digests.values() if d is not None}
     if len(distinct) != 1:
@@ -743,13 +761,7 @@ def _better_album_image(digests: dict[Path, str | None], cover: bytes) -> Path |
     if source is None:
         return None
     art = formats.read_cover(source)
-    if art is None:
-        return None
-    # `artwork.beats` is the comparison, not a second copy of it: the album page
-    # asks the same question of the same sizes when it says what a re-tag would
-    # do, and the two must not be able to answer differently (#410).
-    mine, theirs = images.dimensions(art[0]), images.dimensions(cover)
-    return source if artwork.beats(mine, theirs) else None
+    return (source, art[0]) if art is not None else None
 
 
 def _promote_album_image(

--- a/test/test_artwork.py
+++ b/test/test_artwork.py
@@ -198,8 +198,14 @@ class TestOutcomes:
     def test_a_differing_folder_cover_gets_its_own_row(self) -> None:
         """It is a file the album HAS. Showing it only as an incoming value read
         as something arriving from outside, and left the reader asking which of
-        the two images was about to be replaced (#400)."""
-        view = artwork.summarise(album(art_of(1), art_of(1)), cover_of(art_of(2)))
+        the two images was about to be replaced (#400).
+
+        A larger cover, so it is the one that wins and the row really is
+        replaced — an equal one is left alone since #397."""
+        view = artwork.summarise(
+            album(art_of(1, width=400, height=400), art_of(1, width=400, height=400)),
+            cover_of(art_of(2, width=900, height=900)),
+        )
 
         assert [r.label for r in view.rows] == ["All 2 tracks", "cover.jpg"]
         assert [r.outcome for r in view.rows] == [artwork.Outcome.REPLACED, artwork.Outcome.SAME]
@@ -216,12 +222,23 @@ class TestOutcomes:
         assert not any(r.writes for r in view.rows)
         assert view.writes is False
 
-    def test_gaps_are_filled_and_the_good_images_replaced(self) -> None:
-        """#397 stated on screen: one distinct image plus two holes is not
-        per-track art, so the holes are filled by rewriting the two tracks that
-        were already right."""
+    def test_a_gap_is_filled_without_rewriting_the_tracks_that_are_right(self) -> None:
+        """#397: the holes are filled from the album's own image, and the tracks
+        that already carry it are left alone. The folder cover here is no better
+        — same size, different picture — so it wins nothing."""
         one = art_of(1)
         view = artwork.summarise(album(one, None, one, None), cover_of(art_of(2)))
+
+        outcomes = {r.is_gap: r.outcome for r in view.rows if r.tracks}
+        assert outcomes == {False: artwork.Outcome.KEPT, True: artwork.Outcome.FILLED}
+        gap = next(r for r in view.rows if r.is_gap)
+        assert gap.written_from == "the album's own artwork"
+
+    def test_a_better_folder_cover_does_replace_the_tracks(self) -> None:
+        """The other direction, and the reason the rule is about size rather
+        than about never touching what is there."""
+        small = art_of(1, width=400, height=400)
+        view = artwork.summarise(album(small, None), cover_of(art_of(2, width=900, height=900)))
 
         outcomes = {r.is_gap: r.outcome for r in view.rows if r.tracks}
         assert outcomes == {False: artwork.Outcome.REPLACED, True: artwork.Outcome.FILLED}
@@ -372,13 +389,15 @@ class TestLargerLocalImageWins:
         assert view.rows[0].outcome is artwork.Outcome.REPLACED
 
     def test_equal_sizes_change_nothing(self) -> None:
+        """Neither image wins, so neither file is written: a same-sized
+        different picture is not an improvement in either direction (#397)."""
         mine = art_of(1, width=500, height=500)
         theirs = art_of(2, width=500, height=500)
 
         view = artwork.summarise(album(mine, mine), cover_of(theirs))
 
-        assert view.rows[0].outcome is artwork.Outcome.REPLACED
-        assert view.rows[1].outcome is artwork.Outcome.SAME
+        assert not any(r.writes for r in view.rows)
+        assert view.rows[0].outcome is artwork.Outcome.KEPT
 
     def test_per_track_art_is_never_promoted(self) -> None:
         view = artwork.summarise(

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -2267,3 +2267,45 @@ def test_restoring_a_folder_cover_twice_is_a_no_op(album_with_tracks, tmp_path):
 
     assert (first, second) == (0, 0)  # already correct both times
     assert cover.read_bytes() == small
+
+
+def test_gaps_are_filled_when_the_albums_own_image_wins(album_with_tracks, tmp_path):
+    """#410 promotes the album's image to the folder cover and leaves the tracks
+    alone — but a track with NO art is not "left alone", it is left empty. The
+    gap should be filled from the winning image (#397)."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(2)
+    big = _sized_jpeg(1000, 1000)
+    _embed_cover(album_dir / "01 Track 1.m4a", big)
+    # Track 2 carries nothing at all.
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(_sized_jpeg(400, 400))
+
+    tagger.tag_album(album_dir, _release_2_tracks(), cover_path=cover)
+
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big  # untouched
+    assert ATOM_COVER in MP4(album_dir / "02 Track 2.m4a"), "the gap was left empty"
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == big
+
+
+def test_a_gap_is_filled_from_the_album_without_rewriting_the_rest(album_with_tracks, tmp_path):
+    """#397 proper: one track missing art must not cost the others theirs. The
+    folder cover here is no better — same size, different image — so filling the
+    gap from the album's own image leaves nothing destroyed."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(2)
+    mine = _sized_jpeg(500, 500)
+    _embed_cover(album_dir / "01 Track 1.m4a", mine)
+    cover = tmp_path / "cover.jpg"
+    theirs = _sized_jpeg(500, 500) + b"_a_different_image"
+    cover.write_bytes(theirs)
+
+    tagger.tag_album(album_dir, _release_2_tracks(), cover_path=cover)
+
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == mine  # not destroyed
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == mine  # gap filled
+    assert cover.read_bytes() == theirs  # no promotion: ours is not better, only equal

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -8689,10 +8689,15 @@ def test_artwork_section_names_the_tracks_missing_art(client, cfg):
     assert "Tracks 1, 3" in r.text
     assert "02 Track.m4a" in r.text
     assert "cover.jpg" in r.text
-    # …and says plainly that filling the gap rewrites the two that were right,
-    # naming what would be written rather than drawing it twice (#406).
-    assert "Replaced by" in r.text
-    assert "Filled from" in r.text
+    # The gap is filled from the album's own image, and the tracks that already
+    # have it are left alone — filling one hole no longer costs the others
+    # their artwork (#397). The folder cover here is the same size, so it wins
+    # nothing.
+    # Whitespace-normalised: the template puts the verb and what it names on
+    # separate lines, and asserting the raw string would pin the indentation.
+    rendered = " ".join(r.text.split())
+    assert "Filled from the album&#39;s own artwork" in rendered
+    assert "Replaced by" not in rendered
 
 
 def test_artwork_section_promises_no_overwrite_where_art_is_preserved(client, cfg):


### PR DESCRIPTION
Ten tracks share one image, two carry none, and the album has a folder cover: a
re-tag embedded that cover on all twelve, **replacing ten correct images to fill
two holes.** `has_per_track_art` counts DISTINCT images, so an album that is
uniform except for a gap has one image and never trips the guard that protects a
compilation — a rule that is right about what it was written for and had no
vocabulary for this.

#410 then made it worse in a way I missed at the time: where the album's own
image was the larger, it was promoted to the folder cover and the tracks were
"left alone" — which for a track carrying nothing means **left empty**. The gap
survived the very pass that was meant to improve the album's artwork.

## Two decisions, made separately

**What goes on the tracks.** The folder cover has to be genuinely better to be
written over an image the album already carries. Unless it beats ours, ours is
what gets embedded — which fills the empty tracks and is a no-op on the rest,
whose art already *is* that image, so `_changes_for` records an artwork change
for the gaps alone and `_keep_doomed_art` finds nothing to back up. Nothing
correct is destroyed to fill a hole.

**Whether the folder file catches up.** Only when ours is strictly better, as
#410 has it. Equal is not a reason to overwrite a user's cover, and that write
is the one here that could not be undone from the tracks themselves.

Both need readable dimensions on both sides. An unmeasurable header is not
evidence that the album's image is worth keeping — it is no evidence at all — so
the fallback stays what a re-tag has always done: embed the folder cover, gaps
included. Four existing tests pin exactly that, and they pass unchanged, because
the old contract still holds wherever the comparison cannot be made.

`artwork.summarise` mirrors all of it through the same `beats`, so the section
still says exactly what the button will do.

## Verified against the real library

```
Trans Canada Highway   tracks  600px -> replaced from cover.jpg   (cover wins)
Premiers Symptomes     tracks 2808px -> kept
                       cover.png 2000px -> replaced from the album's own artwork
Dancing Galaxy         tracks 5700px -> kept
Blackbox Life Recorder tracks 3000px -> kept
```

## Testing

`make check` green (1743 passed). The reproduction went in first and failed for
the right reason — twice, once for each half. Mutation-checked: not embedding
the winner, and the page ignoring the rule, each turn the right tests red.

Three view tests were asserting the old behaviour on equal-sized images —
including one written to *document* this bug when the section was built — and
now assert the fix.

Fixes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
