### PR TITLE
Stop reading a shared Bandcamp slug as a shared release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **A purchase is no longer skipped because a different artist used the same
+  album address.** Bandcamp addresses like `/album/home` are unique to one page,
+  not to the world; Harmonist treated them as an identity, so owning Zero 7's
+  *Home* could quietly file The Gathering's away as already downloaded, or hand
+  an unlinked album's store URL to the wrong purchase. Cross-listings — one
+  release sold from both a label page and an artist page — are now confirmed
+  against MusicBrainz instead of assumed, and anything unconfirmed becomes a
+  potential download for you to decide rather than a decision made for you
+  (#425).
+
 - **A download that fits two MusicBrainz editions equally is no longer tagged as
   whichever one came back first.** Where a store URL resolves to several
   releases with the same tracklist, nothing is written: Activity says several

--- a/docs/design.md
+++ b/docs/design.md
@@ -314,14 +314,34 @@ differently from new ones:
   for any library already on disk, *every* purchase is ignored.
 
 **The slug.** All matching below the exact-URL rung is on the **release slug** —
-the `/album/<slug>` (or `/track/<slug>`) path segment, subdomain stripped.
-Bandcamp routinely cross-lists one release under several subdomains (a label page
-**and** the artist's own page), so an on-disk `store_url` of
-`thelabel.bandcamp.com/album/home` (from MusicBrainz's relationship) and a
-purchase at `theartist.bandcamp.com/album/home` share the slug `album/home`. The
-slug is Bandcamp's **stable per-release handle** — minted once, immutable even as
-the artist renames the band or re-letters the title — which is what makes it a
-safe key. The item-type segment is kept so `album`/`track` can't collide.
+the `/album/<slug>` (or `/track/<slug>`) path segment. Within one Bandcamp page
+the slug is that page's **stable per-release handle** — minted once, immutable
+even as the artist renames the band or re-letters the title — which is what makes
+it a safe key there. The item-type segment is kept so `album`/`track` can't
+collide.
+
+**Across pages it is not an identity** (#425). Nothing stops two artists reaching
+for the same title: [Zero 7's *Home*](https://zero7.bandcamp.com/album/home) and
+[The Gathering's *Home*](https://thegathering.bandcamp.com/album/home) are
+different records sharing `/album/home`, and treating the slug as global made
+owning one skip the other's purchase — added to `ignores.txt`, never downloaded,
+nothing said — or hand an unlinked album's `store_url` to the wrong purchase.
+
+Cross-listings are real all the same: Bandcamp routinely sells one release from a
+label page **and** the artist's own page, and dropping the match would re-download
+albums already on disk. So a same-slug album on a *different* host is a candidate,
+**confirmed by MusicBrainz rather than assumed**: `sync_item` asks whether the
+album's release (`mb_release_id`) carries the purchase's URL among its `url-rels`
+— the same authority §2.6 links on, and unlike a slug it can tell two artists
+apart. Confirmed → link/dedup as before. Not confirmed (no release, a lookup that
+failed, or a release that doesn't know the URL) → **neither answer is taken**: the
+purchase is not downloaded, `ignores.txt` is left alone, and it surfaces as a
+potential download for the user to decide. One MB call per unconfirmed candidate,
+cached, and paid at most once per purchase — a confirmed one ends up in
+`ignores.txt`, which short-circuits the check before the next sync reaches it.
+
+The backfill below is looser by design (its phase 2 links on title alone across a
+URL mismatch, and says so with a warning); this rule is about `sync_item`.
 
 #### The backfill: a two-phase matcher
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -146,6 +146,23 @@ it by artist and title, or **Don't download** to set it aside.
 That last one isn't a one-way door: Settings lists everything under **Won't
 download** with a **Restore** button beside each.
 
+**A purchase that shares its web address with an album you own.** Bandcamp album
+addresses are unique to a page, not to the world — Zero 7's *Home* and The
+Gathering's *Home* both live at `/album/home` — so a purchase whose address looks
+like one you already have, but on a different artist's page, is neither
+downloaded nor set aside: it surfaces as a potential download, and Activity says
+why. If MusicBrainz knows the two addresses are the same release (a label page
+and an artist page selling one record), it is linked to the album you own as
+before, with nothing to decide.
+
+Versions before 1.16 could skip such a purchase outright, recording it in
+`ignores.txt` in your config directory as though it had been downloaded. If an
+album you bought never arrived, open that file and look for its line — each is an
+id followed by `#` and the purchase's name. Delete **that one line**, save, and
+run Sync; the purchase is considered again. Don't empty the file: everything else
+in it is the record of what you already have, and clearing it re-downloads your
+collection.
+
 **When a purchase can't be found at all.** A *full* sync that pages your whole
 collection and still can't match an album has learned something real, so it says
 so: the album is demoted to Needs MBID with a read-only "no purchase found" note,

--- a/src/harmonist/bandcamp_hook.py
+++ b/src/harmonist/bandcamp_hook.py
@@ -32,12 +32,15 @@ from . import (
     formats,
     id_registry,
     library_index,
+    mb_cache,
+    mb_lookup,
     pending_downloads,
 )
 from . import sidecar as sidecar_mod
 from .models import BandcampInfo, Sidecar, is_bandcamp_url, title_words, titles_match
 from .pending_downloads import PendingPurchase
 from .url_recovery import album_slug as album_slug  # noqa: PLC0414 (explicit re-export)
+from .url_recovery import store_host
 
 log = logging.getLogger(__name__)
 
@@ -770,6 +773,64 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
                 e,
             )
 
+    def _copies_of_release(
+        self, url: str
+    ) -> tuple[list[library_index.SlugCopy], list[library_index.SlugCopy]]:
+        """Split the albums sharing `url`'s slug into `(this release, lookalikes)`.
+
+        A Bandcamp slug is minted per release *within one page*, so on the same
+        host a shared slug IS shared identity. Across hosts it is not, and it
+        used to be treated as though it were: Zero 7's `/album/home` and The
+        Gathering's `/album/home` are different records by different artists, and
+        owning one made Harmonist skip the other's purchase — never downloading
+        an album the user had paid for, and saying nothing (#425).
+
+        Cross-listings are real, though — one release under both a label page and
+        an artist page is common enough that dropping the match would re-download
+        dozens of albums — so a cross-host resemblance is *confirmed*, not
+        guessed: MusicBrainz has to say the album's release carries the
+        purchase's URL too. That is the same authority `_link_unmatched_by_
+        release_urls` already links on, and unlike a slug it distinguishes two
+        artists who chose the same title.
+
+        One MB call per unconfirmed cross-host candidate, served from the cache
+        when it is fresh, and paid at most once per purchase: a confirmed copy
+        ends with the purchase in `ignores.txt`, which short-circuits this
+        before the next sync gets here.
+        """
+        this_release: list[library_index.SlugCopy] = []
+        lookalikes: list[library_index.SlugCopy] = []
+        for copy in library_index.slug_copies(url):
+            if copy.same_host or self._is_cross_listing(copy, url):
+                this_release.append(copy)
+            else:
+                lookalikes.append(copy)
+        return this_release, lookalikes
+
+    def _is_cross_listing(self, copy: library_index.SlugCopy, url: str) -> bool:
+        """Whether MusicBrainz says `copy`'s release is also sold at `url`.
+
+        Compared as host AND slug, because the slug alone is what could not be
+        trusted in the first place. An album with no release, or a lookup that
+        fails, is not confirmed — the honest answer when the authority cannot be
+        reached is "I don't know", which sends the purchase to the user rather
+        than acting on a resemblance.
+        """
+        if copy.mb_release_id is None:
+            return False
+        try:
+            known = mb_cache.fetch_release_urls(copy.mb_release_id)
+        except mb_lookup.MBError as e:
+            log.warning(
+                "could not ask MusicBrainz whether %s is also sold at %s: %s",
+                copy.mb_release_id,
+                url,
+                e,
+            )
+            return False
+        slug, host = album_slug(url), store_host(url)
+        return any(album_slug(u) == slug and store_host(u) == host for u in known)
+
     def sync_item(self, item: Any, encoding: str | None = None) -> bool:
         if self._progress_callback:
             label = f"{getattr(item, 'band_name', '?')} / {getattr(item, 'item_title', '?')}"
@@ -782,14 +843,24 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
         # the in-memory library_index (built from the scan), so ZERO disk reads
         # here even on a fully-paged collection.
         url = construct_bandcamp_url(item)
+        # Albums that share this purchase's slug, split into the ones that really
+        # are its release and the ones that only look like it (#425). Computed
+        # once — both the link short-circuit and the dedup backstop below ask the
+        # same question, and the answer can cost a MusicBrainz call.
+        this_release: list[library_index.SlugCopy] = []
+        lookalikes: list[library_index.SlugCopy] = []
         if url:
-            # Exact-URL match first; fall back to a subdomain-agnostic slug match
-            # (same release cross-listed under a different subdomain). The slug
-            # fallback adopts the item's URL as the new store_url.
+            # Exact-URL match first; fall back to a slug match on another
+            # subdomain, which is the same release only where MusicBrainz
+            # confirms the cross-listing. The fallback adopts the item's URL as
+            # the new store_url.
             existing_dir = library_index.dir_for_url(url)
             by_slug = False
             if existing_dir is None:
-                existing_dir = library_index.unlinked_slug_match(url)
+                this_release, lookalikes = self._copies_of_release(url)
+                unlinked = [c.album_dir for c in this_release if not c.linked]
+                # 0 = nothing to link; 2+ = which one is the user's call.
+                existing_dir = unlinked[0] if len(unlinked) == 1 else None
                 by_slug = existing_dir is not None
             if existing_dir is not None:
                 # This runs EVERY sync for every on-disk album whose purchase is
@@ -844,24 +915,21 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
                 return False  # didn't download (already on disk)
 
         # Dedup backstop (BOTH modes): this item wasn't matched by the narrow
-        # short-circuit (exact-URL, or unlinked slug), but the release may still be
-        # on disk under a different subdomain (label vs artist page, same slug) or
-        # linked to a different purchase-id (a cross-listing). slug_copies matches
-        # subdomain-insensitively and inclusive of linked albums (in-memory, no
-        # disk); if found, do NOT re-download — ignore so it doesn't churn.
-        if url and not self.ignores.is_ignored(item):
-            on_disk = library_index.slug_copies(url)
-            if on_disk:
-                for path, linked in on_disk:
-                    log.info(
-                        "already on disk: item_id=%s url=%s at %s (linked=%s) — skipping download",
-                        getattr(item, "item_id", "?"),
-                        url,
-                        path,
-                        linked,
-                    )
-                self.ignores.add(item)
-                return False
+        # short-circuit (exact-URL, or a unique unlinked copy), but the release may
+        # still be on disk under a different subdomain (label vs artist page, same
+        # slug, confirmed on MusicBrainz) or linked to a different purchase-id (a
+        # cross-listing). If it is, do NOT re-download — ignore so it doesn't churn.
+        if url and this_release and not self.ignores.is_ignored(item):
+            for copy in this_release:
+                log.info(
+                    "already on disk: item_id=%s url=%s at %s (linked=%s) — skipping download",
+                    getattr(item, "item_id", "?"),
+                    url,
+                    copy.album_dir,
+                    copy.linked,
+                )
+            self.ignores.add(item)
+            return False
 
         item_id_int = int(getattr(item, "item_id", 0) or 0)
         approved = pending_downloads.is_approved(item_id_int)
@@ -877,6 +945,35 @@ class HarmonistSyncer(_BCSyncer):  # type: ignore[misc]
         # subdomain + title). If it links, the album leaves Needs Link for the
         # Library and this purchase is done — no download, no card.
         if self._link_only and not approved and url and self._adopt_link(item, url):
+            return False
+
+        # Something on disk shares this purchase's slug on another Bandcamp page,
+        # and MusicBrainz did not confirm the two are one release (#425). Both
+        # automatic answers are wrong here: downloading risks a duplicate of an
+        # album already owned, and skipping is how an unrelated purchase went
+        # missing without a word. So neither — ignores.txt is left alone (a
+        # decision recorded there would be permanent and invisible) and the
+        # purchase goes to the inbox as a potential download, where Download /
+        # Match to an existing album / Don't download are all one press away.
+        if url and lookalikes and not approved and not self.ignores.is_ignored(item):
+            log.warning(
+                "%s — %s (purchase %s) shares a Bandcamp slug with %s, which is on a "
+                "different Bandcamp page and is not the same MusicBrainz release: "
+                "not downloading it and not skipping it — decide from the inbox",
+                getattr(item, "band_name", "?"),
+                getattr(item, "item_title", "?"),
+                getattr(item, "item_id", "?"),
+                ", ".join(str(c.album_dir.name) for c in lookalikes),
+            )
+            self._pending_this_run.append(
+                PendingPurchase(
+                    item_id=item_id_int,
+                    band=str(getattr(item, "band_name", "") or "?"),
+                    title=str(getattr(item, "item_title", "") or "?"),
+                    url=url,
+                    fmt=encoding or str(getattr(self, "media_format", "?")),
+                )
+            )
             return False
 
         if self._link_only and not approved:

--- a/src/harmonist/library_index.py
+++ b/src/harmonist/library_index.py
@@ -20,16 +20,33 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 from .models import Album, Sidecar
-from .url_recovery import album_slug
+from .url_recovery import album_slug, store_host
 
 _lock = threading.Lock()
 _sidecars: dict[Path, Sidecar] = {}
 _by_item_id: dict[int, Path] = {}
 _by_url: dict[str, Path] = {}
 _by_slug: dict[str, set[Path]] = {}
+
+
+@dataclass(frozen=True)
+class SlugCopy:
+    """An on-disk album sharing a purchase URL's release slug, with what the
+    index knows about how far that resemblance goes."""
+
+    album_dir: Path
+    #: Already tied to a Bandcamp purchase id.
+    linked: bool
+    #: On the same Bandcamp host as the URL asked about — the case where the
+    #: shared slug IS shared identity.
+    same_host: bool
+    #: The release the album is tagged as, when it has one. What a cross-host
+    #: resemblance can be confirmed (or refused) against.
+    mb_release_id: str | None
 
 
 def _index(album_dir: Path, sc: Sidecar) -> None:
@@ -118,23 +135,29 @@ def dir_for_url(url: str) -> Path | None:
         return _by_url.get(url)
 
 
-def slug_copies(url: str) -> list[tuple[Path, bool]]:
-    """Every on-disk album sharing `url`'s release slug, as ``(album_dir, linked)``
-    — subdomain-insensitive, inclusive of linked albums (the dedup backstop)."""
+def slug_copies(url: str) -> list[SlugCopy]:
+    """Every on-disk album whose store URL carries `url`'s release slug.
+
+    Facts, not a verdict (#425). A shared slug on the SAME Bandcamp host is the
+    same release — that is what a slug is. On a different host it is only a
+    lookalike until something authoritative says otherwise, and this index holds
+    nothing that could say so, so it reports the host and the release id and
+    leaves the judgement to the caller (`bandcamp_hook` makes it).
+    """
     slug = album_slug(url)
     if slug is None:
         return []
+    host = store_host(url)
     with _lock:
-        out: list[tuple[Path, bool]] = []
+        out: list[SlugCopy] = []
         for d in _by_slug.get(slug, set()):
             sc = _sidecars.get(d)
-            linked = bool(sc and sc.bandcamp and sc.bandcamp.item_id is not None)
-            out.append((d, linked))
+            out.append(
+                SlugCopy(
+                    album_dir=d,
+                    linked=bool(sc and sc.bandcamp and sc.bandcamp.item_id is not None),
+                    same_host=bool(host and sc and store_host(sc.store_url) == host),
+                    mb_release_id=sc.mb_release_id if sc else None,
+                )
+            )
         return out
-
-
-def unlinked_slug_match(url: str) -> Path | None:
-    """The single UNLINKED album sharing `url`'s slug, or None (0 or 2+ → can't
-    pick) — the link target for a cross-listing whose id we don't yet have."""
-    matches = [d for d, linked in slug_copies(url) if not linked]
-    return matches[0] if len(matches) == 1 else None

--- a/src/harmonist/url_recovery.py
+++ b/src/harmonist/url_recovery.py
@@ -60,6 +60,27 @@ def album_slug(url: str | None) -> str | None:
     return None
 
 
+def store_host(url: str | None) -> str | None:
+    """The Bandcamp host a URL is on, lowercased, or None if it has none.
+
+    The other half of `album_slug` (#425). A slug is Bandcamp's per-release
+    handle *within one page*, not across the site: different artists reach for
+    the same album title, so `/album/home` belongs to Zero 7 on one host and The
+    Gathering on another. Comparing the host as well is what keeps two
+    unrelated releases from being read as one, and it is the whole of the
+    "scoped" in exact/scoped/unique matching for store URLs.
+
+    `www.` is stripped so one host doesn't read as two.
+    """
+    if not url:
+        return None
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return None
+    return host.removeprefix("www.") or None
+
+
 # Bandcamp embeds the link as prose in the comment tag, e.g.
 # "Visit https://artist.bandcamp.com/album/x" — so we extract the URL rather
 # than treating the whole comment as one.

--- a/test/test_bandcamp_hook.py
+++ b/test/test_bandcamp_hook.py
@@ -374,7 +374,10 @@ def test_sync_item_skips_download_when_release_on_disk_by_slug(tmp_path, monkeyp
     """Dedup backstop: a release already on disk under a DIFFERENT subdomain (same
     slug) and linked to a DIFFERENT purchase-id must NOT re-download — by_url is
     exact and by_slug skips linked albums, so only the slug-inclusive check sees it.
-    This is the fix for the ~72 spurious re-downloads on a full-library sync."""
+    This is the fix for the ~72 spurious re-downloads on a full-library sync.
+
+    The cross-listing is confirmed rather than assumed (#425): MusicBrainz has
+    the label page's URL on the same release the album is tagged as."""
     album = tmp_path / "variant" / "sequential sleep"
     album.mkdir(parents=True)
     sc.write(
@@ -384,6 +387,13 @@ def test_sync_item_skips_download_when_release_on_disk_by_slug(tmp_path, monkeyp
             mb_release_id="rel-1",
             bandcamp=BandcampInfo(item_id=999),  # linked to a DIFFERENT purchase
         ),
+    )
+    monkeypatch.setattr(
+        "harmonist.mb_cache.fetch_release_urls",
+        lambda mbid: [
+            "https://variant.bandcamp.com/album/sequential-sleep",
+            "https://echospace313.bandcamp.com/album/sequential-sleep",
+        ],
     )
     s = _bare_syncer()
     s.local_media = MagicMock()
@@ -407,6 +417,161 @@ def test_sync_item_skips_download_when_release_on_disk_by_slug(tmp_path, monkeyp
     assert s.sync_item(item) is False
     assert downloaded == []  # did NOT re-download the existing release
     assert 4032507453 in added  # ignored so it doesn't churn every sync
+
+
+# ---------- a shared slug across two Bandcamp pages (#425) ----------
+
+
+def _home_syncer(tmp_path, monkeypatch, *, downloaded: list[int]) -> HarmonistSyncer:
+    s = _bare_syncer()
+    s.local_media = MagicMock()
+    s.local_media.media_dir = str(tmp_path)
+    s.ignores.is_ignored = lambda item: False
+    s.ignores.add = lambda item: ignored.append(int(getattr(item, "item_id", 0)))
+
+    def fake_download(self, item, encoding=None):
+        downloaded.append(int(getattr(item, "item_id", 0)))
+        return True
+
+    monkeypatch.setattr("harmonist.bandcamp_hook._BCSyncer.sync_item", fake_download)
+    return s
+
+
+def _gathering_purchase() -> _StubItem:
+    """The Gathering's Home — a real release that shares `/album/home` with
+    Zero 7's, on its own Bandcamp page."""
+    return _StubItem(
+        item_id=200,
+        band_name="The Gathering",
+        item_title="Home",
+        url_hints={"subdomain": "thegathering", "slug": "home"},
+    )
+
+
+ignored: list[int] = []
+
+
+@pytest.fixture(autouse=True)
+def _reset_ignored():
+    ignored.clear()
+    yield
+    ignored.clear()
+
+
+def test_another_artists_album_with_the_same_slug_is_not_skipped(tmp_path, monkeypatch):
+    """#425. Owning Zero 7's Home must not make The Gathering's Home vanish: the
+    slug is shared, the release is not, and the purchase used to be added to
+    ignores.txt — never downloaded, and nothing on screen to say why."""
+    owned = tmp_path / "Zero 7" / "Home"
+    owned.mkdir(parents=True)
+    sc.write(
+        owned,
+        Sidecar(
+            store_url="https://zero7.bandcamp.com/album/home",
+            mb_release_id="rel-zero7",
+            bandcamp=BandcampInfo(item_id=100),
+        ),
+    )
+    monkeypatch.setattr(
+        "harmonist.mb_cache.fetch_release_urls",
+        lambda mbid: ["https://zero7.bandcamp.com/album/home"],
+    )
+    downloaded: list[int] = []
+    s = _home_syncer(tmp_path, monkeypatch, downloaded=downloaded)
+
+    assert s.sync_item(_gathering_purchase()) is False
+
+    # Not skipped for good: no ignores entry, and no download either — the
+    # purchase is a decision for the user, in the inbox.
+    assert ignored == []
+    assert downloaded == []
+    assert [(p.item_id, p.title) for p in s._pending_this_run] == [(200, "Home")]
+
+
+def test_another_artists_album_with_the_same_slug_is_not_relinked(tmp_path, monkeypatch):
+    """The other half of #425: an UNLINKED album with the shared slug used to be
+    adopted by the unrelated purchase, overwriting the store URL that said which
+    release it actually is."""
+    owned = tmp_path / "Zero 7" / "Home"
+    owned.mkdir(parents=True)
+    sc.write(
+        owned,
+        Sidecar(store_url="https://zero7.bandcamp.com/album/home", mb_release_id="rel-zero7"),
+    )
+    monkeypatch.setattr(
+        "harmonist.mb_cache.fetch_release_urls",
+        lambda mbid: ["https://zero7.bandcamp.com/album/home"],
+    )
+    downloaded: list[int] = []
+    s = _home_syncer(tmp_path, monkeypatch, downloaded=downloaded)
+
+    assert s.sync_item(_gathering_purchase()) is False
+
+    kept = sc.read(owned)
+    assert kept.store_url == "https://zero7.bandcamp.com/album/home"
+    assert kept.bandcamp is None
+    assert downloaded == []
+
+
+def test_a_cross_listing_musicbrainz_confirms_still_links_the_unlinked_album(tmp_path, monkeypatch):
+    """And the case the slug match exists for: the same release on a label page
+    and an artist page. MusicBrainz carries both URLs on the one release, so the
+    purchase links the album it already has rather than downloading a second
+    copy."""
+    album = tmp_path / "variant" / "sequential sleep"
+    album.mkdir(parents=True)
+    sc.write(
+        album,
+        Sidecar(
+            store_url="https://variant.bandcamp.com/album/sequential-sleep",
+            mb_release_id="rel-1",
+        ),
+    )
+    monkeypatch.setattr(
+        "harmonist.mb_cache.fetch_release_urls",
+        lambda mbid: [
+            "https://variant.bandcamp.com/album/sequential-sleep",
+            "https://echospace313.bandcamp.com/album/sequential-sleep",
+        ],
+    )
+    downloaded: list[int] = []
+    s = _home_syncer(tmp_path, monkeypatch, downloaded=downloaded)
+    item = _StubItem(
+        item_id=4032507453,
+        band_name="echospace [detroit]",
+        item_title="Sequential Sleep",
+        url_hints={"subdomain": "echospace313", "slug": "sequential-sleep"},
+    )
+
+    assert s.sync_item(item) is False
+
+    assert sc.read(album).bandcamp.item_id == 4032507453
+    assert downloaded == []
+    assert s._pending_this_run == []
+
+
+def test_an_unconfirmable_lookalike_is_not_asked_about_twice(tmp_path, monkeypatch):
+    """Idempotent: the purchase stays a potential download run after run rather
+    than accumulating decisions. Nothing is written on either pass."""
+    owned = tmp_path / "Zero 7" / "Home"
+    owned.mkdir(parents=True)
+    sc.write(
+        owned,
+        Sidecar(store_url="https://zero7.bandcamp.com/album/home", mb_release_id="rel-zero7"),
+    )
+    monkeypatch.setattr("harmonist.mb_cache.fetch_release_urls", lambda mbid: [])
+    downloaded: list[int] = []
+    s = _home_syncer(tmp_path, monkeypatch, downloaded=downloaded)
+
+    assert s.sync_item(_gathering_purchase()) is False
+    first = sc.read(owned)
+    s._pending_this_run.clear()
+    assert s.sync_item(_gathering_purchase()) is False
+
+    assert sc.read(owned) == first
+    assert ignored == []
+    assert downloaded == []
+    assert len(s._pending_this_run) == 1
 
 
 def test_link_only_does_not_advance_checkpoint(monkeypatch):
@@ -858,7 +1023,11 @@ def test_sync_item_short_circuit_records_transition_to_activity(monkeypatch, tmp
 
 def test_sync_item_slug_fallback_links_and_adopts_url(monkeypatch, tmp_path):
     """Exact URL misses (different subdomain) but the slug matches → link the
-    item_id WITHOUT downloading, and adopt the item's URL as store_url."""
+    item_id WITHOUT downloading, and adopt the item's URL as store_url.
+
+    Across hosts the slug is corroborated rather than trusted (#425): the album's
+    MusicBrainz release carries the purchase's URL as well as the one it was
+    tagged with, which is what makes the two the same record."""
     existing_dir = tmp_path / "Brock Van Wey" / "Home"
     existing_dir.mkdir(parents=True)
     sc.write(
@@ -869,6 +1038,13 @@ def test_sync_item_slug_fallback_links_and_adopts_url(monkeypatch, tmp_path):
         ),
     )
 
+    monkeypatch.setattr(
+        "harmonist.mb_cache.fetch_release_urls",
+        lambda mbid: [
+            "https://echospacedetroit.bandcamp.com/album/home",
+            "https://brockvanwey.bandcamp.com/album/home",
+        ],
+    )
     s = _bare_syncer()
     s.local_media.media_dir = str(tmp_path)
     s.ignores.is_ignored = MagicMock(return_value=False)
@@ -908,6 +1084,13 @@ def test_sync_item_ambiguous_slug_skips_download_no_dupe(monkeypatch, tmp_path):
             ),
         )
 
+    # Both albums really are this release — MusicBrainz has the purchase's URL
+    # on each of them — so the ambiguity is which copy to LINK, not whether the
+    # release is on disk (#425).
+    monkeypatch.setattr(
+        "harmonist.mb_cache.fetch_release_urls",
+        lambda mbid: ["https://artist.bandcamp.com/album/home"],
+    )
     s = _bare_syncer()
     s.local_media.media_dir = str(tmp_path)
     s.ignores.is_ignored = MagicMock(return_value=False)

--- a/test/test_library_index.py
+++ b/test/test_library_index.py
@@ -38,9 +38,15 @@ def test_reset_from_builds_all_indexes():
     )
     assert library_index.item_ids() == {111}
     assert library_index.dir_for_url("https://x.bandcamp.com/album/a") == Path("/m/A")
-    # slug match is subdomain-insensitive:
-    assert library_index.slug_copies("https://other.bandcamp.com/album/a") == [(Path("/m/A"), True)]
-    assert library_index.unlinked_slug_match("https://z.bandcamp.com/album/b") == Path("/m/B")
+    # The slug index reaches across subdomains, and says which side of that line
+    # each copy is on — a same-host copy is the release, a cross-host one is a
+    # candidate its caller has to confirm (#425).
+    same_host = library_index.slug_copies("https://x.bandcamp.com/album/a")
+    assert [(c.album_dir, c.linked, c.same_host) for c in same_host] == [(Path("/m/A"), True, True)]
+    elsewhere = library_index.slug_copies("https://other.bandcamp.com/album/a")
+    assert [(c.album_dir, c.same_host, c.mb_release_id) for c in elsewhere] == [
+        (Path("/m/A"), False, "rel")
+    ]
 
 
 def test_upsert_then_remove_maintain_indexes():
@@ -55,17 +61,31 @@ def test_upsert_then_remove_maintain_indexes():
     assert library_index.dir_for_url("https://x.bandcamp.com/album/a") is None
 
 
-def test_slug_copies_carries_linked_flag_and_ambiguity():
+def test_slug_copies_carries_linked_flag_and_host():
     library_index.reset_from(
         _albums(
             (Path("/m/linked"), _sc(store_url="https://label.bandcamp.com/album/home", item_id=9)),
             (Path("/m/unl"), _sc(store_url="https://artist.bandcamp.com/album/home")),
         )
     )
-    copies = dict(library_index.slug_copies("https://w.bandcamp.com/album/home"))
-    assert copies == {Path("/m/linked"): True, Path("/m/unl"): False}
-    # one unlinked copy → a single link target; the linked one isn't a candidate.
-    assert library_index.unlinked_slug_match("https://w.bandcamp.com/album/home") == Path("/m/unl")
+    copies = {
+        c.album_dir: c for c in library_index.slug_copies("https://artist.bandcamp.com/album/home")
+    }
+
+    assert copies[Path("/m/linked")].linked and not copies[Path("/m/unl")].linked
+    # `/album/home` is a slug three different artists will have; only the album on
+    # the host the purchase came from is this release on the index's own evidence.
+    assert copies[Path("/m/unl")].same_host
+    assert not copies[Path("/m/linked")].same_host
+
+
+def test_a_www_prefix_is_not_a_different_bandcamp_page():
+    library_index.reset_from(
+        _albums((Path("/m/A"), _sc(store_url="https://artist.bandcamp.com/album/home")))
+    )
+    copies = library_index.slug_copies("https://www.artist.bandcamp.com/album/home")
+
+    assert [c.same_host for c in copies] == [True]
 
 
 def test_sidecar_write_and_delete_are_the_single_update_points(tmp_path):


### PR DESCRIPTION
`/album/home` belongs to [Zero 7](https://zero7.bandcamp.com/album/home) on one Bandcamp page and to [The Gathering](https://thegathering.bandcamp.com/album/home) on another. The sync treated the slug as an identity across every host, so owning one of them added the other's purchase to `ignores.txt` — never downloaded, nothing on screen to say so — and, where the album on disk was unlinked, took the unrelated purchase's URL as its `store_url`.

Cross-listings are real, though: one release sold from both a label page and the artist's own page is why the slug ignored the subdomain in the first place, and dropping the match outright would re-download albums already on disk (the ~72 spurious downloads #104 fixed).

## What changed

- `library_index.slug_copies` now reports facts, not a verdict: each copy's host, linked flag and release id;
- a cross-host candidate is **confirmed rather than assumed** — MusicBrainz has to say the album's release carries the purchase's URL too (host *and* slug). That is the authority `_link_unmatched_by_release_urls` already links on and, unlike a slug, it can tell two artists apart;
- when it can't be confirmed, neither automatic answer is taken: not downloaded, `ignores.txt` left alone, surfaced as a potential download with Download / Match to an existing album / Don't download.

One MB call per unconfirmed candidate, served from the cache and paid at most once per purchase — a confirmed one lands in `ignores.txt`, which short-circuits the check before the next sync gets there.

## Tests

Both branches of the reproduction (linked and unlinked existing album), the genuine cross-listing that MusicBrainz confirms, and idempotence across two runs. All go red when a shared slug is trusted again.

`docs/usage.md` documents recovering a purchase the old behaviour filed away — those ids are in the auto-managed region of `ignores.txt`, which Settings' Restore deliberately never touches — and warns against clearing the file.

Fixes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH