### PR TITLE
Let the Cover Art Archive check be started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ versions follow [semantic versioning](https://semver.org).
   cover that is no better than yours is ignored. The Artwork section shows the
   archive's image beside your own, marked as MusicBrainz's, and serves it from
   Harmonist — so opening an album never tells the Internet Archive which records
-  you own (#276).
+  you own (#276). The **CAA checked** row shows on any album with a MusicBrainz
+  release, reading *not yet* until you ask — it carries the control that asks,
+  so hiding it until the first check left nothing to press (#419).
 
 ### Fixed
 

--- a/templates/partials/_checked_at.html
+++ b/templates/partials/_checked_at.html
@@ -91,14 +91,24 @@
        vocabulary: elapsed time, the exact moment on hover, and the way to ask
        again beside it.
 
-       Absent until the archive has been asked once — a row saying "never" would
-       be a line on every album forever, for a check most albums never need. #}
-    {% if caa_checked_at %}
+       Shown for any album with a MusicBrainz release, asked or not, because
+       this row IS the way to ask (#419). It was hidden until the first check,
+       which put the only control that starts one inside the block that only
+       exists after one — so no album could ever be checked. The reasoning for
+       hiding it was sound in isolation (a row reading "never" on every album is
+       noise) and self-defeating once the button lived in it. #}
+    {% if album.sidecar and album.sidecar.mb_release_id %}
     <dt class="col-start-1 text-2xs text-muted uppercase tracking-widest self-baseline">CAA checked</dt>
+    {% if caa_checked_at %}
     <dd class="text-ink tabular-nums self-baseline whitespace-nowrap"
         title="Cover Art Archive last asked {{ caa_checked_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}">
         {{ ago(caa_checked_at) }}
     </dd>
+    {% else %}
+    {# Not a date, so not in the dates' typeface: this says the question has not
+       been put yet, and the control beside it is how you put it. #}
+    <dd class="text-muted italic self-baseline whitespace-nowrap">not yet</dd>
+    {% endif %}
     <dd class="col-start-3 flex items-center">
         {# Re-asks, and re-renders the Artwork section that reports the answer —
            the same shape as the MusicBrainz control above, which re-fetches into

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -8740,3 +8740,17 @@ def test_artwork_image_404s_for_an_image_this_album_does_not_carry(client, cfg):
     assert client.get(f"/artwork/image/{album_id}/{images.digest(_png(9))}").status_code == 404
     # And a digest-shaped path is the only thing that reaches a file read.
     assert client.get(f"/artwork/image/{album_id}/..%2F..%2Fetc%2Fpasswd").status_code == 404
+
+
+def test_the_cover_art_check_is_reachable_before_it_has_ever_run(client, cfg):
+    """The control that asks the archive used to live inside the row that only
+    exists once it has been asked, so no album could ever start (#419)."""
+    d = _make_tagged_album(cfg, "Checkable", mbid="rel-caa", tagged_at=datetime.now(UTC))
+    album_id = _id_for(cfg, d)
+
+    r = client.get(f"/album/{album_id}")
+
+    assert r.status_code == 200
+    rendered = " ".join(r.text.split())
+    assert "CAA checked" in rendered
+    assert f"/album/{album_id}/artwork?check=1" in rendered


### PR DESCRIPTION
The **CAA checked** row carried the only control that asks the Cover Art
Archive, and the row rendered only once the archive had been asked. Every album
that had never been checked — which was all of them — had no way to start.

```jinja
{% if caa_checked_at %}      {# the row… #}
  …
  <button hx-get="…/artwork?check=1">   {# …and the only way to make it exist #}
{% endif %}
```

The reasoning was sound in isolation: a row reading "never" on every album
forever is noise, so it was hidden until there was something to say. Putting the
button inside the same block is what made that self-defeating.

## Fix

The row shows for any album with a MusicBrainz release — which is exactly what
makes it checkable — reading *not yet* until it has been asked, in muted italic
rather than the dates' own typeface, because it is not a date. The row is the
affordance, which is what it was meant to be.

## Why the tests missed it

They call `/album/{id}/artwork?check=1` directly and assert on the answer, so
every one of them passed against a control no user could reach. That is the #40
bug class in a different coat — correct, and unreachable.

The test added here asks the question none of them did: is it on the page at
all, before anything has happened? Mutation-checked — restoring the old
condition turns it red.

## Verified

`make check` green (1767 passed), and confirmed in a browser in demo mode:
**CAA CHECKED · *not yet*** with its control, under **MB CHECKED**.

Fixes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
