### PR TITLE
Ask the Cover Art Archive what it has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- **Harmonist can ask the Cover Art Archive what it has for an album**, and say
+  whether it is better than the artwork you already have. The album panel gains
+  a **CAA checked** date beside the MusicBrainz one, with a control to ask
+  again; the answer, and the time it was established, are remembered. Nothing is
+  fetched unless you press it, and nothing is written yet — this reports, it
+  does not act (#276).
+
 ### Fixed
 
 - **The Artwork section shows what a re-tag would put there**, beside what is

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -281,6 +281,42 @@ _MIGRATIONS: tuple[tuple[str, ...], ...] = (
             ignored_at      TEXT NOT NULL
         )""",
     ),
+    # 8 -> 9: what the Cover Art Archive holds for a release, and when we asked
+    # (#276).
+    #
+    # A cache of an ANSWER, not of an image. The listing carries no dimensions,
+    # so "is theirs bigger than mine" costs a ranged read of the image itself —
+    # a question worth asking once and remembering, rather than on every album
+    # page view. What is kept is the measurement: how large their front cover
+    # is, and how to fetch it when a re-tag decides it wins.
+    #
+    # `fetched_at` is load-bearing beyond caching: it is the "CAA checked N ago"
+    # the album panel shows beside the MusicBrainz one, which is what makes a
+    # stale answer visible and gives the user something to press. Same reasoning
+    # as `mb_release_cache.fetched_at` (#127) — an answer served from a store
+    # has to say how old it is.
+    #
+    # `etag` is what makes re-asking nearly free: coverartarchive.org serves one
+    # on the listing and honours `If-None-Match` with a 304 and no body.
+    #
+    # NULLABLE image columns are the "CAA has nothing for this release" answer,
+    # which is a real answer and the commonest one for a private Bandcamp
+    # release. Storing it is what stops the next check asking again — the
+    # timestamp says when we established it.
+    #
+    # No index: one row per release, looked up by primary key.
+    (
+        """CREATE TABLE caa_cache (
+            mbid       TEXT PRIMARY KEY,
+            fetched_at TEXT NOT NULL,
+            etag       TEXT,
+            image_url  TEXT,
+            width      INTEGER,
+            height     INTEGER,
+            length     INTEGER,
+            mime       TEXT
+        )""",
+    ),
 )
 
 SCHEMA_VERSION = len(_MIGRATIONS)  # the version this build expects/creates
@@ -756,6 +792,86 @@ def artwork_backups() -> list[ArtworkBackup]:
         ArtworkBackup(album_id=by_event[e][0], event_id=e, digests=frozenset(by_event[e][1]))
         for e in order
     ]
+
+
+@dataclass(frozen=True)
+class CachedCoverArt:
+    """What the Cover Art Archive said about one release, and when (#276).
+
+    `image_url` is None when the archive has nothing for the release — a real
+    answer, and the commonest one for a private Bandcamp release. The timestamp
+    is what makes it usable: it says when that was established, so the check is
+    not repeated on every album page view and the user can see how old it is.
+    """
+
+    fetched_at: datetime
+    etag: str | None = None
+    image_url: str | None = None
+    width: int | None = None
+    height: int | None = None
+    length: int | None = None
+    mime: str | None = None
+
+    @property
+    def has_art(self) -> bool:
+        return self.image_url is not None
+
+
+def cached_cover_art(mbid: str) -> CachedCoverArt | None:
+    """The stored Cover Art Archive answer for `mbid`, or None if never asked.
+
+    Swallows a store failure and returns None, like `cached_release` and for the
+    same reason: a miss has a perfect fallback, which is to go and ask. Raising
+    would turn a degraded cache into a broken album page.
+    """
+    try:
+        conn = _ensure()
+        with _LOCK:
+            row = conn.execute(
+                "SELECT fetched_at, etag, image_url, width, height, length, mime "
+                "FROM caa_cache WHERE mbid = ?",
+                (mbid,),
+            ).fetchone()
+    except sqlite3.Error:
+        log.exception("activity_store cached_cover_art failed", extra=_QUIET_MIRROR)
+        return None
+    if row is None:
+        return None
+    fetched_at, etag, image_url, width, height, length, mime = row
+    return CachedCoverArt(
+        fetched_at=datetime.fromisoformat(fetched_at),
+        etag=etag,
+        image_url=image_url,
+        width=width,
+        height=height,
+        length=length,
+        mime=mime,
+    )
+
+
+def store_cover_art(mbid: str, answer: CachedCoverArt) -> None:
+    """Remember what the archive said. REPLACEs, so re-asking overwrites."""
+    try:
+        conn = _ensure()
+        with _LOCK:
+            conn.execute(
+                "INSERT OR REPLACE INTO caa_cache "
+                "(mbid, fetched_at, etag, image_url, width, height, length, mime) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    mbid,
+                    answer.fetched_at.isoformat(),
+                    answer.etag,
+                    answer.image_url,
+                    answer.width,
+                    answer.height,
+                    answer.length,
+                    answer.mime,
+                ),
+            )
+            conn.commit()
+    except sqlite3.Error:
+        log.exception("activity_store store_cover_art failed", extra=_QUIET_MIRROR)
 
 
 def already_discovered(album_ids: list[str]) -> set[str]:

--- a/src/harmonist/artwork.py
+++ b/src/harmonist/artwork.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Protocol
 
 from .formats import TrackTags
 from .formats.types import EmbeddedArt
@@ -46,6 +47,28 @@ def has_per_track_art(digests: Iterable[str | None]) -> bool:
     wrong answer, not about this being the wrong reading of it.
     """
     return len({d for d in digests if d is not None}) > 1
+
+
+class CoverArtAnswer(Protocol):
+    """What this module needs of a Cover Art Archive answer (#276).
+
+    A protocol rather than the stored type, so `artwork` stays what it is: pure
+    functions over values, with no reach into the event store. The concrete
+    `activity_store.CachedCoverArt` satisfies it by having these members.
+
+    Read-only properties throughout, deliberately: the concrete type is a
+    FROZEN dataclass, and a protocol declaring plain attributes demands settable
+    ones that a frozen instance cannot satisfy.
+    """
+
+    @property
+    def has_art(self) -> bool: ...
+
+    @property
+    def width(self) -> int | None: ...
+
+    @property
+    def height(self) -> int | None: ...
 
 
 def beats(mine: Size | None, theirs: Size | None) -> bool:
@@ -236,6 +259,11 @@ class ArtworkView:
     #: as artless would report a mount that blinked as an album that lost its
     #: covers (#112).
     unreadable: int = 0
+    #: What the Cover Art Archive holds for this release, when it has been asked
+    #: (#276). Reported rather than acted on for now: a re-tag still writes only
+    #: what is already on disk, and the archive's answer is here to say whether
+    #: it is worth taking.
+    caa: CoverArtAnswer | None = None
     #: A folder cover exists but could not be read. NOT the same as having none,
     #: and the difference is the whole right-hand column: with the cover unread
     #: there is no saying what a re-tag would write, so the section states that
@@ -276,6 +304,37 @@ class ArtworkView:
         return tuple(out.values())
 
     @property
+    def caa_note(self) -> str | None:
+        """What the archive has, said in one line — or None when it has not been
+        asked, which is most albums.
+
+        Compared against the LARGEST image the album already has, not against
+        the folder cover alone: the question a reader is asking is whether the
+        archive is worth taking, and an album whose tracks carry 3000px is not
+        improved by a 2000px archive cover just because its `cover.jpg` is
+        smaller still.
+        """
+        answer = self.caa
+        if answer is None:
+            return None
+        if not answer.has_art:
+            return "The Cover Art Archive has no front cover for this release."
+        theirs = Size(answer.width, answer.height) if answer.width and answer.height else None
+        if theirs is None:
+            return "The Cover Art Archive has a front cover, but its size could not be read."
+        best = max(
+            (r.image.size for r in self.images if r.image and r.image.size),
+            key=lambda s: s.width,
+            default=None,
+        )
+        if best is not None and not beats(theirs, best):
+            return (
+                f"The Cover Art Archive's front cover is {theirs.width}×{theirs.height} — "
+                "no better than what this album already has."
+            )
+        return f"The Cover Art Archive has a larger front cover: {theirs.width}×{theirs.height}."
+
+    @property
     def count(self) -> str | None:
         """The count beside the section heading — "3 images · 2 gaps", or None
         when there is nothing to count. Mirrors History's `· N`.
@@ -312,6 +371,7 @@ def describe(image: EmbeddedArt) -> str:
 def summarise(
     tracks: Sequence[tuple[str, TrackTags]],
     cover: FolderCover | None,
+    caa: CoverArtAnswer | None = None,
 ) -> ArtworkView:
     """Everything the section shows, from tags already read and a folder cover.
 
@@ -453,4 +513,5 @@ def summarise(
         cover=cover,
         total_tracks=len(tracks),
         unreadable=len(tracks) - len(readable),
+        caa=caa,
     )

--- a/src/harmonist/cover_art.py
+++ b/src/harmonist/cover_art.py
@@ -10,11 +10,13 @@ tools (notably Plex) that read art from disk.
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
+from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
 
-from . import album_files, audit, formats
+from . import activity_store, album_files, audit, formats, images
 
 CAA_BASE = "https://coverartarchive.org"
 DEFAULT_TIMEOUT = 30.0
@@ -131,6 +133,125 @@ def _fetch_to_disk(
     finally:
         if owns_client:
             http.close()
+
+
+#: How much of an image to read to find its size. The dimensions live in the
+#: JPEG frame header, which sits behind however much EXIF and colour profile the
+#: encoder wrote: on a release measured from the dogfood library the header was
+#: past 16 KB and inside 64 KB, on a 100 KB file. Generous, and still a fraction
+#: of the 200 KB–5 MB the whole image would cost.
+MEASURE_BYTES = 65536
+
+
+def check_front(
+    release_mbid: str,
+    *,
+    known: activity_store.CachedCoverArt | None = None,
+    client: httpx.Client | None = None,
+) -> activity_store.CachedCoverArt:
+    """Ask the archive what front cover it has for `release_mbid`, and measure it.
+
+    Returns the answer whatever it is — including "nothing", which is a real
+    answer and the commonest one for a private Bandcamp release. The caller
+    stores it; re-asking is what the user presses the refresh control for.
+
+    **Two requests at most, and usually one and a bit.** The listing is
+    revalidated with `If-None-Match` when `known` carries an etag, and
+    coverartarchive.org answers a match with a 304 and no body — so a re-check of
+    an unchanged release costs one request and no transfer, and the previous
+    measurement is returned unchanged. Only a listing that has actually moved
+    costs the second request.
+
+    That second request is a RANGE, not the whole image: the listing carries no
+    dimensions, so the only way to answer "is theirs bigger than mine" is to look
+    at the image, and `MEASURE_BYTES` of it is enough to reach the frame header.
+    A server that ignores the range simply sends more than was asked for, which
+    still works.
+
+    The thumbnails are no use for this. `front-1200` returns 200 for a release
+    whose original is 350×350 — the archive caps a thumbnail at the original
+    rather than upscaling — so their presence says nothing about the size.
+
+    Never raises for an ordinary "no": a 404 is an answer. A transport failure
+    does propagate as `CoverArtError`, because "I could not ask" and "there is
+    nothing there" must not be recorded as the same thing.
+    """
+    owns_client = client is None
+    http = client or httpx.Client(follow_redirects=True, timeout=DEFAULT_TIMEOUT)
+    now = datetime.now(UTC)
+    try:
+        headers = {"If-None-Match": known.etag} if known and known.etag else {}
+        try:
+            listing = http.get(f"{CAA_BASE}/release/{release_mbid}", headers=headers)
+        except httpx.HTTPError as e:
+            raise CoverArtError(f"CAA listing request failed for {release_mbid}: {e}") from e
+
+        if listing.status_code == 304 and known is not None:
+            # Unchanged since we last looked. The measurement still stands; only
+            # the timestamp moves, so the page can say when that was confirmed.
+            return replace(known, fetched_at=now)
+        if listing.status_code == 404:
+            return activity_store.CachedCoverArt(fetched_at=now)
+        if not listing.is_success:
+            raise CoverArtError(f"CAA returned {listing.status_code} for {release_mbid}")
+
+        url = _front_url(listing)
+        etag = listing.headers.get("etag")
+        if url is None:
+            # A listing with images but no front — a back cover, a booklet. Not
+            # a cover to offer, and remembered so it is not asked again.
+            return activity_store.CachedCoverArt(fetched_at=now, etag=etag)
+
+        try:
+            head = http.get(url, headers={"Range": f"bytes=0-{MEASURE_BYTES - 1}"})
+        except httpx.HTTPError as e:
+            raise CoverArtError(f"CAA image request failed for {release_mbid}: {e}") from e
+        if not head.is_success:
+            raise CoverArtError(f"CAA returned {head.status_code} for {url}")
+        size = images.dimensions(head.content)
+        return activity_store.CachedCoverArt(
+            fetched_at=now,
+            etag=etag,
+            image_url=url,
+            width=size.width if size else None,
+            height=size.height if size else None,
+            # The WHOLE image's length, off the range response, not what was
+            # read: `content-range` states it, and a server that ignored the
+            # range states it in `content-length` instead.
+            length=_total_length(head),
+            mime=head.headers.get("content-type"),
+        )
+    finally:
+        if owns_client:
+            http.close()
+
+
+def _front_url(listing: httpx.Response) -> str | None:
+    """The URL of the release's front cover, or None if it has no front image."""
+    try:
+        payload = listing.json()
+    except ValueError:
+        return None
+    images_ = payload.get("images") if isinstance(payload, dict) else None
+    if not isinstance(images_, list):
+        return None
+    for image in images_:
+        if isinstance(image, dict) and image.get("front") and isinstance(image.get("image"), str):
+            # https, because the listing states http and the browser this ends
+            # up in will be on a page served over TLS.
+            return str(image["image"]).replace("http://", "https://", 1)
+    return None
+
+
+def _total_length(resp: httpx.Response) -> int | None:
+    """The full image's byte length, however the server answered the range."""
+    content_range = resp.headers.get("content-range", "")
+    if "/" in content_range:
+        total = content_range.rsplit("/", 1)[-1].strip()
+        if total.isdigit():
+            return int(total)
+    length = resp.headers.get("content-length")
+    return int(length) if length and length.isdigit() and resp.status_code == 200 else None
 
 
 def _filename_for(resp: httpx.Response) -> str:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -2230,7 +2230,9 @@ _DIGEST = re.compile(r"[0-9a-f]{64}")
 _IMMUTABLE = {"Cache-Control": "public, max-age=31536000, immutable"}
 
 
-def _artwork_view(album: Album) -> artwork.ArtworkView:
+def _artwork_view(
+    album: Album, caa: activity_store.CachedCoverArt | None = None
+) -> artwork.ArtworkView:
     """What the album page's Artwork section shows (#155).
 
     One pass over the files, and no MusicBrainz release: artwork facts are disk
@@ -2246,7 +2248,7 @@ def _artwork_view(album: Album) -> artwork.ArtworkView:
     """
     audio, _ = _album_tracks(album.path, album.folders)
     if album.cover_path is None or not album.cover_path.exists():
-        return artwork.summarise(audio, None)
+        return artwork.summarise(audio, None, caa)
     try:
         data = album.cover_path.read_bytes()
     except OSError:
@@ -2255,13 +2257,13 @@ def _artwork_view(album: Album) -> artwork.ArtworkView:
         # lead to opposite conclusions about what a re-tag would do (#112). The
         # view says so and shows no outcomes at all rather than guessing.
         log.exception("could not read the folder cover for %s", album.path)
-        return replace(artwork.summarise(audio, None), cover_unreadable=True)
+        return replace(artwork.summarise(audio, None, caa), cover_unreadable=True)
     mime = "image/png" if album.cover_path.suffix.lower() == ".png" else "image/jpeg"
     cover = artwork.FolderCover(
         name=album.cover_path.name,
         image=formats.EmbeddedArt.of(data, mime),
     )
-    return artwork.summarise(audio, cover)
+    return artwork.summarise(audio, cover, caa)
 
 
 def _albums(request: Request) -> list[Album]:
@@ -4046,6 +4048,15 @@ def _register_routes(app: FastAPI) -> None:
                 if album.sidecar and album.sidecar.mb_release_id
                 else None
             ),
+            # …and when the Cover Art Archive was last asked (#276). Another
+            # local read; the row is simply absent until it has been asked once.
+            caa_checked_at=(
+                answer.fetched_at
+                if album.sidecar
+                and album.sidecar.mb_release_id
+                and (answer := activity_store.cached_cover_art(album.sidecar.mb_release_id))
+                else None
+            ),
             # The inbox's "you may already own this" pairing, for the action
             # blocks this page now renders (#150). Without it a surrendered
             # album's page would show the no-purchase panel while its inbox card
@@ -4800,19 +4811,59 @@ def _register_routes(app: FastAPI) -> None:
         return JSONResponse(payload)
 
     @app.get("/album/{album_id}/artwork", response_class=HTMLResponse)
-    def album_artwork(request: Request, album_id: str) -> Response:
+    def album_artwork(request: Request, album_id: str, check: bool = False) -> Response:
         """The Artwork section (#155), fetched after the page paints.
 
         Lazy for the reason Tags and Tracks are — it opens every file in the
         album — but unlike them it is not gated on a MusicBrainz release, and
         renders for an album in any state.
+
+        `?check=1` also asks the Cover Art Archive about this album's release
+        (#276), which is the only thing here that leaves the machine. Never on
+        an ordinary render: the archive is served from the Internet Archive and
+        a measurement took sixteen seconds over a remote link, so a page that
+        asked on every view would be a page that hangs. It is one deliberate
+        press, on one album, and the answer is stored with the time it was
+        established so the panel can say how old it is.
         """
         album = _refreshed_from_disk(request, _find_album(request, album_id))
-        return _templates(request).TemplateResponse(
+        mbid = album.sidecar.mb_release_id if album.sidecar else None
+        if check and mbid:
+            _check_cover_art(mbid)
+        caa = activity_store.cached_cover_art(mbid) if mbid else None
+        ctx = _ctx(
             request,
-            "partials/_artwork.html",
-            _ctx(request, album=album, artwork=_artwork_view(album)),
+            album=album,
+            artwork=_artwork_view(album, caa),
+            # The panel's dates ride back out of band, so the timestamp and the
+            # answer it describes update together — the same pairing the
+            # MusicBrainz control has with the Tags section.
+            caa_checked_at=caa.fetched_at if caa else None,
+            # BOTH dates, because the swap replaces the whole block: sending
+            # only the one that changed would blank the MusicBrainz row beside
+            # it. A local SQLite read, no request in it.
+            mb_read_at=mb_cache.fetched_at(mbid) if mbid else None,
+            oob=True,
         )
+        return _templates(request).TemplateResponse(request, "partials/_artwork.html", ctx)
+
+    def _check_cover_art(mbid: str) -> None:
+        """Ask the archive, and remember the answer — including "nothing".
+
+        Failure is swallowed here on purpose, and it is the one place in this
+        feature where that is right: the user pressed a button to learn
+        something optional about their artwork, the album page around it is
+        unaffected, and the stored answer keeps whatever it said before rather
+        than being overwritten with a failure. Loud in the log, per the
+        unattended rule, and the panel's timestamp simply does not move — which
+        is the honest signal that the check did not happen.
+        """
+        try:
+            answer = cover_art.check_front(mbid, known=activity_store.cached_cover_art(mbid))
+        except cover_art.CoverArtError:
+            log.exception("could not ask the Cover Art Archive about release %s", mbid)
+            return
+        activity_store.store_cover_art(mbid, answer)
 
     @app.get("/artwork/image/{album_id}/{digest}")
     def artwork_image(request: Request, album_id: str, digest: str) -> Response:

--- a/templates/partials/_artwork.html
+++ b/templates/partials/_artwork.html
@@ -34,6 +34,14 @@
     {% endif %}
 </h2>
 
+{# What the Cover Art Archive holds, once it has been asked (#276). A line, not
+   a row: nothing is written from it yet, so it states a finding rather than
+   proposing a change. The control that asks lives with the panel's other
+   "checked" dates, where the MusicBrainz one already is. #}
+{% if artwork.caa_note %}
+<p class="text-sm text-mb-purple">{{ artwork.caa_note }}</p>
+{% endif %}
+
 {% if artwork.cover_unreadable %}
 {# "Couldn't read it" and "there isn't one" lead to opposite conclusions about
    what a re-tag would write, so the section says which (#112). #}
@@ -130,4 +138,12 @@
     {{ artwork.unreadable }} file{{ 's' if artwork.unreadable != 1 }} couldn't be read, so
     {{ 'it says' if artwork.unreadable == 1 else 'they say' }} nothing about this album's artwork.
 </p>
+{% endif %}
+
+{# The panel's dates, refreshed alongside — this response may have just asked
+   the archive, and the "CAA checked" row it updates lives up in the panel.
+   Rendered only when this response carries them, so the ordinary lazy load of
+   this section leaves the panel alone. #}
+{% if caa_checked_at is defined and oob is defined %}
+{% with oob = true %}{% include 'partials/_checked_at.html' %}{% endwith %}
 {% endif %}

--- a/templates/partials/_checked_at.html
+++ b/templates/partials/_checked_at.html
@@ -28,7 +28,7 @@
    `oob` is set by `library_compare.html`; unset at page build. #}
 <div id="album-checked-{{ album.id }}" class="contents"{% if oob %} hx-swap-oob="true"{% endif %}>
     {% if mb_read_at %}
-    <dt class="col-start-1 text-2xs text-muted uppercase tracking-widest self-baseline">Checked</dt>
+    <dt class="col-start-1 text-2xs text-muted uppercase tracking-widest self-baseline">MB checked</dt>
     <dd class="text-ink tabular-nums self-baseline whitespace-nowrap"
         {# The other three dates are facts about the album, from its sidecar.
            This one is cache freshness, keyed by release id in activity.db, and
@@ -74,6 +74,42 @@
                 hx-disabled-elt="this"
                 title="Read this release from MusicBrainz again"
                 aria-label="Read this release from MusicBrainz again"
+                class="inline-flex items-center justify-center w-4 h-4 rounded-full text-muted hover:text-mb-purple hover:bg-mb-purple/10 transition">
+            <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor"
+                 stroke-width="2.5" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M20 12a8 8 0 11-2.34-5.66"/>
+                <path stroke-linecap="round" stroke-linejoin="round" d="M20 3.5V9h-5.5"/>
+            </svg>
+        </button>
+    </dd>
+    {% endif %}
+
+    {# …and when the Cover Art Archive was last asked about this release (#276).
+       Its own row rather than a clause of the one above, because they are two
+       different services answering two different questions, and either can be
+       stale while the other is fresh. Same shape, so the panel gains no new
+       vocabulary: elapsed time, the exact moment on hover, and the way to ask
+       again beside it.
+
+       Absent until the archive has been asked once — a row saying "never" would
+       be a line on every album forever, for a check most albums never need. #}
+    {% if caa_checked_at %}
+    <dt class="col-start-1 text-2xs text-muted uppercase tracking-widest self-baseline">CAA checked</dt>
+    <dd class="text-ink tabular-nums self-baseline whitespace-nowrap"
+        title="Cover Art Archive last asked {{ caa_checked_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}">
+        {{ ago(caa_checked_at) }}
+    </dd>
+    <dd class="col-start-3 flex items-center">
+        {# Re-asks, and re-renders the Artwork section that reports the answer —
+           the same shape as the MusicBrainz control above, which re-fetches into
+           Tags. `hx-disabled-elt` because this is a real request to an external
+           service and a double-press would spend two. #}
+        <button type="button"
+                hx-get="/album/{{ album.id }}/artwork?check=1"
+                hx-target="#album-artwork" hx-swap="innerHTML"
+                hx-disabled-elt="this"
+                title="Ask the Cover Art Archive about this release again"
+                aria-label="Ask the Cover Art Archive about this release again"
                 class="inline-flex items-center justify-center w-4 h-4 rounded-full text-muted hover:text-mb-purple hover:bg-mb-purple/10 transition">
             <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor"
                  stroke-width="2.5" aria-hidden="true">

--- a/test/test_activity_store.py
+++ b/test/test_activity_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+from datetime import UTC, datetime
 
 import pytest
 
@@ -1086,3 +1087,91 @@ def test_migrates_a_v7_database_in_place_keeping_its_rows(tmp_path):
     assert [e.message for e in events] == ["written by v7"]  # pre-existing data intact
     assert activity_store.cached_release("rel-old", "media") is not None
     assert activity_store.ignored_updates() == {}
+
+
+# ---------- the Cover Art Archive cache (#276) ----------
+
+
+def test_migrates_a_v8_database_in_place_keeping_its_rows(tmp_path):
+    """The 8 -> 9 upgrade, run the way a user's database meets it: an
+    activity.db written by the previous build, opened by this one."""
+    db = tmp_path / "v8.db"
+    conn = sqlite3.connect(db, isolation_level=None)
+    # Every migration up to 8, applied as that build would have left them.
+    for statements in activity_store._MIGRATIONS[:8]:
+        for sql in statements:
+            conn.execute(sql)
+    conn.execute(
+        "INSERT INTO events (ts, level, source, message) VALUES (?, ?, ?, ?)",
+        ("2026-07-01T00:00:00+00:00", "info", "activity", "written by v8"),
+    )
+    conn.execute("PRAGMA user_version = 8")
+    conn.close()
+
+    activity_store.init(db)
+
+    assert _user_version(db) == activity_store.SCHEMA_VERSION
+    assert [e.message for e in activity_store.recent()] == ["written by v8"]
+    # …and the new table is usable, having not existed a moment ago.
+    assert activity_store.cached_cover_art("rel-1") is None
+
+
+def test_an_unasked_release_has_no_stored_answer(tmp_path):
+    activity_store.init(tmp_path / "a.db")
+    assert activity_store.cached_cover_art("never-asked") is None
+
+
+def test_storing_and_reading_back_an_answer(tmp_path):
+    activity_store.init(tmp_path / "a.db")
+    now = datetime.now(UTC)
+
+    activity_store.store_cover_art(
+        "rel-1",
+        activity_store.CachedCoverArt(
+            fetched_at=now,
+            etag='"abc"',
+            image_url="https://coverartarchive.org/release/rel-1/1.jpg",
+            width=1400,
+            height=1400,
+            length=718000,
+            mime="image/jpeg",
+        ),
+    )
+
+    got = activity_store.cached_cover_art("rel-1")
+    assert got is not None
+    assert (got.width, got.height, got.length) == (1400, 1400, 718000)
+    assert got.etag == '"abc"'
+    assert got.has_art is True
+    assert got.fetched_at == now
+
+
+def test_the_archive_having_nothing_is_a_stored_answer(tmp_path):
+    """ "Asked, and there is none" must be remembered, or every check asks
+    again — and it is the commonest answer for a private Bandcamp release."""
+    activity_store.init(tmp_path / "a.db")
+
+    activity_store.store_cover_art(
+        "rel-2", activity_store.CachedCoverArt(fetched_at=datetime.now(UTC))
+    )
+
+    got = activity_store.cached_cover_art("rel-2")
+    assert got is not None
+    assert got.has_art is False
+
+
+def test_re_asking_replaces_the_stored_answer(tmp_path):
+    activity_store.init(tmp_path / "a.db")
+    first = datetime(2026, 1, 1, tzinfo=UTC)
+    second = datetime(2026, 6, 1, tzinfo=UTC)
+    activity_store.store_cover_art(
+        "rel-3", activity_store.CachedCoverArt(fetched_at=first, width=500, height=500)
+    )
+
+    activity_store.store_cover_art(
+        "rel-3", activity_store.CachedCoverArt(fetched_at=second, width=1400, height=1400)
+    )
+
+    got = activity_store.cached_cover_art("rel-3")
+    assert got is not None
+    assert (got.fetched_at, got.width) == (second, 1400)

--- a/test/test_artwork.py
+++ b/test/test_artwork.py
@@ -406,3 +406,45 @@ class TestLargerLocalImageWins:
         )
 
         assert not any(r.writes for r in view.rows)
+
+
+class TestCoverArtArchiveNote:
+    """What the section says once the archive has been asked (#276)."""
+
+    class _Answer:
+        def __init__(self, width=None, height=None, art=True):
+            self.width, self.height, self._art = width, height, art
+
+        @property
+        def has_art(self) -> bool:
+            return self._art
+
+    def test_nothing_said_until_it_has_been_asked(self) -> None:
+        assert artwork.summarise(album(art_of(1)), None).caa_note is None
+
+    def test_a_larger_archive_cover_is_worth_saying(self) -> None:
+        view = artwork.summarise(
+            album(art_of(1, width=600, height=600)), None, self._Answer(1400, 1400)
+        )
+        assert view.caa_note == "The Cover Art Archive has a larger front cover: 1400×1400."
+
+    def test_measured_against_the_best_image_the_album_has(self) -> None:
+        """Not against the folder cover alone: an album whose tracks carry
+        3000px is not improved by a 2000px archive cover just because its
+        cover.jpg is smaller still."""
+        big = art_of(1, width=3000, height=3000)
+        small = art_of(2, width=500, height=500)
+
+        view = artwork.summarise(album(big), cover_of(small), self._Answer(2000, 2000))
+
+        assert view.caa_note is not None
+        assert "no better than what this album already has" in view.caa_note
+
+    def test_the_archive_having_nothing_is_reported(self) -> None:
+        view = artwork.summarise(album(art_of(1)), None, self._Answer(art=False))
+        assert view.caa_note == "The Cover Art Archive has no front cover for this release."
+
+    def test_an_unmeasurable_archive_cover_says_so(self) -> None:
+        view = artwork.summarise(album(art_of(1)), None, self._Answer())
+        assert view.caa_note is not None
+        assert "size could not be read" in view.caa_note


### PR DESCRIPTION
The first half of #276: Harmonist can ask the Cover Art Archive about an album's
release and say whether what it holds is better than what the album already has.

**It reports; it does not act.** Nothing is written, and nothing is fetched
unless a user presses for it.

## Asking is expensive, so it is never automatic

The listing carries no dimensions, so "is theirs bigger" can only be answered by
looking at the image — and the archive redirects to the Internet Archive, where
a measurement took **sixteen seconds** over a remote link. A page that asked on
every view would be a page that hangs. It is one press, on one album.

**Two requests at most, usually one and a bit.** The listing is revalidated with
`If-None-Match`; coverartarchive.org answers a match with a 304 and no body, so
re-checking an unchanged release costs one request, no transfer, and the
previous measurement stands. Only a listing that has moved costs the second
request — and that one is a RANGE: 64 KB reaches the frame header, against
200 KB–5 MB for the whole image.

The thumbnails are no shortcut, which is worth recording because it looks like
one: `front-1200` returns **200 for a release whose original is 350×350**, since
the archive caps a thumbnail at the original rather than upscaling. Their
presence says nothing about size.

## The answer is stored, including "nothing"

That is a real answer and the commonest one for a private Bandcamp release;
remembering it is what stops the next check asking again.

Schema **8 → 9**, appended, nullable image columns, `user_version` derived from
`len(_MIGRATIONS)` as before. The upgrade path is tested from a **v8 database
built by applying the first eight migrations**, not from a fresh one — rows
survive, the new table exists, and the version lands on 9.

## The UI

`fetched_at` earns its column twice: it is the cache's honesty, and it is the
panel's new **CAA checked** row — the same shape as the MusicBrainz one already
there, elapsed time with the exact moment on hover and the control to ask again
beside it. Two services answering two questions, either of which can be stale
while the other is fresh, so they get a row each.

The control re-asks and re-renders the Artwork section, with **both** dates
swapped back out of band — the swap replaces the whole block, so sending only
the one that changed would blank the MusicBrainz row beside it.

The section's note measures the archive against the **largest image the album
already has**, not against its folder cover: an album whose tracks carry 3000px
is not improved by a 2000px archive cover just because its `cover.jpg` is
smaller still.

## Verified against the live archive

```
stored: 350x350  100766B  etag="5308f440-203"
album at  200px -> "The Cover Art Archive has a larger front cover: 350×350."
album at 3000px -> "…350×350 — no better than what this album already has."
```

…and the revalidation path returns the stored measurement unchanged on a 304.

## Testing

`make check` green (1753 passed), including the migration's upgrade path.

## Next

Caching the archive's image on disk so the section can show it beside yours, and
then writing it when it wins — which is where #408's backup and #410's rule
already wait for it.

Refs #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
