### PR TITLE
Give each copy of a release its own address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **A release you have two copies of now has two tiles that open two albums.**
+  Both copies were addressed by the release's MusicBrainz id, so either tile
+  opened the same one and a re-tag or a re-download taken from the second copy
+  acted on the first. Each copy now has its own address; a link written before
+  the second copy appeared says which copies it could mean rather than picking
+  one, and both show the release's history, each entry naming the folder it
+  touched (#424).
+
 - **Undo now puts each disc's tags back on its own disc.** An album whose files
   span several folders had every change recorded under a bare filename, so
   undoing a tagging of a two-disc album whose discs both contain an `01.m4a`

--- a/docs/design.md
+++ b/docs/design.md
@@ -1896,6 +1896,27 @@ tracks:
 
 No evidence either way means no merge.
 
+**Two copies get two addresses** (#424). Keeping them apart on disk is only half
+the job: an id that names the *release* cannot name one of its copies, so both
+Library tiles opened the same album and a re-tag or a re-download taken from
+either reached whichever copy the scan met first. So while a release is on disk
+more than once, each copy's id is the release qualified by where that copy lives
+(`scanner._copy_id`) — derived, not allocated, so it is the same on every scan
+and cannot move between copies as folders come and go. A release on disk once
+keeps the bare MBID as its id, which is every album in an ordinary library.
+
+Two consequences, both deliberate:
+
+- **A link holding the bare release id** — written before the second copy
+  appeared — resolves to that copy while it is the only one, and otherwise says
+  the release is in the library N times and names them, rather than opening one
+  of them. Which copy an action changes is not a coin to toss.
+- **The copies share one history.** Everything that writes an event takes its
+  album id from a sidecar, and a sidecar knows only the release, so a copy's
+  records land under the bare release id. Both copies therefore show the
+  release's history (`Album.shared_history_ids`), and every record names the
+  folder it touched — which is what keeps that honest.
+
 **Nothing on disk changes.** Grouping is a reading of what is already there —
 no file moves, no sidecar written, no migration. Every part keeps its own
 complete sidecar: none is primary, none is a shard, and a folder moved out of the

--- a/src/harmonist/activity_store.py
+++ b/src/harmonist/activity_store.py
@@ -1036,7 +1036,9 @@ def resolve_alias(album_id: str, *, max_hops: int = 20) -> str | None:
     return None if current == album_id else current
 
 
-def album_history(album_id: str, limit: int = 200, *, offset: int = 0) -> list[StoredEvent]:
+def album_history(
+    album_id: str, limit: int = 200, *, offset: int = 0, also: Sequence[str] = ()
+) -> list[StoredEvent]:
     """Everything recorded about one album — activity AND audit — newest first.
 
     Unions over the album's ALIAS CHAIN, which is the whole point: an album's
@@ -1046,8 +1048,17 @@ def album_history(album_id: str, limit: int = 200, *, offset: int = 0) -> list[S
     how it got into its current state.
 
     This is the consumer the alias capture (#73) was built for.
+
+    `also` names further ids the album's records may sit under, with their own
+    chains: the copies of a release that is on disk twice have ids of their own,
+    while every writer still derives its id from the sidecar and so records
+    under the release (`Album.shared_history_ids`, #424).
     """
-    ids = [album_id, *_alias_ancestors(album_id)]
+    ids: list[str] = []
+    for known in dict.fromkeys([album_id, *also]):
+        for i in [known, *_alias_ancestors(known)]:
+            if i not in ids:
+                ids.append(i)
     placeholders = ",".join("?" * len(ids))
     q = (
         f"SELECT {_EVENT_COLUMNS} "

--- a/src/harmonist/models.py
+++ b/src/harmonist/models.py
@@ -350,6 +350,11 @@ class Album:
     albums with no sidecar it comes from `id_registry`, which derives it
     from the path relative to the library root — so it survives a restart
     and records written against such an album stay attached to it (#114).
+
+    The exception is a release that is on disk more than once: an id that names
+    the release cannot address one of its copies, so each copy's id is qualified
+    by where it lives (`scanner._copy_id`, #424). `sidecar.mb_release_id` still
+    says what it is.
     """
 
     id: str
@@ -463,6 +468,20 @@ class Album:
     # muted is a string compare rather than a database read and a hash, which at
     # Library scale is the difference between free and unusable.
     mb_version: str | None = None
+
+    @property
+    def shared_history_ids(self) -> tuple[str, ...]:
+        """Other ids this album's records may have been written under.
+
+        Empty for almost every album. A release on disk more than once gives
+        each copy an id of its own (#424) — but everything that WRITES an event
+        derives its id from a sidecar, and a sidecar knows only the release. So
+        a copy's records land under the bare release id, and both copies show
+        the release's history rather than one of them showing none of it. Each
+        record names the folder it touched, which is what keeps that honest.
+        """
+        mbid = self.sidecar.mb_release_id if self.sidecar else None
+        return (mbid,) if mbid and mbid != self.id else ()
 
     @property
     def folders(self) -> tuple[Path, ...]:

--- a/src/harmonist/scanner.py
+++ b/src/harmonist/scanner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from stat import S_ISREG
@@ -312,18 +313,34 @@ def merge_by_identity(scanned: list[ScannedDir]) -> list[Album]:
 
     merged: list[Album] = []
     for mbid, parts in by_release.items():
-        if len(parts) == 1:
-            merged.append(parts[0].album)
-            continue
-        groups = _disjoint_groups(parts)
-        if len(groups) == len(parts):
-            # Nothing could be merged — every part overlaps every other, i.e.
-            # they are duplicates of each other, not pieces of one album.
-            merged.extend(p.album for p in parts)
-            continue
-        for group in groups:
-            merged.append(group[0].album if len(group) == 1 else _combine(mbid, group))
+        copies = [
+            group[0].album if len(group) == 1 else _combine(mbid, group)
+            for group in _disjoint_groups(parts)
+        ]
+        # A release on disk more than once: each copy needs an address of its
+        # own, or both tiles open the same album and an action taken from either
+        # reaches whichever copy was scanned first (#424). The release id stays
+        # on the sidecar, where a lookup or a re-tag reads it — it is what these
+        # albums ARE, and it is exactly what cannot address one of them.
+        if len(copies) > 1:
+            copies = [replace(a, id=_copy_id(mbid, a.path)) for a in copies]
+        merged.extend(copies)
     return singles + merged
+
+
+def _copy_id(mbid: str, album_dir: Path) -> str:
+    """One copy's id: the release, qualified by where this copy lives.
+
+    Derived rather than allocated, so it is the same on every scan and does not
+    depend on the order the copies were found in — a number handed out in scan
+    order would move between copies as folders come and go, and take their links
+    and their history with it.
+
+    The release stays visible in the id because that is what the album is, and
+    because a link written before the second copy appeared holds the bare id:
+    `_find_album` can still say which release was meant, and offer the copies.
+    """
+    return f"{mbid}~{id_registry.get_or_mint(album_dir)[:8]}"
 
 
 def _disjoint_groups(parts: list[ScannedDir]) -> list[list[ScannedDir]]:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -1946,7 +1946,7 @@ def _artwork_plan(album: Album, event_id: int) -> dict[str, str]:
     looking at, so Undo cannot act on a different set of files from the one it
     described.
     """
-    history = activity_store.album_history(album.id)
+    history = activity_store.album_history(album.id, also=album.shared_history_ids)
     detail = activity_store.tag_changes_for([e.id for e in history])
     records = tag_history.group_records(history, detail).get(event_id)
     return tag_history.artwork_replaced(records) if records else {}
@@ -1979,7 +1979,7 @@ def _revert_plan(album: Album, event_id: int) -> tuple[tag_history.FileRevert, .
     looking at, so Undo cannot act on a different set of files from the one it
     described. Same contract as `_artwork_plan`.
     """
-    history = activity_store.album_history(album.id)
+    history = activity_store.album_history(album.id, also=album.shared_history_ids)
     detail = activity_store.tag_changes_for([e.id for e in history])
     records = tag_history.group_records(history, detail).get(event_id)
     return tag_history.revert_plan(records) if records else ()
@@ -2501,6 +2501,20 @@ def _find_album(request: Request, album_id: str) -> Album:
     for a in albums:
         if a.id == album_id:
             return a
+    # A link written when this release was on disk once, and holding its bare
+    # MBID (#424). One copy left → it is unambiguously what the link meant.
+    # Several → say so, rather than opening whichever comes first: which copy
+    # a re-tag or a re-download acts on is not a coin to toss.
+    copies = [a for a in albums if a.sidecar and a.sidecar.mb_release_id == album_id]
+    if len(copies) == 1:
+        return copies[0]
+    if copies:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"this release is in your library {len(copies)} times "
+            f"({', '.join(sorted(a.path.name for a in copies))}) — open the copy you "
+            "mean from the Library, where each has its own tile",
+        )
     # Race fallback: the rendered page may hold the pre-sidecar id of an album
     # whose canonical id has since changed (auto-reconcile beat the user). That
     # id derives from the album's path, so re-derive it for each album on disk
@@ -4062,7 +4076,7 @@ def _register_routes(app: FastAPI) -> None:
             # Keyed on the album's CURRENT id — album_history unions backwards
             # over the chain from there, so passing the (possibly stale) URL id
             # would find only the tail of its own history.
-            history = activity_store.album_history(album.id)
+            history = activity_store.album_history(album.id, also=album.shared_history_ids)
             # What each tagging actually changed, field by field (#86). ONE
             # query for the whole page rather than one per row: an album
             # re-tagged a few times has a `tag.track` row per file per tagging,

--- a/test/test_identity_grouping.py
+++ b/test/test_identity_grouping.py
@@ -245,6 +245,46 @@ def test_three_copies_of_two_discs_pair_off(tmp_path):
     assert all(a.track_count == 4 for a in albums)
 
 
+def test_two_copies_of_one_release_get_addresses_of_their_own(tmp_path):
+    """#424. The scan keeps separate copies separate, and then gave both the
+    release's MBID as their id — so both Library tiles opened the same album and
+    an action taken from either reached whichever copy came back first."""
+    alac = _part(tmp_path / "ALAC" / "Wide Angle", track_ids=DISC1)
+    flac = _part(tmp_path / "FLAC" / "Wide Angle", track_ids=DISC1)
+
+    albums = {a.path: a for a in scan(tmp_path)}
+
+    assert set(albums) == {alac, flac}
+    assert albums[alac].id != albums[flac].id
+    # The release is still what each of them IS — kept as metadata, where a
+    # lookup or a re-tag reads it.
+    assert all(a.sidecar.mb_release_id == REL_A for a in albums.values())
+    # And the id is the copy's, not a number handed out in scan order: it is the
+    # same on the next scan, and the same whichever order the two arrive in.
+    again = {a.path: a.id for a in scan(tmp_path)}
+    assert again == {p: a.id for p, a in albums.items()}
+
+
+def test_the_only_copy_of_a_release_keeps_the_release_as_its_id(tmp_path):
+    """The ordinary case is untouched — every album on disk, every link already
+    written and every history row still say the same thing."""
+    _part(tmp_path / "Wide Angle", track_ids=DISC1)
+
+    assert scan(tmp_path)[0].id == REL_A
+
+
+def test_the_discs_of_one_copy_are_still_one_album(tmp_path):
+    """The copies are told apart by what they hold, not by how many folders
+    there are: two discs of one release remain a single album with one id."""
+    _part(tmp_path / "CD1", track_ids=DISC1, disc=1, disc_total=2)
+    _part(tmp_path / "CD2", track_ids=DISC2, disc=2, disc_total=2)
+
+    albums = scan(tmp_path)
+
+    assert len(albums) == 1
+    assert albums[0].id == REL_A
+
+
 # ---------------------------------------------------------------------------
 # What the merged album looks like
 # ---------------------------------------------------------------------------

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2002,6 +2002,95 @@ def _make_tagged_album(cfg, name: str, *, mbid: str, tagged_at, item_id: int | N
     return d
 
 
+def _two_copies_of_one_release(cfg, mbid: str = "rel-two-copies") -> list[Path]:
+    """The same release on disk twice — two copies in different trees, the shape
+    the scanner deliberately keeps separate (#424)."""
+    import shutil
+
+    dirs: list[Path] = []
+    for kind in ("Main Library", "Second Rip"):
+        d = cfg.paths.music_dir / kind / "Doubled"
+        d.mkdir(parents=True)
+        f = d / "01 Track.m4a"
+        shutil.copy(SINE_M4A, f)
+        audio = MP4(f)
+        audio[ATOM_MB_ALBUM_ID] = [mbid.encode()]
+        # The SAME release-track id in both, which is what makes them copies of
+        # one album rather than two parts of it.
+        audio["----:com.apple.iTunes:MusicBrainz Release Track Id"] = [b"rt-1"]
+        audio.save()
+        sc.write(
+            d,
+            Sidecar(
+                mb_release_id=mbid,
+                store_url="https://x.bandcamp.com/album/doubled",
+                bandcamp=BandcampInfo(item_id=7100 + len(dirs)),
+                tagged_at=datetime.now(UTC),
+            ),
+        )
+        dirs.append(d)
+    return dirs
+
+
+def test_each_copy_of_a_release_has_its_own_tile_and_page(client, cfg):
+    """#424. Both copies were addressed by the release's MBID, so both tiles
+    opened the same album — the second copy could not be selected at all."""
+    alac, flac = _two_copies_of_one_release(cfg)
+
+    body = client.get("/library").text
+    ids = set(re.findall(r'href="/album/([^"]+)"', body))
+
+    assert len(ids) == 2
+    pages = [client.get(f"/album/{i}").text for i in ids]
+    # Each page names the folders of the copy it is, and only that one.
+    assert sum(str(alac) in p for p in pages) == 1
+    assert sum(str(flac) in p for p in pages) == 1
+
+
+def test_an_action_reaches_the_copy_it_was_taken_from(client, cfg):
+    """The point of the addresses: a mutation from one copy's page changes that
+    copy's sidecar and leaves the other alone."""
+    from harmonist import scanner
+
+    alac, flac = _two_copies_of_one_release(cfg)
+    albums = {a.path: a.id for a in scanner.scan(cfg.paths.music_dir)}
+
+    r = client.post(f"/unconfirmed/{albums[flac]}/manual")
+
+    assert r.status_code == 200
+    assert sc.read(flac).store_url is None
+    assert sc.read(alac).store_url == "https://x.bandcamp.com/album/doubled"
+
+
+def test_both_copies_show_the_history_recorded_under_the_release(client, cfg):
+    """Everything that WRITES an event takes its id from a sidecar, and a sidecar
+    knows only the release — so a copy's records land under the release id.
+    Showing the release's history on both copies (each record naming the folder
+    it touched) is the honest reading of that; showing one copy none of it is
+    not."""
+    from harmonist import scanner
+
+    alac, _flac = _two_copies_of_one_release(cfg)
+    album_id = next(a.id for a in scanner.scan(cfg.paths.music_dir) if a.path == alac)
+
+    r = client.get(f"/album/{album_id}")
+
+    assert r.status_code == 200
+    assert "Main Library/Doubled" in r.text
+    assert "Second Rip/Doubled" in r.text
+
+
+def test_a_link_holding_the_bare_release_id_says_which_copies_it_could_mean(client, cfg):
+    """A link written before the second copy appeared. Opening whichever copy
+    came back first is the bug; saying there are two is the answer."""
+    _two_copies_of_one_release(cfg)
+
+    r = client.get("/album/rel-two-copies")
+
+    assert r.status_code == 409
+    assert "in your library 2 times" in r.text
+
+
 def test_library_renders_only_done_albums(client, cfg):
     from datetime import datetime
 


### PR DESCRIPTION
The scan deliberately keeps two physical copies of one release apart — an ALAC copy and a FLAC copy are not two halves of an album — and then gave both the release's MBID as their id. Both Library tiles pointed at the same URL, `_find_album` answered it with whichever copy came first, and the second copy could not be selected at all: a re-tag or a re-download taken from its tile acted on the other one.

## What changed

An id that names the release cannot name one of its copies. While a release is on disk more than once, each copy's id is the release qualified by where that copy lives — **derived** from the path, so it is the same on every scan and does not depend on the order the copies were found in. A release on disk once is untouched, which is every album in an ordinary library: no id moves, no link breaks, no history is orphaned.

Two loose ends closed explicitly rather than left to chance:

- a link holding the bare release id resolves to the single remaining copy when there is one, and otherwise says how many copies exist and names them (409) instead of opening one;
- every writer takes its album id from a sidecar, which knows only the release, so a copy's records land under the release id — both copies therefore show the release's history, and each record names the folder it touched.

## Tests

Distinct, order-independent, scan-stable ids for two copies; the single copy keeping the bare MBID; two discs of one copy still one album; two tiles opening two pages; a mutation from one copy's page leaving the other's sidecar alone; the bare-id link naming the copies; and the shared history being deliberate. Each goes red under its own mutation.

Fixes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH