### PR TITLE
Keep the backup you are taking now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **The artwork change you just made is the one that can be undone.** A backup
+  taken as an image was replaced could be evicted by the store's size cap in the
+  same breath — leaving the newest change the only unreversible one, and, for a
+  folder cover, overwriting the original on the strength of a backup that was
+  already gone. The image being kept now is retained ahead of older history, and
+  if it genuinely cannot fit, the cover is left alone (#427).
+
 - **The Artwork section shows what a re-tag would put there**, beside what is
   there now and under a heading that says which is which — where it previously
   asserted "replaced by…" in a way that read equally as something that had

--- a/src/harmonist/artwork_store.py
+++ b/src/harmonist/artwork_store.py
@@ -100,6 +100,11 @@ def keep(data: bytes, *, mime: str | None = None) -> str | None:
     refusing it because the undo store is full would be a worse failure than
     losing the undo. Returns None so the caller can record honestly that no
     copy was kept.
+
+    **A digest means the image is still there** (#427). Callers treat one as
+    permission to destroy the original — `tagger._promote_album_image` overwrites
+    a folder cover on the strength of it — so a key for an image the sweep at the
+    end of this call already deleted is not a weaker promise, it is a false one.
     """
     root = _root
     if root is None:
@@ -127,7 +132,19 @@ def keep(data: bytes, *, mime: str | None = None) -> str | None:
         log.exception("could not keep artwork %s — the change will not be undoable", key[:12])
         return None
     audit.record("artwork.keep", digest=key, bytes=len(data))
-    _evict_if_over_cap()
+    # `pending`, because the tagging that is replacing this image has not
+    # recorded itself yet: protection is derived from those records, so for the
+    # length of this call the newest change is the one image nothing protects
+    # (#427). Without saying so here, eviction spends the overage on it first
+    # and hands back a key to a file it has just deleted.
+    _evict_if_over_cap(pending=key)
+    if path_for(key) is None:
+        log.warning(
+            "artwork %s could not be retained under the store's cap — the change "
+            "it was backing up will not be undoable",
+            key[:12],
+        )
+        return None
     return key
 
 
@@ -220,7 +237,7 @@ def protected_digests() -> frozenset[str]:
     return frozenset(out)
 
 
-def _evict_if_over_cap() -> None:
+def _evict_if_over_cap(*, pending: str | None = None) -> None:
     """Drop images until the store is under cap, protected ones last.
 
     Two passes, and the order is the whole point (#408). The first spends the
@@ -234,6 +251,11 @@ def _evict_if_over_cap() -> None:
     Within each pass, least recently *referenced* rather than stored: `keep`
     touches an image it already holds, so an image shared by several albums is
     as fresh as its newest use.
+
+    `pending` is the backup being taken right now, which no record protects yet
+    because the tagging that replaces it has not been written (#427). It joins
+    the protected pass as its newest member, so the documented policy — oldest
+    change first — applies to it rather than around it.
     """
     root = _root
     if root is None or not root.is_dir():
@@ -248,6 +270,8 @@ def _evict_if_over_cap() -> None:
         return
 
     protected = protected_digests()
+    if pending is not None:
+        protected |= {pending}
     by_age = sorted(entries, key=lambda e: e[1].st_mtime)
     passes = (
         [e for e in by_age if e[0].stem not in protected],

--- a/test/test_artwork_store.py
+++ b/test/test_artwork_store.py
@@ -137,12 +137,14 @@ def test_eviction_is_audited_because_it_deletes_the_last_copy(tmp_path):
 
 def test_a_zero_cap_keeps_nothing():
     """A legitimate choice on a volume with no room: artwork replacement stops
-    being reversible, and nothing accumulates."""
+    being reversible, and nothing accumulates. The caller is told so rather
+    than handed a digest for a file the cap evicted on its way out (#427) —
+    that digest is what `_promote_album_image` reads as permission to destroy
+    the original."""
     artwork_store.configure(artwork_store._root, max_bytes=0)
-    key = artwork_store.keep(JPEG, mime="image/jpeg")
 
-    assert key is not None  # the write happened...
-    assert artwork_store.path_for(key) is None  # ...and was immediately evicted
+    assert artwork_store.keep(JPEG, mime="image/jpeg") is None
+    assert artwork_store.path_for(artwork_store.digest(JPEG)) is None
 
 
 @pytest.mark.parametrize(
@@ -265,7 +267,10 @@ class TestEviction:
         # A cap that forces exactly one of the two out.
         artwork_store.configure(artwork_store._root, max_bytes=len(protected) + 100)
 
-        artwork_store.keep(_image(3))  # any keep triggers the sweep
+        # Swept directly rather than by keeping a third image, because the image
+        # a `keep` is in the middle of storing is protected in its own right
+        # (#427) and would be a third competitor rather than a trigger.
+        artwork_store._evict_if_over_cap()
 
         assert artwork_store.path_for(artwork_store.digest(protected)) is not None
         assert artwork_store.path_for(artwork_store.digest(old_unprotected)) is None
@@ -298,3 +303,29 @@ class TestEviction:
         artwork_store.keep(new)
 
         assert artwork_store.path_for(artwork_store.digest(old)) is None
+
+    def test_the_backup_being_taken_now_is_not_the_first_thing_evicted(self):
+        """#427. `keep` runs BEFORE the tagger records the replacement, so the
+        image it just wrote is the only unprotected candidate when older
+        protected ones already fill the cap — and eviction would spend the
+        overage on it. The newest change is the one most likely to be undone;
+        it must outlive older protected history, not be sacrificed for it."""
+        older, taking_now = _image(1), _image(2)
+        artwork_store.keep(older)
+        _replaced("album-a", older)
+        artwork_store.configure(artwork_store._root, max_bytes=len(taking_now) + 100)
+
+        key = artwork_store.keep(taking_now)
+
+        assert key is not None
+        assert artwork_store.path_for(key) is not None, "the new backup was evicted"
+        assert artwork_store.path_for(artwork_store.digest(older)) is None
+
+    def test_a_backup_that_could_not_be_retained_is_reported_as_not_kept(self):
+        """A digest is the caller's licence to overwrite the original (see
+        `tagger._promote_album_image`). If the cap cannot hold the image even
+        after everything else has gone, saying so is the difference between a
+        change that is merely unundoable and one whose original is destroyed."""
+        artwork_store.configure(artwork_store._root, max_bytes=10)
+
+        assert artwork_store.keep(_image(1)) is None

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -2251,6 +2251,25 @@ def test_the_replaced_folder_cover_can_be_undone(album_with_tracks, tmp_path):
     assert kept.read_bytes() == small
 
 
+def test_a_cover_is_not_replaced_when_its_backup_could_not_be_retained(album_with_tracks, tmp_path):
+    """A digest from `keep` is what licenses the overwrite, so a digest for an
+    image the store's cap evicted on the way out would make the newest artwork
+    change the one irreversible one (#427). A cap too small to hold the cover
+    means the promotion does not happen at all."""
+    from harmonist import artwork_store
+
+    artwork_store.configure(tmp_path / "artwork", max_bytes=10)
+    album_dir = album_with_tracks(1)
+    _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(1000, 1000))
+    cover = tmp_path / "cover.jpg"
+    small = _sized_jpeg(400, 400)
+    cover.write_bytes(small)
+
+    tagger.update_artwork(album_dir, _single_track_release(), cover)
+
+    assert cover.read_bytes() == small
+
+
 def test_a_larger_folder_cover_is_still_embedded(album_with_tracks, tmp_path):
     """The other direction is unchanged: the cover wins when it is the better
     image, which is what a re-tag has always done."""


### PR DESCRIPTION
`artwork_store.keep` writes the image, then sweeps the store for its size cap — but the tagging that replaces that image has not recorded itself yet, and retention is *derived from those records*. So for the length of the call the newest backup is the one image nothing protects, and when older protected history already fills the cap it is the first thing evicted. `keep` then returned its digest anyway.

That inverts the documented policy (oldest change first) exactly when the cap bites, and `tagger._promote_album_image` reads a digest as permission to overwrite a folder cover: the newest artwork change could become the only irreversible one, its original destroyed.

## What changed

- the sweep is told which image is being kept right now and treats it as the newest member of the protected set, so the cap policy applies *to* it rather than around it;
- `keep` verifies the image survived the sweep — a digest now means the image is there, which is what its callers have always assumed. A cap too small to hold it returns `None` and warns, and the folder cover is left alone.

## Tests

`test_artwork_store.py` gains the reproduction (a 350-byte cap with older protected history) and the "could not be retained" contract; `test_tagger.py` covers the promotion being refused end to end. All four go red with the fix reverted. `test_a_zero_cap_keeps_nothing` now asserts the new contract — a zero cap reports honestly that nothing was kept.

Fixes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH