### PR TITLE
Say at the top when the artwork wants attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ versions follow [semantic versioning](https://semver.org).
   likely to be worth undoing on its own, and it has always had its own Undo in
   History — now it has its own way to be done, too (#418).
 
+- **The top of an album's page says when its artwork wants attention**, with a
+  link down to the Artwork section, which is usually well below the fold. And
+  the Re-tag buttons no longer claim "per-track embedded artwork is preserved" —
+  true once, and since #418 simply: your artwork is left alone (#417).
+
 ### Added
 
 - **Harmonist can take better artwork from the Cover Art Archive.** The album

--- a/src/harmonist/artwork.py
+++ b/src/harmonist/artwork.py
@@ -308,6 +308,26 @@ class ArtworkView:
         return tuple(out.values())
 
     @property
+    def summary(self) -> str:
+        """One line for the top of the page (#417) — what updating the artwork
+        would do, in the terms the rows use.
+
+        Written here rather than in the template for the reason the verdict was:
+        it has several shapes, and a Jinja `{% if %}` chain is where wording goes
+        to stop being reviewed.
+        """
+        filled = sum(len(r.tracks) for r in self.rows if r.is_gap and r.writes)
+        replaced = sum(1 for r in self.images if r.writes)
+        parts = []
+        if filled:
+            parts.append(f"{filled} track{'' if filled == 1 else 's'} missing artwork")
+        if replaced:
+            parts.append(f"{replaced} image{'' if replaced == 1 else 's'} that could be better")
+        if not parts:
+            return "This album's artwork can be updated."
+        return f"This album has {' and '.join(parts)}."
+
+    @property
     def caa_note(self) -> str | None:
         """What the archive has, said in one line — or None when it has not been
         asked, which is most albums.

--- a/templates/album.html
+++ b/templates/album.html
@@ -48,6 +48,22 @@
        album's state. #}
     <div id="album-update-{{ album.id }}"></div>
 
+    {# A pointer to the Artwork section when it has something to act on (#417).
+       The section is typically well below the fold, and until now the top of
+       the page said nothing about artwork at all.
+
+       Its OWN line rather than a clause of the update section above, because
+       the two answer to different things: that section is what MusicBrainz has
+       that your files don't, and it renders only when MusicBrainz has something
+       to say. Artwork can want attention when the tags are perfect — and the
+       better image is often one of the album's own files, which MusicBrainz has
+       no opinion about whatsoever.
+
+       Filled out of band by the artwork fetch below, which has already made the
+       one pass over the files this needs. Empty at page build, and empty again
+       whenever nothing would change. #}
+    <div id="album-artwork-note-{{ album.id }}"></div>
+
     {# The decisions the inbox would offer about this album, offered here (#150).
 
        The inbox is where the decisions are and the album page is where the

--- a/templates/partials/_album_update.html
+++ b/templates/partials/_album_update.html
@@ -67,7 +67,12 @@
                     hx-post="/retag/{{ album.id }}"
                     hx-swap="none" hx-disabled-elt="this" hx-indicator="#tagging-{{ album.id }}"
                     class="px-3 py-1.5 bg-mb-purple/10 hover:bg-mb-purple/20 text-mb-purple border border-mb-purple/30 rounded text-xs font-bold uppercase tracking-widest transition"
-                    title="Re-tag from MusicBrainz. Per-track embedded artwork is preserved.">
+                    {# What it does to artwork, kept true (#417). It read
+                       "Per-track embedded artwork is preserved", which was the
+                       whole story until a re-tag could also replace a folder
+                       cover and embed a larger image. Since #418 it is simpler
+                       than either: a re-tag never replaces an image you have. #}
+                    title="Re-tag from MusicBrainz. Your artwork is left alone — a track with none is given the album's cover.">
                 Re-tag from MB
             </button>
             {% endif %}

--- a/templates/partials/_artwork.html
+++ b/templates/partials/_artwork.html
@@ -181,3 +181,22 @@
 {% if caa_checked_at is defined and oob is defined %}
 {% with oob = true %}{% include 'partials/_checked_at.html' %}{% endwith %}
 {% endif %}
+
+{# …and the pointer to all this, up beside the album's other findings (#417).
+   Sent out of band from the fetch that already knows the answer, so the top of
+   the page costs no second pass over the files. Emitted even when there is
+   nothing to say — an empty div is what CLEARS the note after the artwork has
+   been updated. #}
+<div id="album-artwork-note-{{ album.id }}" hx-swap-oob="true">
+    {% if artwork.writes %}
+    <section class="border border-line rounded-lg px-4 py-3 flex items-center gap-3">
+        <span class="text-sm text-ink">{{ artwork.summary }}</span>
+        {# An in-page anchor, not an hx-get: the section is already on the page,
+           and this is navigation to it rather than a request for it. #}
+        <a href="#album-artwork"
+           class="text-2xs uppercase tracking-widest font-bold text-mb-purple hover:underline">
+            Artwork ↓
+        </a>
+    </section>
+    {% endif %}
+</div>

--- a/templates/partials/_mb_merged.html
+++ b/templates/partials/_mb_merged.html
@@ -81,7 +81,7 @@
                 hx-swap="none" hx-disabled-elt="this" hx-indicator="#tagging-{{ album.id }}"
                 class="px-2 py-1 rounded-md text-2xs font-bold uppercase tracking-widest
                        bg-white hover:bg-surface text-ink border border-line transition"
-                title="Re-tag from MusicBrainz, which writes the surviving release's id — and everything else it says — to this album's files. Per-track embedded artwork is preserved.">
+                title="Re-tag from MusicBrainz, which writes the surviving release's id — and everything else it says — to this album's files. Your artwork is left alone.">
             Point these files at it
         </button>
         {% endif %}

--- a/templates/partials/library_detail.html
+++ b/templates/partials/library_detail.html
@@ -175,7 +175,7 @@
                     hx-swap="none" hx-disabled-elt="this" hx-indicator="#tagging-{{ album.id }}"
                     class="mt-2 ml-1.5 px-2 py-1 rounded-md text-2xs font-bold uppercase tracking-widest
                            bg-white hover:bg-surface text-ink border border-line transition"
-                    title="Re-tag from MusicBrainz, which writes the MusicBrainz Album Id to the {{ album.partial_tag_count[1] - album.partial_tag_count[0] }} file(s) missing it. Per-track embedded artwork is preserved.">
+                    title="Re-tag from MusicBrainz, which writes the MusicBrainz Album Id to the {{ album.partial_tag_count[1] - album.partial_tag_count[0] }} file(s) missing it. Your artwork is left alone.">
                 Write it to those files
             </button>
             {% endif %}

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -8787,3 +8787,28 @@ def test_the_artwork_action_writes_artwork_and_not_tags(client, cfg):
 
     assert r.status_code == 200
     assert MP4(track)[ATOM_TITLE] == ["Left alone"]
+
+
+def test_the_artwork_note_points_at_the_section_when_there_is_something_to_do(client, cfg):
+    """The section is below the fold, and the top of the page said nothing about
+    artwork at all (#417)."""
+    d = _album_with_art(cfg, "Improvable", covers=[_png(1), None], folder=_png(2))
+
+    r = client.get(f"/album/{_id_for(cfg, d)}/artwork")
+
+    rendered = " ".join(r.text.split())
+    assert "missing artwork" in rendered
+    assert 'href="#album-artwork"' in rendered
+
+
+def test_the_artwork_note_is_cleared_when_nothing_would_change(client, cfg):
+    """Emitted empty rather than omitted: the out-of-band swap is what clears a
+    note left over from before the artwork was updated."""
+    same = _png(1)
+    d = _album_with_art(cfg, "Settled", covers=[same, same], folder=same)
+
+    r = client.get(f"/album/{_id_for(cfg, d)}/artwork")
+
+    rendered = " ".join(r.text.split())
+    assert 'id="album-artwork-note-' in rendered  # the wrapper is always sent
+    assert 'href="#album-artwork"' not in rendered  # …and is empty


### PR DESCRIPTION
The album page could describe an album's artwork in detail and say nothing about
it above the fold, where the reader actually is. The Artwork section is
typically a screenful or two down, and nothing pointed at it.

Now the top of the page carries one line — *"This album has 1 track missing
artwork."* — with an anchor down to the section.

## Its own line, not a clause of the update section

The obvious home was the box that already carries findings. That box is **what
MusicBrainz has that your files don't**, and it renders only when MusicBrainz
has something to say.

Artwork can want attention when the tags are perfect, and the better image is
often one of the album's **own files**, which MusicBrainz has no opinion about
whatsoever. Putting the note there would have made it appear and disappear for
reasons unrelated to itself. It sits directly below that section, so it reads as
part of the same region without inheriting its conditions.

## It costs nothing

Sent **out of band by the artwork fetch**, which has already made the one pass
over the files this needs — no second read, and no change to `/compare`.

Emitted even when there is nothing to say: an empty div is what **clears** the
note once the artwork has been updated, which is why the wrapper is always
present and only its contents are conditional. There is a test for the empty
case, and it is the one the mutation check turns red.

## The tooltip was worse than the issue said

**Three** buttons claimed *"Per-track embedded artwork is preserved"* — the
update section, the merged-release card, and the partial-tag button in the
panel. That was the whole story until a re-tag could replace a folder cover and
embed a larger image, and since #418 it is both wrong and needlessly
complicated. They now say what is true: your artwork is left alone, and a track
with none is given the album's cover.

## Testing

`make check` green (1774 passed). Verified in demo mode — the note renders under
the update section with its anchor, on the album with a gap.

Fixes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
