### PR TITLE
Let the Cover Art Archive's image compete, win, and be seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
-- **Harmonist can ask the Cover Art Archive what it has for an album**, and say
-  whether it is better than the artwork you already have. The album panel gains
-  a **CAA checked** date beside the MusicBrainz one, with a control to ask
-  again; the answer, and the time it was established, are remembered. Nothing is
-  fetched unless you press it, and nothing is written yet — this reports, it
-  does not act (#276).
+- **Harmonist can take better artwork from the Cover Art Archive.** The album
+  panel gains a **CAA checked** date beside the MusicBrainz one, with a control
+  to ask; if the archive's front cover is larger than anything the album has,
+  it is kept locally and a re-tag writes it — to the tracks and to the folder
+  cover, whose previous image is kept so the change can be undone. Nothing is
+  fetched unless you press, a tagging never reaches the network, and an archive
+  cover that is no better than yours is ignored (#276).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ versions follow [semantic versioning](https://semver.org).
   it is kept locally and a re-tag writes it — to the tracks and to the folder
   cover, whose previous image is kept so the change can be undone. Nothing is
   fetched unless you press, a tagging never reaches the network, and an archive
-  cover that is no better than yours is ignored (#276).
+  cover that is no better than yours is ignored. The Artwork section shows the
+  archive's image beside your own, marked as MusicBrainz's, and serves it from
+  Harmonist — so opening an album never tells the Internet Archive which records
+  you own (#276).
 
 ### Fixed
 

--- a/src/harmonist/artwork.py
+++ b/src/harmonist/artwork.py
@@ -160,6 +160,10 @@ class ArtRow:
     #: and the album's own artwork for the folder cover's row when that is the
     #: better image (#410). None where nothing is written.
     written_from: str | None = None
+    #: Whether what would be written came from the Cover Art Archive (#276) —
+    #: which is the one case where the MusicBrainz hexagon is a claim Harmonist
+    #: can support. A folder cover may have come from a Bandcamp download.
+    from_archive: bool = False
     #: …and the image itself, so the row can SHOW what it would become rather
     #: than only assert it (#413). "Replaced by the album's own artwork" carries
     #: no tense — a reader cannot tell whether it already happened — and the
@@ -372,6 +376,7 @@ def summarise(
     tracks: Sequence[tuple[str, TrackTags]],
     cover: FolderCover | None,
     caa: CoverArtAnswer | None = None,
+    archive: EmbeddedArt | None = None,
 ) -> ArtworkView:
     """Everything the section shows, from tags already read and a folder cover.
 
@@ -430,10 +435,19 @@ def summarise(
             on_cover=on_cover,
             written_from=written_from,
             written_image=written_image,
+            from_archive=written_image is not None and archive_wins,
         )
 
     def carried_by_cover(digest: str) -> str | None:
         return cover.name if cover is not None and cover.image.digest == digest else None
+
+    def _unchanged(digest: str) -> bool:
+        """Whether this row's tracks keep what they have — preserved per-track
+        art, an album image that already won, or art that already IS the
+        winner."""
+        if preserved or keep_ours:
+            return True
+        return bool(carried_by_cover(digest)) and not archive_wins
 
     # The album's own image may be the better one, in which case the folder file
     # is what changes and the tracks are left alone (#410). Asked through the
@@ -459,6 +473,23 @@ def summarise(
     #: …and the image those words name.
     gap_image = album_image if keep_ours else (cover.image if cover else None)
 
+    # The archive is the third candidate, and it displaces both when it beats
+    # them (#276). Asked in the same order and by the same `beats` as
+    # `tagger._prepare`, because this is the page saying what that code will do.
+    local_best = gap_image.size if gap_image else None
+    archive_wins = (
+        not preserved
+        and archive is not None
+        and cover is not None
+        and beats(archive.size, local_best)
+    )
+    if archive_wins:
+        assert archive is not None  # narrowed by `archive_wins`
+        keep_ours = False
+        promote = archive.digest != cover.image.digest if cover else False
+        fills_gaps = "the Cover Art Archive"
+        gap_image = archive
+
     rows = [
         row(
             art_of[digest],
@@ -466,12 +497,15 @@ def summarise(
             Outcome.KEPT
             if preserved or keep_ours
             else Outcome.SAME
-            if carried_by_cover(digest)
+            if carried_by_cover(digest) and not archive_wins
             else Outcome.REPLACED,
             on_cover=carried_by_cover(digest),
-            written_from=(
-                None if preserved or keep_ours or carried_by_cover(digest) else cover.name  # type: ignore[union-attr]
-            ),
+            # What this row would become, named and shown. `fills_gaps` is the
+            # winner whatever it turned out to be — the folder cover, or the
+            # archive when it beat everything — so the row cannot name one and
+            # be written the other.
+            written_from=None if _unchanged(digest) else fills_gaps,
+            written_image=None if _unchanged(digest) else gap_image,
         )
         for digest, refs in by_digest.items()
     ]
@@ -486,10 +520,11 @@ def summarise(
                 (),
                 Outcome.REPLACED if promote else Outcome.SAME,
                 on_cover=cover.name,
-                # Named as the thing it is rather than by a filename: the image
-                # replacing it lives in the tracks, and the row above is it.
-                written_from="the album's own artwork" if promote else None,
-                written_image=album_image if promote else None,
+                # Named as the thing it is rather than by a filename: what
+                # replaces the folder cover is the album's own image or the
+                # archive's, neither of which is a file in this album.
+                written_from=fills_gaps if promote else None,
+                written_image=gap_image if promote else None,
             )
         )
     # A gap is filled whenever there is anything to fill it with — including

--- a/src/harmonist/cover_art.py
+++ b/src/harmonist/cover_art.py
@@ -10,6 +10,8 @@ tools (notably Plex) that read art from disk.
 from __future__ import annotations
 
 import logging
+import os
+import re
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -147,6 +149,7 @@ def check_front(
     release_mbid: str,
     *,
     known: activity_store.CachedCoverArt | None = None,
+    keep_if_wider_than: int | None = None,
     client: httpx.Client | None = None,
 ) -> activity_store.CachedCoverArt:
     """Ask the archive what front cover it has for `release_mbid`, and measure it.
@@ -171,6 +174,12 @@ def check_front(
     The thumbnails are no use for this. `front-1200` returns 200 for a release
     whose original is 350×350 — the archive caps a thumbnail at the original
     rather than upscaling — so their presence says nothing about the size.
+
+    `keep_if_wider_than` is the album's current best width. When the archive's
+    image beats it, the whole image is fetched and cached, so the page can show
+    it and a re-tag can write it — the one case where the full 200 KB–5 MB is
+    worth spending, and only during a check the user asked for. An image that
+    loses is measured and forgotten.
 
     Never raises for an ordinary "no": a 404 is an answer. A transport failure
     does propagate as `CoverArtError`, because "I could not ask" and "there is
@@ -209,6 +218,13 @@ def check_front(
         if not head.is_success:
             raise CoverArtError(f"CAA returned {head.status_code} for {url}")
         size = images.dimensions(head.content)
+        if (
+            size is not None
+            and keep_if_wider_than is not None
+            and size.width > keep_if_wider_than
+            and cached_image(release_mbid) is None
+        ):
+            _fetch_and_cache(http, release_mbid, url, head.headers.get("content-type"))
         return activity_store.CachedCoverArt(
             fetched_at=now,
             etag=etag,
@@ -224,6 +240,20 @@ def check_front(
     finally:
         if owns_client:
             http.close()
+
+
+def _fetch_and_cache(http: httpx.Client, release_mbid: str, url: str, mime: str | None) -> None:
+    """Pull the whole image and keep it. Best-effort: a failure here loses the
+    picture, not the measurement that was the point of the check."""
+    try:
+        full = http.get(url)
+    except httpx.HTTPError:
+        log.warning("could not fetch the archive image for %s", release_mbid, exc_info=True)
+        return
+    if not full.is_success:
+        log.warning("archive image for %s returned %s", release_mbid, full.status_code)
+        return
+    cache_image(release_mbid, full.content, mime or full.headers.get("content-type"))
 
 
 def _front_url(listing: httpx.Response) -> str | None:
@@ -252,6 +282,87 @@ def _total_length(resp: httpx.Response) -> int | None:
             return int(total)
     length = resp.headers.get("content-length")
     return int(length) if length and length.isdigit() and resp.status_code == 200 else None
+
+
+# ---------------------------------------------------------------------------
+# The candidate cache (#276)
+# ---------------------------------------------------------------------------
+#
+# The archive's image, kept so it can be SHOWN beside the album's own and
+# written if it wins. One file per release, named for the release — not
+# content-addressed like `artwork_store`, because there is nothing to
+# deduplicate: two releases sharing a cover is not a thing that happens, and a
+# release has exactly one current front cover.
+#
+# The deeper difference from `artwork_store` is what eviction costs. That store
+# holds the ONLY copy of something the user had, so dropping a file breaks a
+# promise (#408). These are copies of something the archive still has, so
+# dropping one costs a re-fetch and nothing else — which is why this needs no
+# per-album retention, no protected set, and no undo semantics. Deleting the
+# whole directory is safe at any moment.
+
+_caa_root: Path | None = None
+
+
+def configure_cache(root: Path | None) -> None:
+    """Point the candidate cache at `root` (created on demand). None disables
+    it — every call becomes a no-op, and the archive's image simply is not
+    shown."""
+    global _caa_root
+    _caa_root = root
+
+
+def cache_image(release_mbid: str, data: bytes, mime: str | None) -> Path | None:
+    """Keep the archive's image for this release. Returns where, or None.
+
+    Best-effort by design, like `artwork_store.keep`: a cache that cannot be
+    written must not fail the check the user asked for. They lose a thumbnail,
+    not an answer.
+    """
+    root = _caa_root
+    if root is None or not _is_mbid(release_mbid):
+        return None
+    path = root / f"{release_mbid}{'.png' if mime and 'png' in mime.lower() else '.jpg'}"
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        # Temp file then rename, so a crash cannot leave a half-image behind a
+        # name that claims to be complete — as everywhere else Harmonist writes.
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_bytes(data)
+        os.replace(tmp, path)
+    except OSError:
+        log.exception("could not cache the Cover Art Archive image for %s", release_mbid)
+        return None
+    return path
+
+
+def cached_image(release_mbid: str) -> Path | None:
+    """Where this release's archive image is held locally, or None."""
+    root = _caa_root
+    if root is None or not _is_mbid(release_mbid):
+        return None
+    for suffix in (".jpg", ".png"):
+        path = root / f"{release_mbid}{suffix}"
+        if path.exists():
+            return path
+    return None
+
+
+def _is_mbid(value: str) -> bool:
+    """Guard the path join: the id reaches here from a sidecar, and a value
+    carrying a separator must never become a filename.
+
+    A CHARACTER guard, not a format one. Real release ids are UUIDs, but
+    Harmonist's own fixtures and demo library use short readable ids, and a
+    regex demanding 36 hex characters would silently disable the cache for every
+    one of them — a check that appears to work and quietly stores nothing. What
+    matters here is only that the value cannot escape the directory.
+    """
+    return bool(_SAFE_ID.fullmatch(value))
+
+
+#: An id safe to use as a filename: no separators, no traversal, bounded.
+_SAFE_ID = re.compile(r"(?!\.)[A-Za-z0-9._-]{1,64}")
 
 
 def _filename_for(resp: httpx.Response) -> str:

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -24,6 +24,7 @@ from . import (
     artwork_store,
     audit,
     compare,
+    cover_art,
     formats,
     images,
     mb_lookup,
@@ -224,8 +225,8 @@ def tag_album(
     # change to `cover.jpg` in the same shape a tagged file's artwork change
     # takes, which is what puts an Undo on it: `tag_history.artwork_replaced`
     # reads that pair, and `restore_artwork` writes it back.
-    if prep.promote_cover_from is not None and cover_path is not None:
-        promoted = _promote_album_image(album_dir, cover_path, prep.promote_cover_from, album_id)
+    if prep.promote_cover is not None and cover_path is not None:
+        promoted = _promote_album_image(album_dir, cover_path, prep.promote_cover, album_id)
         if promoted is not None:
             was, now = promoted
             event_id = audit.record(
@@ -496,11 +497,12 @@ class _Prepared:
     #: not MusicBrainz's scalar `country` and is not stale either. Album-constant
     #: for the reason above.
     accepted_countries: frozenset[str]
-    #: The album's own embedded image, when it is BETTER than the folder cover
-    #: and should be promoted to it instead of being overwritten by it (#410).
-    #: The file to read it from, so `_prepare` stays free of image bytes and of
-    #: side effects — `plan_album` runs this same code and must write nothing.
-    promote_cover_from: Path | None = None
+    #: The image the folder cover should become, when something beats it — the
+    #: album's own artwork (#410) or the Cover Art Archive's (#276). None when
+    #: the folder file already holds the winner, which is the common case.
+    #: Bytes rather than a source, because the winner may come from the archive
+    #: cache rather than from a track.
+    promote_cover: bytes | None = None
 
 
 def _prepare(
@@ -557,6 +559,7 @@ def _prepare(
     # path where scanning is already the slow part (#44, #74). Guarding here
     # rather than relying on the `and` below, which used to short-circuit this
     # read and stopped doing so when the digests were hoisted out.
+    cover_bytes = cover
     art_before = _art_digests(files) if cover is not None else {}
     # DATA SAFETY: if the tracks carry DIFFERENT embedded art (a per-track-art
     # album, e.g. a compilation), embedding one album cover would destroy those
@@ -572,42 +575,55 @@ def _prepare(
     if preserves_per_track_art:
         cover = None
 
-    # The folder cover is not automatically the better image (#410), and a track
-    # with no art is not a reason to rewrite the tracks that have it (#397). A
-    # re-tag used to do both: on a real library it shrank one album in twelve —
-    # 3000px replaced by 2000px, in one case 5700px by 2000px — and it replaced
-    # every correct image on an album to fill the one track that had none.
+    # THE LARGEST IMAGE WINS, among the three the album can offer: what its
+    # tracks carry, what its folder holds, and what the Cover Art Archive has if
+    # anyone has asked (#276, #410). A re-tag used to embed the folder cover
+    # regardless, which on a real library shrank one album in twelve — 3000px
+    # replaced by 2000px, in one case 5700px by 2000px.
     #
-    # `overwrite_art` still means what it says: a user asking for the folder
-    # cover to be embedded is not asking for it to be judged.
-    promote_cover_from = None
-    own = _album_image(art_before) if cover is not None and not overwrite_art else None
-    if own is not None and cover is not None:
-        source, mine = own
-        ours, theirs = images.dimensions(mine), images.dimensions(cover)
-        # Two decisions, related and not the same.
-        #
-        # 1. WHAT GOES ON THE TRACKS. The folder cover has to be genuinely
-        #    better to be written over an image the album already carries: a
-        #    same-sized different picture is not an improvement, and replacing
-        #    ten correct images to fill two gaps is what #397 was filed for. So
-        #    unless the cover beats ours, OURS is what gets embedded — which
-        #    fills the empty tracks and is a no-op on the rest, whose art
-        #    already is this image, so `_changes_for` records an artwork change
-        #    for the gaps alone and `_keep_doomed_art` finds nothing to back up.
-        #
-        #    Both sizes have to be readable for any of it to apply. An
-        #    unmeasurable header is not evidence that the album's image is worth
-        #    keeping — it is no evidence at all — so the fallback is what a
-        #    re-tag has always done: embed the folder cover, gaps included.
-        if ours is not None and theirs is not None and not artwork.beats(theirs, ours):
-            cover = mine
-            # 2. WHETHER THE FOLDER FILE CATCHES UP. Only when ours is strictly
-            #    better (#410). Equal is not a reason to overwrite a user's
-            #    cover, and this is the one write here that could not be undone
-            #    from the tracks themselves.
-            if artwork.beats(ours, theirs):
-                promote_cover_from = source
+    # `overwrite_art` opts out of the whole comparison: a user asking for the
+    # folder cover to be embedded is not asking for it to be judged.
+    promote_cover = None
+    if cover is not None and not overwrite_art:
+        folder_size = images.dimensions(cover)
+        own = _album_image(art_before)
+        # The archive's image, from the LOCAL CACHE only. A tagging never
+        # reaches the network: `plan_album` runs this same code on the
+        # gardener's path, where a request per album is exactly what must not
+        # happen. An album nobody has checked has no third candidate.
+        archive = _archive_candidate(release)
+
+        # Ordered worst-first so that each candidate has to genuinely beat the
+        # one before it to displace it — ties go to what is already there,
+        # because a same-sized different picture is not an improvement and is
+        # not worth overwriting a user's file for.
+        winner, winner_size = cover, folder_size
+        if own is not None:
+            _, mine = own
+            ours = images.dimensions(mine)
+            # Unless the folder cover BEATS the album's own image, the album's
+            # own is what gets embedded — which fills the tracks that carry
+            # nothing and is a no-op on the rest (#397). Both sizes must be
+            # readable: an unmeasurable header is no evidence, so the fallback
+            # is what a re-tag has always done.
+            if (
+                ours is not None
+                and folder_size is not None
+                and not artwork.beats(folder_size, ours)
+            ):
+                winner, winner_size = mine, ours
+        if archive is not None:
+            theirs = images.dimensions(archive)
+            if artwork.beats(theirs, winner_size):
+                winner, winner_size = archive, theirs
+
+        cover = winner
+        # The folder file catches up when the winner is not already what it
+        # holds. That write is the one here that could not be undone from the
+        # tracks themselves, so it happens only on a strict improvement — and
+        # `tag_album` keeps the old cover before replacing it (#408).
+        if winner is not cover_bytes and artwork.beats(winner_size, folder_size):
+            promote_cover = winner
 
     return _Prepared(
         files=files,
@@ -618,7 +634,7 @@ def _prepare(
         # per-track-art guard above may have cancelled it.
         art_after=images.digest(cover) if cover is not None else None,
         preserves_per_track_art=preserves_per_track_art,
-        promote_cover_from=promote_cover_from,
+        promote_cover=promote_cover,
         media_total=len(release.get("medium-list", [])) or 1,
         accepted_album_title=title_with_disambiguation(
             release.get("title"), release.get("disambiguation")
@@ -742,6 +758,28 @@ def _mime_for(path: Path) -> str:
     return "image/png" if path.suffix.lower() == ".png" else "image/jpeg"
 
 
+def _archive_candidate(release: Release) -> bytes | None:
+    """The archive's image for this release, when it is cached AND larger than
+    the folder cover — or None.
+
+    Cache-only, deliberately. The fetch happens when the user asks for a check
+    (#276); by the time a tagging runs, the answer either is on disk or is not,
+    and a tagging that reached the network would put a request behind every
+    album the gardener touches.
+    """
+    mbid = release.get("id")
+    if not isinstance(mbid, str):
+        return None
+    path = cover_art.cached_image(mbid)
+    if path is None:
+        return None
+    try:
+        return path.read_bytes()
+    except OSError:
+        log.exception("could not read the cached archive image for %s", mbid)
+        return None
+
+
 def _album_image(digests: dict[Path, str | None]) -> tuple[Path, bytes] | None:
     """The album's own artwork and the file to read it from, when it has exactly
     one — or None.
@@ -765,7 +803,7 @@ def _album_image(digests: dict[Path, str | None]) -> tuple[Path, bytes] | None:
 
 
 def _promote_album_image(
-    album_dir: Path, cover_path: Path, source: Path, album_id: str | None
+    album_dir: Path, cover_path: Path, incoming: bytes, album_id: str | None
 ) -> tuple[str, str] | None:
     """Write the album's own image over the folder cover, keeping what was there.
 
@@ -776,9 +814,6 @@ def _promote_album_image(
     Best-effort, like every other artwork operation: a promotion that cannot be
     written is a reason to warn, not to abandon the re-tag the user asked for.
     """
-    art = formats.read_cover(source)
-    if art is None:  # vanished between the two passes
-        return None
     try:
         was = cover_path.read_bytes()
     except OSError:
@@ -796,7 +831,7 @@ def _promote_album_image(
         return None
     try:
         tmp = cover_path.with_suffix(cover_path.suffix + ".tmp")
-        tmp.write_bytes(art[0])
+        tmp.write_bytes(incoming)
         os.replace(tmp, cover_path)
     except OSError:
         log.exception("could not write the album's larger image to %s", cover_path)
@@ -807,12 +842,12 @@ def _promote_album_image(
         album=album_dir,
         file=cover_path.name,
         source="album",
-        bytes=len(art[0]),
+        bytes=len(incoming),
         overwrote=True,
         was=images.digest(was),
-        digest=images.digest(art[0]),
+        digest=images.digest(incoming),
     )
-    return images.digest(was), images.digest(art[0])
+    return images.digest(was), images.digest(incoming)
 
 
 def _keep_doomed_art(digests: dict[Path, str | None], incoming: str) -> None:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -436,6 +436,11 @@ def create_app(
         max_bytes=cfg.artwork_store.max_bytes,
         keep_per_album=cfg.artwork_store.keep_per_album,
     )
+    # Where the Cover Art Archive's own images are kept once fetched (#276).
+    # Beside the artwork store rather than inside it: these are copies of
+    # something the archive still has, so losing one costs a re-fetch, and they
+    # must not compete for the space that store promises to an album's undo.
+    cover_art.configure_cache(cfg.artwork_dir / "caa")
     # Audit paths are recorded relative to the library (#98). Demo mode already
     # has its sandbox substituted into cfg, so this follows it automatically.
     audit.set_library_root(cfg.paths.music_dir)
@@ -4829,7 +4834,7 @@ def _register_routes(app: FastAPI) -> None:
         album = _refreshed_from_disk(request, _find_album(request, album_id))
         mbid = album.sidecar.mb_release_id if album.sidecar else None
         if check and mbid:
-            _check_cover_art(mbid)
+            _check_cover_art(mbid, _artwork_view(album))
         caa = activity_store.cached_cover_art(mbid) if mbid else None
         ctx = _ctx(
             request,
@@ -4847,7 +4852,7 @@ def _register_routes(app: FastAPI) -> None:
         )
         return _templates(request).TemplateResponse(request, "partials/_artwork.html", ctx)
 
-    def _check_cover_art(mbid: str) -> None:
+    def _check_cover_art(mbid: str, current: artwork.ArtworkView) -> None:
         """Ask the archive, and remember the answer — including "nothing".
 
         Failure is swallowed here on purpose, and it is the one place in this
@@ -4858,8 +4863,20 @@ def _register_routes(app: FastAPI) -> None:
         unattended rule, and the panel's timestamp simply does not move — which
         is the honest signal that the check did not happen.
         """
+        # What the archive has to beat to be worth downloading: the widest image
+        # the album already has. A candidate that loses is measured and
+        # forgotten; only a winner costs the full 200 KB–5 MB, and only during a
+        # check the user asked for.
+        best = max(
+            (r.image.size.width for r in current.images if r.image and r.image.size),
+            default=None,
+        )
         try:
-            answer = cover_art.check_front(mbid, known=activity_store.cached_cover_art(mbid))
+            answer = cover_art.check_front(
+                mbid,
+                known=activity_store.cached_cover_art(mbid),
+                keep_if_wider_than=best,
+            )
         except cover_art.CoverArtError:
             log.exception("could not ask the Cover Art Archive about release %s", mbid)
             return

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -2235,8 +2235,33 @@ _DIGEST = re.compile(r"[0-9a-f]{64}")
 _IMMUTABLE = {"Cache-Control": "public, max-age=31536000, immutable"}
 
 
+def _archive_image(mbid: str | None) -> formats.EmbeddedArt | None:
+    """The Cover Art Archive's image for this release, described, when one has
+    been fetched (#276).
+
+    Read from the local cache — the page never asks the archive on a render, and
+    an album nobody has checked simply has no candidate here. Described rather
+    than carried, like every other image on this page: the bytes go back to the
+    browser through the image route, keyed by the digest measured here.
+    """
+    if mbid is None:
+        return None
+    path = cover_art.cached_image(mbid)
+    if path is None:
+        return None
+    try:
+        data = path.read_bytes()
+    except OSError:
+        log.exception("could not read the cached archive image for %s", mbid)
+        return None
+    mime = "image/png" if path.suffix.lower() == ".png" else "image/jpeg"
+    return formats.EmbeddedArt.of(data, mime)
+
+
 def _artwork_view(
-    album: Album, caa: activity_store.CachedCoverArt | None = None
+    album: Album,
+    caa: activity_store.CachedCoverArt | None = None,
+    archive: formats.EmbeddedArt | None = None,
 ) -> artwork.ArtworkView:
     """What the album page's Artwork section shows (#155).
 
@@ -2253,7 +2278,7 @@ def _artwork_view(
     """
     audio, _ = _album_tracks(album.path, album.folders)
     if album.cover_path is None or not album.cover_path.exists():
-        return artwork.summarise(audio, None, caa)
+        return artwork.summarise(audio, None, caa, archive)
     try:
         data = album.cover_path.read_bytes()
     except OSError:
@@ -2262,13 +2287,13 @@ def _artwork_view(
         # lead to opposite conclusions about what a re-tag would do (#112). The
         # view says so and shows no outcomes at all rather than guessing.
         log.exception("could not read the folder cover for %s", album.path)
-        return replace(artwork.summarise(audio, None, caa), cover_unreadable=True)
+        return replace(artwork.summarise(audio, None, caa, archive), cover_unreadable=True)
     mime = "image/png" if album.cover_path.suffix.lower() == ".png" else "image/jpeg"
     cover = artwork.FolderCover(
         name=album.cover_path.name,
         image=formats.EmbeddedArt.of(data, mime),
     )
-    return artwork.summarise(audio, cover, caa)
+    return artwork.summarise(audio, cover, caa, archive)
 
 
 def _albums(request: Request) -> list[Album]:
@@ -4839,7 +4864,7 @@ def _register_routes(app: FastAPI) -> None:
         ctx = _ctx(
             request,
             album=album,
-            artwork=_artwork_view(album, caa),
+            artwork=_artwork_view(album, caa, _archive_image(mbid)),
             # The panel's dates ride back out of band, so the timestamp and the
             # answer it describes update together — the same pairing the
             # MusicBrainz control has with the Tags section.
@@ -4908,6 +4933,17 @@ def _register_routes(app: FastAPI) -> None:
             art = formats.read_cover(path)
             if art is not None and images.digest(art[0]) == digest:
                 return Response(content=art[0], media_type=art[1], headers=_IMMUTABLE)
+        # …and the Cover Art Archive's candidate, which is not in the album at
+        # all (#276). Served from Harmonist rather than linked to the archive:
+        # the page talks to one host, so opening an album cannot tell the
+        # Internet Archive which records this user owns.
+        mbid = album.sidecar.mb_release_id if album.sidecar else None
+        cached = cover_art.cached_image(mbid) if mbid else None
+        if cached is not None:
+            data = cached.read_bytes()
+            if images.digest(data) == digest:
+                media = "image/png" if cached.suffix.lower() == ".png" else "image/jpeg"
+                return Response(content=data, media_type=media, headers=_IMMUTABLE)
         raise HTTPException(status.HTTP_404_NOT_FOUND, "no such image")
 
     @app.get("/cover/{album_id}")

--- a/templates/partials/_artwork.html
+++ b/templates/partials/_artwork.html
@@ -112,7 +112,18 @@
         <div class="art-row__side art-row__side--after">
             {{ image_cell(r.written_image, album.id, r.written_from) }}
             <div class="art-row__facts art-row__facts--mb">
-                <span class="art-row__who">{{ r.written_from }}</span>
+                <span class="art-row__who">{{ r.written_from }}{% if r.from_archive %}{#
+                    #}{# The hexagon, finally truthful (#276). It was left off
+                         every earlier incoming image on purpose — a folder cover
+                         may have come from a Bandcamp download, and marking it
+                         MusicBrainz's would have been a claim Harmonist could
+                         not support. This image really is the archive's. #}
+                    <span class="mb-mark" tabindex="0" role="img"
+                          title="From the Cover Art Archive"
+                          aria-label="From the Cover Art Archive"><svg
+                        viewBox="0 0 24 24" width="9" height="9" fill="currentColor"
+                        aria-hidden="true"
+                        ><path d="M12 2L21 7L21 17L12 22L3 17L3 7Z"/></svg></span>{% endif %}</span>
                 <span class="art-row__meta">{{ describe_image(r.written_image) }}</span>
             </div>
         </div>

--- a/test/test_artwork.py
+++ b/test/test_artwork.py
@@ -448,3 +448,82 @@ class TestCoverArtArchiveNote:
         view = artwork.summarise(album(art_of(1)), None, self._Answer())
         assert view.caa_note is not None
         assert "size could not be read" in view.caa_note
+
+
+class TestArchiveWins:
+    """The archive as the third candidate, on the page (#276)."""
+
+    def test_a_larger_archive_image_replaces_everything(self) -> None:
+        mine = art_of(1, width=600, height=600)
+        theirs = art_of(2, width=800, height=800)
+        archive = art_of(3, width=1400, height=1400)
+
+        view = artwork.summarise(album(mine, mine), cover_of(theirs), archive=archive)
+
+        # Both the tracks and the folder cover are replaced, by the same image.
+        assert {r.outcome for r in view.rows} == {artwork.Outcome.REPLACED}
+        assert {r.written_from for r in view.rows} == {"the Cover Art Archive"}
+        assert {r.written_image for r in view.rows} == {archive}
+
+    def test_an_archive_image_that_loses_changes_nothing(self) -> None:
+        big = art_of(1, width=3000, height=3000)
+
+        view = artwork.summarise(
+            album(big, big), cover_of(big), archive=art_of(2, width=400, height=400)
+        )
+
+        assert not any(r.writes for r in view.rows)
+
+    def test_it_must_beat_the_best_the_album_has_not_just_the_cover(self) -> None:
+        """An album whose tracks carry 3000px is not improved by a 2000px
+        archive cover just because its folder file is smaller still."""
+        tracks = art_of(1, width=3000, height=3000)
+        folder = art_of(2, width=500, height=500)
+
+        view = artwork.summarise(
+            album(tracks), cover_of(folder), archive=art_of(3, width=2000, height=2000)
+        )
+
+        assert not any(r.written_from == "the Cover Art Archive" for r in view.rows)
+
+    def test_per_track_artwork_is_still_never_overwritten(self) -> None:
+        """The archive does not get to flatten a compilation, however large."""
+        view = artwork.summarise(
+            album(art_of(1, width=500, height=500), art_of(2, width=500, height=500)),
+            cover_of(art_of(3, width=500, height=500)),
+            archive=art_of(4, width=3000, height=3000),
+        )
+
+        assert not any(r.writes for r in view.rows)
+
+
+def test_a_track_row_replaced_by_the_cover_shows_the_incoming_image() -> None:
+    """The gap this missed until #276: only the gap and folder rows carried an
+    incoming image, so the commonest changing row of all — tracks about to be
+    overwritten by a better folder cover — showed nothing on the right."""
+    small = art_of(1, width=400, height=400)
+    big = art_of(2, width=900, height=900)
+
+    view = artwork.summarise(album(small, small), cover_of(big))
+
+    tracks_row = view.rows[0]
+    assert tracks_row.outcome is artwork.Outcome.REPLACED
+    assert tracks_row.written_from == "cover.jpg"
+    assert tracks_row.written_image == big
+
+
+def test_only_the_archives_image_carries_the_musicbrainz_mark() -> None:
+    """The hexagon is a claim about provenance. A folder cover may have come
+    from a Bandcamp download, so it never gets one; the archive's image is the
+    one case Harmonist can support (#276)."""
+    small = art_of(1, width=400, height=400)
+    folder = art_of(2, width=900, height=900)
+    archive = art_of(3, width=1400, height=1400)
+
+    from_cover = artwork.summarise(album(small), cover_of(folder))
+    from_archive = artwork.summarise(album(small), cover_of(folder), archive=archive)
+
+    assert from_cover.rows[0].written_image == folder
+    assert from_cover.rows[0].from_archive is False
+    assert from_archive.rows[0].written_image == archive
+    assert from_archive.rows[0].from_archive is True

--- a/test/test_cover_art.py
+++ b/test/test_cover_art.py
@@ -222,3 +222,48 @@ def test_ensure_cover_raises_on_network_error(tmp_path):
 
     with pytest.raises(CoverArtError):
         ensure_cover(tmp_path, "rel-123", client=_client(handler))
+
+
+# ---------- the candidate cache (#276) ----------
+
+
+def test_a_traversing_id_never_becomes_a_path(tmp_path):
+    """The id comes from a sidecar, so it is untrusted input joined to a path."""
+    from harmonist import cover_art
+
+    cover_art.configure_cache(tmp_path / "caa")
+    for bad in ("../escape", "a/b", "..", ".hidden/../x", "x" * 100):
+        assert cover_art.cache_image(bad, b"data", "image/jpeg") is None
+        assert cover_art.cached_image(bad) is None
+    assert not list((tmp_path / "caa").glob("**/*")) or all(
+        p.parent == tmp_path / "caa" for p in (tmp_path / "caa").glob("**/*")
+    )
+
+
+def test_an_ordinary_id_round_trips(tmp_path):
+    from harmonist import cover_art
+
+    cover_art.configure_cache(tmp_path / "caa")
+    assert cover_art.cache_image("demo-rel-1", b"\xff\xd8\xffdata", "image/jpeg") is not None
+
+    path = cover_art.cached_image("demo-rel-1")
+    assert path is not None
+    assert path.read_bytes() == b"\xff\xd8\xffdata"
+    assert path.suffix == ".jpg"
+
+
+def test_a_png_keeps_its_extension(tmp_path):
+    from harmonist import cover_art
+
+    cover_art.configure_cache(tmp_path / "caa")
+    cover_art.cache_image("demo-rel-2", b"\x89PNG", "image/png")
+    path = cover_art.cached_image("demo-rel-2")
+    assert path is not None and path.suffix == ".png"
+
+
+def test_no_cache_configured_is_a_no_op(tmp_path):
+    from harmonist import cover_art
+
+    cover_art.configure_cache(None)
+    assert cover_art.cache_image("demo-rel-3", b"data", "image/jpeg") is None
+    assert cover_art.cached_image("demo-rel-3") is None

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -2309,3 +2309,71 @@ def test_a_gap_is_filled_from_the_album_without_rewriting_the_rest(album_with_tr
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == mine  # not destroyed
     assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == mine  # gap filled
     assert cover.read_bytes() == theirs  # no promotion: ours is not better, only equal
+
+
+def test_a_larger_archive_image_wins_and_is_written(album_with_tracks, tmp_path):
+    """#276: the Cover Art Archive is the third candidate. Cached by an earlier
+    check — a tagging never reaches the network — and it wins on size like any
+    other, so it is embedded and the folder cover catches up."""
+    from harmonist import artwork_store, cover_art
+
+    artwork_store.configure(tmp_path / "artwork")
+    cover_art.configure_cache(tmp_path / "caa")
+    album_dir = album_with_tracks(1)
+    mine = _sized_jpeg(500, 500)
+    _embed_cover(album_dir / "01 Track 1.m4a", mine)
+    cover = album_dir / "cover.jpg"
+    folder = _sized_jpeg(800, 800)
+    cover.write_bytes(folder)
+    theirs = _sized_jpeg(1400, 1400)
+    release = _single_track_release()
+    cover_art.cache_image(release["id"], theirs, "image/jpeg")
+
+    tagger.tag_album(album_dir, release, cover_path=cover)
+
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == theirs
+    assert cover.read_bytes() == theirs
+    # …and what it replaced is recoverable, since this overwrote a folder cover.
+    assert artwork_store.path_for(artwork_store.digest(folder)) is not None
+
+
+def test_a_smaller_archive_image_is_ignored(album_with_tracks, tmp_path):
+    """Cached does not mean better. The archive loses like any other candidate
+    that does not beat what is already there."""
+    from harmonist import artwork_store, cover_art
+
+    artwork_store.configure(tmp_path / "artwork")
+    cover_art.configure_cache(tmp_path / "caa")
+    album_dir = album_with_tracks(1)
+    big = _sized_jpeg(2000, 2000)
+    _embed_cover(album_dir / "01 Track 1.m4a", big)
+    cover = album_dir / "cover.jpg"
+    cover.write_bytes(_sized_jpeg(1000, 1000))
+    release = _single_track_release()
+    cover_art.cache_image(release["id"], _sized_jpeg(400, 400), "image/jpeg")
+
+    tagger.tag_album(album_dir, release, cover_path=cover)
+
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big
+    assert cover.read_bytes() == big  # the album's own image still won
+
+
+def test_tagging_never_asks_the_archive(album_with_tracks, tmp_path, monkeypatch):
+    """A tagging reads the cache and nothing else. `plan_album` runs this same
+    code on the gardener's path, where a request per album is exactly what must
+    not happen."""
+    from harmonist import artwork_store, cover_art
+
+    artwork_store.configure(tmp_path / "artwork")
+    cover_art.configure_cache(tmp_path / "caa")
+
+    def _boom(*a, **k):
+        raise AssertionError("a tagging asked the Cover Art Archive")
+
+    monkeypatch.setattr(cover_art, "check_front", _boom)
+    album_dir = album_with_tracks(1)
+    _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(500, 500))
+    cover = album_dir / "cover.jpg"
+    cover.write_bytes(_sized_jpeg(800, 800))
+
+    tagger.tag_album(album_dir, _single_track_release(), cover_path=cover)


### PR DESCRIPTION
The second half of #276. The archive's front cover is now the third candidate
alongside what the tracks carry and what the folder holds, and the same rule
settles it: **the largest image wins.**

## The cache is deliberately not the artwork store

One file per release, named for the release rather than content-addressed —
there is nothing to deduplicate, and a release has one current front cover.

The deeper difference is what eviction costs. `artwork_store` holds the **only**
copy of something the user had, so dropping a file breaks the promise #408
makes. These are copies of something the archive still has, so dropping one
costs a re-fetch and nothing else — no retention, no protected set, no undo
semantics, and deleting the whole directory is safe at any moment. Keeping them
in the same store would have let a robot's candidates compete for the space that
store promises to an album's undo.

## The full image is fetched only when it would win

A check measures with a 64 KB range. The 200 KB–5 MB download happens only if
that measurement beats the widest image the album already has, and only during a
check the user pressed. A candidate that loses is measured and forgotten.

## A tagging never reaches the network

`_archive_candidate` reads the local cache and nothing else, because
`plan_album` runs the same code on the gardener's path where a request per album
is exactly what must not happen. An album nobody has checked simply has no third
candidate. There is a test that fails if a tagging so much as calls the fetcher.

## The comparison

Ordered worst-first, so each candidate has to genuinely beat the one before it
to displace it: ties go to what is already there, since a same-sized different
picture is not an improvement and is not worth overwriting a user's file for.

`promote_cover` carries bytes now rather than a source file, because the winner
may come from the archive rather than from a track — and when it does,
`tag_album` keeps the old folder cover before replacing it, exactly as #410
already arranged and #408 requires.

## A guard that appeared to work while storing nothing

Worth recording. The cache's filename guard started as a UUID pattern, and
Harmonist's own fixtures and demo library use short readable release ids like
`demo-rel-dingoes` — so it silently disabled the cache for every one of them
while every call still returned cleanly. It is a **character** guard now: what
matters is that an id from a sidecar cannot escape the directory, not that it
looks like a UUID. Covered by a traversal test (`../escape`, `a/b`, `..`, an
over-long id).

## Testing

`make check` green (1760 passed). Both behaviours mutation-checked: removing the
archive candidate, and letting it win unconditionally, each turn the right test
red.

## Next

Showing the archive's image in the section's incoming column — the plumbing is
here, the row does not render it yet — and then the background pass.

Refs #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH

---

## Second commit: showing it

The archive's candidate now appears in the incoming column, so an album whose
artwork is about to improve shows what it would become rather than asserting it.

**Served from Harmonist, not linked to coverartarchive.org** — a privacy
decision rather than an implementation detail: the album page talks to one host,
so opening an album cannot tell the Internet Archive which records this user
owns. The image route already addresses images by digest, so the cached
candidate is simply a third place it looks.

**It carries the hexagon**, and it is the first incoming image that has any
business with one. Every earlier one was left unmarked on purpose: a folder
cover may have come from a Bandcamp download, and stamping it MusicBrainz's
would have been a claim Harmonist could not support.

### A gap this uncovered

**The track rows have never shown an incoming image at all.** #413 added it to
the gap row and the folder row; the edit meant to add it to the track rows
silently did not apply — ruff had rewrapped the code, so the patch matched
nothing, and the tests written at the time covered the two rows that worked. The
commonest changing row of all — tracks about to be overwritten by a better
folder cover — showed a bare "Replaced by cover.jpg" with nothing beside it.
Fixed here, with a test that fails if it goes missing again.

### Verified end to end against the live archive

A 350×350 front cover beating a 200px track image and a 300px folder cover wins
both rows, shows in both, and is marked.
