### PR TITLE
Give artwork its own action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- **Updating artwork is now its own action, separate from a re-tag.** A re-tag
+  fills tracks that have no artwork and never replaces one you already have;
+  improving an album's images is an **Update artwork** button in the Artwork
+  section, beside the pictures it changes. Replacing artwork is the change most
+  likely to be worth undoing on its own, and it has always had its own Undo in
+  History — now it has its own way to be done, too (#418).
+
 ### Added
 
 - **Harmonist can take better artwork from the Cover Art Archive.** The album

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -241,12 +241,16 @@ def tag_album(
     for file_path, (medium, track_pos_in_medium, track) in prep.pairs:
         tagset = _build_tagset(release, medium, track_pos_in_medium, track, prep.media_total)
         before = formats.read_owned(file_path)
+        # None for a file that already carries an image: `write_tags` then
+        # leaves its art alone, and `_changes_for` records no artwork change for
+        # it, because none happens (#418).
+        incoming = prep.cover if file_path in prep.art_targets else None
         changes = _changes_for(
             tagset,
             before,
             file_path,
             prep.art_before,
-            prep.art_after,
+            images.digest(incoming) if incoming is not None else None,
             prep.accepted_album_title,
             prep.accepted_countries,
         )
@@ -259,7 +263,7 @@ def tag_album(
             # is what makes the gardener's nightly pass (#32) a real no-op
             # rather than one that merely records nothing.
             continue
-        formats.write_tags(file_path, tagset, prep.cover)
+        formats.write_tags(file_path, tagset, incoming)
         wrote_something = True
         # The `tag.track` line comes AFTER the write, and the detail hangs off
         # it: a record claiming a change that never landed would make a future
@@ -503,6 +507,116 @@ class _Prepared:
     #: Bytes rather than a source, because the winner may come from the archive
     #: cache rather than from a track.
     promote_cover: bytes | None = None
+    #: The files this TAGGING may write `cover` to — the ones carrying nothing,
+    #: or every file under `overwrite_art` (#418). Everything else keeps the
+    #: image it has; improving those is the artwork action's job.
+    art_targets: frozenset[Path] = frozenset()
+
+
+@dataclass(frozen=True)
+class ArtworkPlan:
+    """What should happen to an album's images, decided once (#418).
+
+    Shared by the two paths that act on artwork so they cannot reach different
+    verdicts: a tagging, which fills gaps and touches nothing else, and the
+    artwork action, which replaces. Splitting the decision out is what lets the
+    second exist — `_prepare` also pairs files to tracks and enforces the count
+    guard, neither of which an artwork change has any business requiring.
+    """
+
+    #: Every file's current embedded image as a digest, or None where it has
+    #: none. The gaps are the None entries.
+    before: dict[Path, str | None]
+    #: The image that ought to be on every track, or None when nothing should be
+    #: written at all — no folder cover, or per-track artwork worth preserving.
+    winner: bytes | None
+    #: The image the folder cover should become, when something beats it.
+    promote_cover: bytes | None = None
+    #: Whether per-track artwork is being preserved, which is a decision worth
+    #: reporting rather than a silent no-op.
+    preserves_per_track_art: bool = False
+
+    @property
+    def digest(self) -> str | None:
+        """The winner's content address, or None when nothing would be written."""
+        return images.digest(self.winner) if self.winner is not None else None
+
+    def gaps(self) -> list[Path]:
+        """The files carrying no image at all — what a TAGGING may fill."""
+        return [path for path, digest in self.before.items() if digest is None]
+
+    def replacements(self) -> list[Path]:
+        """The files carrying a DIFFERENT image from the winner — what only the
+        artwork action may overwrite (#418)."""
+        winner = self.digest
+        if winner is None:
+            return []
+        return [
+            path for path, digest in self.before.items() if digest is not None and digest != winner
+        ]
+
+
+def decide_artwork(
+    files: list[Path],
+    release: Release,
+    cover_path: Path | None,
+    *,
+    overwrite_art: bool = False,
+) -> ArtworkPlan:
+    """Which image wins, and what would have to change for it to be everywhere.
+
+    THE LARGEST IMAGE WINS, among the three an album can offer: what its tracks
+    carry, what its folder holds, and what the Cover Art Archive has if anyone
+    has asked (#276, #410). A re-tag used to embed the folder cover regardless,
+    which on a real library shrank one album in twelve — 3000px replaced by
+    2000px, in one case 5700px by 2000px.
+
+    `overwrite_art` opts out of the comparison entirely: a user asking for the
+    folder cover to be embedded is not asking for it to be judged.
+
+    Reads files and the local caches, and nothing else. No network: `plan_album`
+    reaches this on the gardener's path, where a request per album is exactly
+    what must not happen.
+    """
+    cover = cover_path.read_bytes() if cover_path else None
+    before = _art_digests(files) if cover is not None else {}
+
+    # DATA SAFETY: if the tracks carry DIFFERENT embedded art (a per-track-art
+    # album, e.g. a compilation), embedding one album cover would destroy those
+    # images. Preserve them — the folder cover.* is still written separately.
+    preserves = (
+        cover is not None and not overwrite_art and artwork.has_per_track_art(before.values())
+    )
+    if preserves:
+        return ArtworkPlan(before=before, winner=None, preserves_per_track_art=True)
+    if cover is None or overwrite_art:
+        return ArtworkPlan(before=before, winner=cover)
+
+    folder_size = images.dimensions(cover)
+    own = _album_image(before)
+    # The archive's image, from the LOCAL CACHE only.
+    archive = _archive_candidate(release)
+
+    # Ordered worst-first so each candidate has to genuinely beat the one before
+    # it to displace it — ties go to what is already there, because a same-sized
+    # different picture is not an improvement and is not worth overwriting a
+    # user's file for.
+    winner, winner_size = cover, folder_size
+    if own is not None:
+        _, mine = own
+        ours = images.dimensions(mine)
+        if ours is not None and folder_size is not None and not artwork.beats(folder_size, ours):
+            winner, winner_size = mine, ours
+    if archive is not None:
+        theirs = images.dimensions(archive)
+        if artwork.beats(theirs, winner_size):
+            winner, winner_size = archive, theirs
+
+    # The folder file catches up when the winner is not what it holds. That
+    # write is the one here that could not be undone from the tracks themselves,
+    # so it happens only on a strict improvement.
+    promote = winner if winner is not cover and artwork.beats(winner_size, folder_size) else None
+    return ArtworkPlan(before=before, winner=winner, promote_cover=promote)
 
 
 def _prepare(
@@ -559,71 +673,25 @@ def _prepare(
     # path where scanning is already the slow part (#44, #74). Guarding here
     # rather than relying on the `and` below, which used to short-circuit this
     # read and stopped doing so when the digests were hoisted out.
-    cover_bytes = cover
-    art_before = _art_digests(files) if cover is not None else {}
-    # DATA SAFETY: if the tracks carry DIFFERENT embedded art (a per-track-art
-    # album, e.g. a compilation), embedding one album cover would destroy those
-    # images. Preserve them — pass cover=None (write_tags leaves the existing
-    # embedded cover untouched); the folder cover.* is still written separately.
+    art = decide_artwork(files, release, cover_path, overwrite_art=overwrite_art)
+    art_before = art.before
+    preserves_per_track_art = art.preserves_per_track_art
+    # A TAGGING FILLS GAPS AND REPLACES NOTHING (#418). Improving an image the
+    # album already has is its own action now, because it is the change a user
+    # is most likely to want to undo on its own — and because the severity
+    # levels have said so all along: adding artwork where there is none is
+    # ENRICHMENT, replacing it is COVER_ART.
     #
-    # Decided here and REPORTED rather than announced: `plan_album` must reach
-    # the same verdict without logging anything, so the warning belongs to
-    # `tag_album`, which is the one that acts on it.
-    preserves_per_track_art = (
-        cover is not None and not overwrite_art and artwork.has_per_track_art(art_before.values())
-    )
-    if preserves_per_track_art:
-        cover = None
-
-    # THE LARGEST IMAGE WINS, among the three the album can offer: what its
-    # tracks carry, what its folder holds, and what the Cover Art Archive has if
-    # anyone has asked (#276, #410). A re-tag used to embed the folder cover
-    # regardless, which on a real library shrank one album in twelve — 3000px
-    # replaced by 2000px, in one case 5700px by 2000px.
+    # Per FILE, not per album, which is why this is a set of targets rather than
+    # a flag: an album with ten good images and two gaps gets the two filled and
+    # the ten left exactly as they are. That album is #397, and it is the shape
+    # this rule exists for.
     #
-    # `overwrite_art` opts out of the whole comparison: a user asking for the
-    # folder cover to be embedded is not asking for it to be judged.
-    promote_cover = None
-    if cover is not None and not overwrite_art:
-        folder_size = images.dimensions(cover)
-        own = _album_image(art_before)
-        # The archive's image, from the LOCAL CACHE only. A tagging never
-        # reaches the network: `plan_album` runs this same code on the
-        # gardener's path, where a request per album is exactly what must not
-        # happen. An album nobody has checked has no third candidate.
-        archive = _archive_candidate(release)
-
-        # Ordered worst-first so that each candidate has to genuinely beat the
-        # one before it to displace it — ties go to what is already there,
-        # because a same-sized different picture is not an improvement and is
-        # not worth overwriting a user's file for.
-        winner, winner_size = cover, folder_size
-        if own is not None:
-            _, mine = own
-            ours = images.dimensions(mine)
-            # Unless the folder cover BEATS the album's own image, the album's
-            # own is what gets embedded — which fills the tracks that carry
-            # nothing and is a no-op on the rest (#397). Both sizes must be
-            # readable: an unmeasurable header is no evidence, so the fallback
-            # is what a re-tag has always done.
-            if (
-                ours is not None
-                and folder_size is not None
-                and not artwork.beats(folder_size, ours)
-            ):
-                winner, winner_size = mine, ours
-        if archive is not None:
-            theirs = images.dimensions(archive)
-            if artwork.beats(theirs, winner_size):
-                winner, winner_size = archive, theirs
-
-        cover = winner
-        # The folder file catches up when the winner is not already what it
-        # holds. That write is the one here that could not be undone from the
-        # tracks themselves, so it happens only on a strict improvement — and
-        # `tag_album` keeps the old cover before replacing it (#408).
-        if winner is not cover_bytes and artwork.beats(winner_size, folder_size):
-            promote_cover = winner
+    # `overwrite_art` remains what it always was — an explicit "embed the folder
+    # cover over everything" — and is the one way a tagging still replaces.
+    cover = art.winner
+    art_targets = frozenset(files if overwrite_art else art.gaps())
+    promote_cover = art.promote_cover if overwrite_art else None
 
     return _Prepared(
         files=files,
@@ -635,6 +703,7 @@ def _prepare(
         art_after=images.digest(cover) if cover is not None else None,
         preserves_per_track_art=preserves_per_track_art,
         promote_cover=promote_cover,
+        art_targets=art_targets,
         media_total=len(release.get("medium-list", [])) or 1,
         accepted_album_title=title_with_disambiguation(
             release.get("title"), release.get("disambiguation")
@@ -1116,6 +1185,95 @@ class ArtworkUnavailableError(Exception):
     cap, or never kept because the store was full or disabled. Raised rather
     than silently doing nothing, because "undo" that quietly succeeds without
     restoring anything is the confident lie the design forbids."""
+
+
+def update_artwork(
+    album_dir: Path,
+    release: Release,
+    cover_path: Path | None,
+    *,
+    files: list[Path] | None = None,
+    overwrite_art: bool = False,
+) -> int:
+    """Put the winning image on every track and on the folder cover (#418).
+
+    The other half of the split: a tagging fills gaps and replaces nothing, and
+    this replaces. It exists as its own action because replacing artwork is the
+    change a user is most likely to want to undo on its own — History has
+    offered a separate Undo for it since #131, and having one way to reverse
+    them separately and no way to do them separately was the asymmetry.
+
+    Writes ARTWORK ONLY. Tags are not touched, not even the ones that happen to
+    be stale: pressing a button about images must not quietly re-tag an album,
+    which is the whole point of separating them.
+
+    No count guard and no file-to-track pairing, unlike `_prepare` — an album
+    missing half its tracks still has artwork worth fixing, and which file is
+    which track has no bearing on what image it should carry.
+
+    Returns how many files changed. Zero is an ordinary answer: it means the
+    winner is already everywhere, which is what a second press should find.
+    """
+    paths = files if files is not None else album_files.audio_files(album_dir)
+    art = decide_artwork(paths, release, cover_path, overwrite_art=overwrite_art)
+    winner, digest = art.winner, art.digest
+    if winner is None or digest is None:
+        return 0
+
+    album_id = sidecar_mod.album_id_for(album_dir)
+    targets = [p for p in paths if art.before.get(p) != digest]
+    if not targets and art.promote_cover is None:
+        return 0
+
+    # Before anything is written, and for the same reason `tag_album` records
+    # its `tag.album` line first: a crash part-way through leaves evidence of
+    # what was attempted rather than silence.
+    audit.record(
+        "artwork.update",
+        album_id=album_id,
+        album=album_dir,
+        files=len(targets),
+        digest=digest,
+        mode="replace" if overwrite_art else "best",
+    )
+    # Keep whatever is about to be destroyed, so this is undoable — the same
+    # pass a tagging makes, and the reason the artwork store exists (#131).
+    _keep_doomed_art(art.before, digest)
+
+    changed = 0
+    for path in targets:
+        was = art.before.get(path)
+        formats.write_cover(path, winner)
+        changed += 1
+        # Recorded in the shape a tagged file's artwork change takes, which is
+        # what puts an Undo on it: `tag_history.artwork_replaced` reads that
+        # pair and `restore_artwork` writes it back.
+        event_id = audit.record(
+            "tag.track",
+            album_id=album_id,
+            album=album_dir,
+            file=album_files.rel_name(album_dir, path),
+        )
+        if event_id is not None:
+            activity_store.record_tag_changes(
+                event_id,
+                file=album_files.rel_name(album_dir, path),
+                changes={owned.ARTWORK: [was, digest]},
+            )
+
+    if art.promote_cover is not None and cover_path is not None:
+        promoted = _promote_album_image(album_dir, cover_path, art.promote_cover, album_id)
+        if promoted is not None:
+            was, now = promoted
+            event_id = audit.record(
+                "tag.track", album_id=album_id, album=album_dir, file=cover_path.name
+            )
+            if event_id is not None:
+                activity_store.record_tag_changes(
+                    event_id, file=cover_path.name, changes={owned.ARTWORK: [was, now]}
+                )
+            changed += 1
+    return changed
 
 
 def restore_artwork(album_dir: Path, digests: dict[str, str]) -> int:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -4907,6 +4907,55 @@ def _register_routes(app: FastAPI) -> None:
             return
         activity_store.store_cover_art(mbid, answer)
 
+    @app.post("/album/{album_id}/artwork/update", response_class=HTMLResponse)
+    def album_artwork_update(request: Request, album_id: str) -> Response:
+        """Put the winning image on every track and on the folder cover (#418).
+
+        Artwork only — no tags are written, not even stale ones. A button about
+        images that quietly re-tagged an album would defeat the separation this
+        exists for: replacing artwork is the change a user is most likely to
+        want to undo on its own, and History has offered a separate Undo for it
+        since #131.
+
+        Re-renders the section, so what the page shows afterwards is what is now
+        on disk rather than what was proposed a moment ago.
+        """
+        album = _refreshed_from_disk(request, _find_album(request, album_id))
+        mbid = album.sidecar.mb_release_id if album.sidecar else None
+        if mbid is None:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "album has no MusicBrainz release")
+        try:
+            release = mb_cache.fetch_release(mbid)
+        except mb_lookup.MBError as e:
+            return _flash_response(
+                "Couldn't update artwork", str(e), level=Level.ERROR, tasks_changed=False
+            )
+        changed = tagger_mod.update_artwork(
+            album.path,
+            release,
+            album.cover_path,
+            files=album_files.for_paths(album.folders) if album.folders else None,
+        )
+        activity.info(
+            f"Updated artwork on {changed} file{'s' if changed != 1 else ''}"
+            if changed
+            else "Artwork was already up to date",
+            album_id=album.id,
+        )
+        # Re-read from disk: the files just changed, and the section describes
+        # what they carry.
+        album = _refreshed_from_disk(request, _find_album(request, album_id))
+        caa = activity_store.cached_cover_art(mbid)
+        return _templates(request).TemplateResponse(
+            request,
+            "partials/_artwork.html",
+            _ctx(
+                request,
+                album=album,
+                artwork=_artwork_view(album, caa, _archive_image(mbid)),
+            ),
+        )
+
     @app.get("/artwork/image/{album_id}/{digest}")
     def artwork_image(request: Request, album_id: str, digest: str) -> Response:
         """One of the album's images, by content digest.

--- a/templates/partials/_artwork.html
+++ b/templates/partials/_artwork.html
@@ -133,6 +133,29 @@
 </div>
 {% endif %}
 
+{# The action, when there is something for it to do (#418). Beside the images
+   rather than up with Re-tag, so what is being accepted is on screen — and
+   separate from Re-tag because replacing artwork is the change most likely to
+   be undone on its own, which History has always treated as its own thing.
+
+   No button when nothing would change, the same way the rows say nothing then.
+
+   `hx-confirm` because this overwrites images the user has; the folder cover is
+   kept first, so it can be put back from History (#408). #}
+{% if artwork.writes %}
+<form hx-post="/album/{{ album.id }}/artwork/update"
+      hx-target="#album-artwork" hx-swap="innerHTML"
+      hx-disabled-elt="find button"
+      hx-confirm="Update this album's artwork? What is replaced is kept, so this can be undone from History."
+      class="pt-1">
+    <button type="submit"
+            class="text-2xs uppercase tracking-widest font-bold px-3 py-1.5 rounded
+                   border border-mb-purple/40 text-mb-purple hover:bg-mb-purple/10 transition"
+            title="Write the winning image to every track and to the folder cover"
+            aria-label="Update this album's artwork">Update artwork</button>
+</form>
+{% endif %}
+
 {# The full-size views, one per distinct image. A popover rather than a
    hand-rolled overlay: it brings its own dismiss, Escape handling and top-layer
    placement (web-ui rule 1), and it is the same element the odd-tracks pill

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -252,10 +252,12 @@ def test_tagging_records_artwork_replacement_by_digest(album_with_tracks, tmp_pa
     assert first[0] is None  # no embedded art before
     assert len(first[1]) == 64  # sha256 hex
 
+    # Replacing it is the ARTWORK ACTION's job now, not a re-tag's (#418) — but
+    # the record it leaves is the same shape, which is what keeps one Undo.
     newer = tmp_path / "cover2.jpg"
     newer.write_bytes(b"\xff\xd8\xff" + b"second" * 40)
     before = len(_detail())
-    tagger.tag_album(album_dir, _release_2_tracks(), newer)
+    tagger.update_artwork(album_dir, _release_2_tracks(), newer)
 
     replaced = _detail()[before:][0].changes[owned.ARTWORK]
     assert replaced[0] == first[1]  # what was there is what we recorded before
@@ -873,19 +875,76 @@ def test_tag_album_overwrite_art_forces_replacement(album_with_tracks, tmp_path)
     assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == new
 
 
-def test_tag_album_embeds_when_art_missing_on_some_tracks(album_with_tracks, tmp_path):
-    """'Missing on some tracks' is NOT per-track art — only ACTUAL differences are.
-    One track with a cover + one without → the album cover embeds normally."""
+def test_tagging_fills_the_gap_and_leaves_the_rest(album_with_tracks, tmp_path):
+    """A tagging fills tracks carrying nothing and replaces nothing (#418).
+
+    'Missing on some tracks' is not per-track art, so there IS a cover to write —
+    but only where there is a hole. The track that already had an image keeps
+    it; improving that one is the artwork action's job."""
     album_dir = album_with_tracks(2)
-    _embed_cover(album_dir / "01 Track 1.m4a", _minimal_jpeg())  # track 2 has none
+    had = _minimal_jpeg()
+    _embed_cover(album_dir / "01 Track 1.m4a", had)  # track 2 has none
     new = b"\xff\xd8\xff\xe0UNIFORM\xff\xd9"
     new_cover = tmp_path / "cover.jpg"
     new_cover.write_bytes(new)
 
     tagger.tag_album(album_dir, _release_2_tracks(), cover_path=new_cover)
 
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == had  # untouched
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == new  # filled
+
+
+def test_the_artwork_action_replaces_what_a_tagging_would_not(album_with_tracks, tmp_path):
+    """The other half of the same album: the action does replace."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(2)
+    _embed_cover(album_dir / "01 Track 1.m4a", _minimal_jpeg())
+    new = b"\xff\xd8\xff\xe0UNIFORM\xff\xd9"
+    new_cover = tmp_path / "cover.jpg"
+    new_cover.write_bytes(new)
+
+    changed = tagger.update_artwork(album_dir, _release_2_tracks(), new_cover)
+
+    assert changed == 2
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == new
     assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == new
+
+
+def test_the_artwork_action_touches_no_tags(album_with_tracks, tmp_path):
+    """Pressing a button about images must not quietly re-tag an album — which
+    is the whole point of separating them (#418)."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(1)
+    track = album_dir / "01 Track 1.m4a"
+    audio = MP4(track)
+    audio[ATOM_TITLE] = ["A title MusicBrainz disagrees with"]
+    audio.save()
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xff\xd8\xff\xe0NEW\xff\xd9")
+
+    tagger.update_artwork(album_dir, _single_track_release(), cover)
+
+    assert MP4(track)[ATOM_TITLE] == ["A title MusicBrainz disagrees with"]
+
+
+def test_the_artwork_action_is_idempotent(album_with_tracks, tmp_path):
+    """A second press finds the winner already everywhere and writes nothing."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(2)
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xff\xd8\xff\xe0ONLY\xff\xd9")
+
+    first = tagger.update_artwork(album_dir, _release_2_tracks(), cover)
+    second = tagger.update_artwork(album_dir, _release_2_tracks(), cover)
+
+    assert first == 2
+    assert second == 0
 
 
 def test_tag_album_returns_count(album_with_tracks):
@@ -2164,7 +2223,7 @@ def test_a_larger_embedded_image_is_promoted_to_the_folder_cover(album_with_trac
     cover = tmp_path / "cover.jpg"
     cover.write_bytes(_sized_jpeg(400, 400))
 
-    tagger.tag_album(album_dir, _release_2_tracks(), cover_path=cover)
+    tagger.update_artwork(album_dir, _release_2_tracks(), cover)
 
     # The tracks keep the better image…
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big
@@ -2185,7 +2244,7 @@ def test_the_replaced_folder_cover_can_be_undone(album_with_tracks, tmp_path):
     small = _sized_jpeg(400, 400)
     cover.write_bytes(small)
 
-    tagger.tag_album(album_dir, _single_track_release(), cover_path=cover)
+    tagger.update_artwork(album_dir, _single_track_release(), cover)
 
     kept = artwork_store.path_for(artwork_store.digest(small))
     assert kept is not None, "the overwritten folder cover was not kept"
@@ -2204,7 +2263,7 @@ def test_a_larger_folder_cover_is_still_embedded(album_with_tracks, tmp_path):
     big = _sized_jpeg(1000, 1000)
     cover.write_bytes(big)
 
-    tagger.tag_album(album_dir, _single_track_release(), cover_path=cover)
+    tagger.update_artwork(album_dir, _single_track_release(), cover)
 
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big
     assert cover.read_bytes() == big
@@ -2223,7 +2282,7 @@ def test_per_track_artwork_never_promotes_one_track_to_the_album_cover(album_wit
     small = _sized_jpeg(400, 400)
     cover.write_bytes(small)
 
-    tagger.tag_album(album_dir, _release_2_tracks(), cover_path=cover)
+    tagger.update_artwork(album_dir, _release_2_tracks(), cover)
 
     assert cover.read_bytes() == small
 
@@ -2241,7 +2300,7 @@ def test_a_promoted_cover_can_be_put_back(album_with_tracks, tmp_path):
     small = _sized_jpeg(400, 400)
     cover.write_bytes(small)
 
-    tagger.tag_album(album_dir, _single_track_release(), cover_path=cover)
+    tagger.update_artwork(album_dir, _single_track_release(), cover)
     assert cover.read_bytes() == big  # promoted
 
     restored = tagger.restore_artwork(album_dir, {"cover.jpg": artwork_store.digest(small)})
@@ -2329,7 +2388,7 @@ def test_a_larger_archive_image_wins_and_is_written(album_with_tracks, tmp_path)
     release = _single_track_release()
     cover_art.cache_image(release["id"], theirs, "image/jpeg")
 
-    tagger.tag_album(album_dir, release, cover_path=cover)
+    tagger.update_artwork(album_dir, release, cover)
 
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == theirs
     assert cover.read_bytes() == theirs
@@ -2352,7 +2411,7 @@ def test_a_smaller_archive_image_is_ignored(album_with_tracks, tmp_path):
     release = _single_track_release()
     cover_art.cache_image(release["id"], _sized_jpeg(400, 400), "image/jpeg")
 
-    tagger.tag_album(album_dir, release, cover_path=cover)
+    tagger.update_artwork(album_dir, release, cover)
 
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big
     assert cover.read_bytes() == big  # the album's own image still won

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -8754,3 +8754,36 @@ def test_the_cover_art_check_is_reachable_before_it_has_ever_run(client, cfg):
     rendered = " ".join(r.text.split())
     assert "CAA checked" in rendered
     assert f"/album/{album_id}/artwork?check=1" in rendered
+
+
+def test_the_artwork_action_is_offered_only_when_something_would_change(client, cfg):
+    """No button when nothing would change, the same way the rows say nothing."""
+    same = _png(1)
+    settled = _album_with_art(cfg, "Settled", covers=[same, same], folder=same)
+    improvable = _album_with_art(cfg, "Improvable", covers=[_png(1), None], folder=_png(2))
+
+    quiet = client.get(f"/album/{_id_for(cfg, settled)}/artwork")
+    offered = client.get(f"/album/{_id_for(cfg, improvable)}/artwork")
+
+    assert "Update artwork" not in quiet.text
+    assert "Update artwork" in offered.text
+
+
+def test_the_artwork_action_writes_artwork_and_not_tags(client, cfg):
+    """The separation, end to end: images change, the title does not (#418)."""
+    from mutagen.mp4 import MP4
+
+    from harmonist import formats
+
+    d = _make_tagged_album(cfg, "ArtOnly", mbid="rel-art", tagged_at=datetime.now(UTC))
+    track = next(d.glob("*.m4a"))
+    formats.write_cover(track, _png(1))
+    (d / "cover.jpg").write_bytes(_png(2))
+    audio = MP4(track)
+    audio[ATOM_TITLE] = ["Left alone"]
+    audio.save()
+
+    r = client.post(f"/album/{_id_for(cfg, d)}/artwork/update")
+
+    assert r.status_code == 200
+    assert MP4(track)[ATOM_TITLE] == ["Left alone"]


### PR DESCRIPTION
Updating an album's images was something a re-tag did on the way past. It is its
own button now, in the Artwork section, beside the pictures it changes.

## The behaviour change, stated plainly

**A re-tag fills gaps and never replaces an image you already have.** Improving
artwork is the **Update artwork** action. `overwrite_art` is unchanged and
remains the one way a tagging still replaces.

This revises what #410 and #276 shipped earlier — deliberately, and with those
tests moved rather than deleted (below).

## The dividing line is the severity taxonomy, not a UI preference

- Adding artwork where there is none is `ENRICHMENT` — additive, nothing
  destroyed — so a tagging still fills gaps, and a first tagging still gives an
  album its cover.
- Replacing an image the album already has is `COVER_ART`, the level that exists
  because its undo needed machinery of its own (#408). That is what moved.

Per **file**, not per album, which is the point: an album with ten good images
and two gaps gets the two filled and the ten left exactly as they are. That
album is #397, and this is the rule it was asking for.

## The asymmetry it closes

History has offered a separate Undo for artwork since #131. There was one way to
reverse them separately and no way to do them separately — so undoing artwork
you disliked meant undoing a tagging you were happy with.

## What made it possible

`decide_artwork` — the verdict was buried in `_prepare`, which also pairs files
to tracks and enforces the count guard, neither of which an artwork change has
any business requiring. An album missing half its tracks still has artwork worth
fixing. Both callers ask one function now, so they cannot reach different
answers.

`update_artwork` writes **artwork and nothing else**, not even tags that happen
to be stale: a button about images that quietly re-tagged an album would defeat
the separation it exists for. Each change is recorded in the shape a tagged
file's takes, so the Undo it produces is the one History already knows how to
offer.

## Tests

Eight moved rather than deleted — the behaviours they pin are still required, of
the action rather than of the tagging. Two more were rewritten to state the new
contract, one of them the test that used to assert a re-tag replaces every
track's art to fill one hole. New coverage for the action being artwork-only,
idempotent, and offered only when something would change.

`make check` green (1772 passed).

## Verified in demo mode, against real files

```
before:  01 art=d546efa9   02 art=None      03 art=d546efa9
after:   01 art=d546efa9   02 art=d546efa9  03 art=d546efa9
titles:  unchanged throughout
```

The `hx-confirm` path was **not** exercised in a browser — a native `confirm()`
blocks the automation session — so the POST was driven directly. Worth one click
by hand.

Fixes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
