### PR TITLE
Ask the Cover Art Archive the way MusicBrainz is asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,20 @@ versions follow [semantic versioning](https://semver.org).
   panel gains a **CAA checked** date beside the MusicBrainz one, with a control
   to ask; if the archive's front cover is larger than anything the album has,
   it is kept locally and a re-tag writes it — to the tracks and to the folder
-  cover, whose previous image is kept so the change can be undone. Nothing is
-  fetched unless you press, a tagging never reaches the network, and an archive
-  cover that is no better than yours is ignored. The Artwork section shows the
+  cover, whose previous image is kept so the change can be undone. A tagging
+  never reaches the network, and an archive cover that is no better than yours
+  is ignored. The Artwork section shows the
   archive's image beside your own, marked as MusicBrainz's, and serves it from
   Harmonist — so opening an album never tells the Internet Archive which records
   you own (#276). The **CAA checked** row shows on any album with a MusicBrainz
   release, reading *not yet* until you ask — it carries the control that asks,
-  so hiding it until the first check left nothing to press (#419).
+  so hiding it until the first check left nothing to press (#419). Opening an
+  album's page now asks the archive by itself when the stored answer is missing
+  or more than a week old, exactly as it asks MusicBrainz — after the page is
+  up, so nothing waits on it, and never twice inside the window. The control
+  beside the date still asks regardless, and a check that fails leaves the
+  previous answer and its date untouched. Tune it with `[cover_art]
+  cache_ttl_seconds` (#436).
 
 
 - **An Artwork section on the album page** — what artwork your files actually

--- a/docs/design.md
+++ b/docs/design.md
@@ -853,6 +853,18 @@ MusicBrainz rate-limits at **one request per second, per request rather than per
 
 **`fetched_at` is why this needs no sidecar field.** It answers "how current is what I'm looking at?" on the album page — rendered as the panel's **Checked** date, with a re-read control beside it, which is the escape hatch that keeps a cached comparison from being a dead end. It is also the clock the gardener's incremental scheduling reads to decide which albums are due. That last reader is what dissolves the derived-state tension #32 carried: "when was this last checked" lives here, keyed by MBID, and needs nothing on disk beside the album.
 
+### Caching the Cover Art Archive
+
+`caa_cache` is the same layer over `cover_art.check_front` (#436), and deliberately so: an album page asks the two services the same way, reports both as dates in the same panel, and offers the same control beside each. Before it, the archive was asked *only* when someone pressed that control — nothing consulted the stored answer's age, so the choice was between asking on every view and asking never.
+
+**Where the two services differ, the layer differs with them.** MusicBrainz's limit is per *request*, so a conditional GET buys nothing and not asking is the only economy. The archive's cost is *bytes and seconds*: a check is up to three requests, served through a redirect to the Internet Archive, and one measured **sixteen seconds** over a remote link — while `If-None-Match` genuinely works, because unlike MusicBrainz's, its ETag is a real content validator. So:
+
+- **the TTL is a week, not an hour** (`[cover_art] cache_ttl_seconds`). Cover art changes far less often than tags;
+- **a stale row is still sent back with the question**, carrying its etag, so a re-check of unchanged art costs one request and no transfer;
+- **the check never sits on a render.** The Artwork section renders from the stored answer and then triggers a second request that does the asking, so nothing paints behind the archive. A response to that second request never asks for another — a failed check leaves a stale row, and re-triggering on staleness alone would be a page that asks forever.
+
+**A stored negative is safe here only because of the TTL.** "No front cover for this release" is the commonest answer for a private Bandcamp release and is stored so the next check does not ask again (#276) — a thing §"Never store a negative" otherwise forbids. What makes it survivable is that the answer now expires: art uploaded to the archive today is found within a TTL by itself, and the control is for not waiting.
+
 ---
 
 ## 5. Tagging contract (Picard-compatible)
@@ -1160,6 +1172,7 @@ src/harmonist/
   compare.py            Field-by-field tag-vs-MB comparison primitives (Tags section + tracklist)
   tagger.py             Picard-compatible tag writer (+ embedded cover), and the undo of one (#157)
   cover_art.py          Cover Art Archive fetch + cover.* writing
+  caa_cache.py          TTL cache over cover_art's front-cover check, in activity.db (#436)
   formats/              Per-format tag I/O (m4a, mp3, flac, ogg, opus; _vorbis shared; types)
                         owned.py names the tags Harmonist writes, per-album vs per-track
                         write_owned sets/removes a whole owned snapshot — what a revert needs

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -85,6 +85,10 @@ max_downloads_per_sync = 25       # safety cap
 user_agent = "Harmonist/1.0 ( you@example.com )"
 cache_ttl_seconds = 3600          # re-serve a fetched release for this long
 
+[cover_art]
+size = "original"                 # what to fetch from the Cover Art Archive
+cache_ttl_seconds = 604800        # re-serve a stored archive answer for a week
+
 [library]
 watch_settle_seconds = 5          # quiet time before a watched change rescans
 
@@ -112,6 +116,13 @@ album's page shows when its release was last read, as the **Checked** date in th
 album panel with a refresh button beside it, so you can always force a fresh look
 after editing MusicBrainz — and
 re-tagging and **Recheck** never use the cache. Set it to `0` to always fetch.
+
+The Cover Art Archive is asked the same way, with its own
+`[cover_art] cache_ttl_seconds` — **a week** rather than an hour, because cover
+art changes far less often than tags and the archive is the slowest thing
+Harmonist talks to. An album's page asks it when the stored answer is older than
+that, in the background once the page is up, and reports it as the **CAA
+checked** date with its own refresh button beside it.
 
 `[gardener] level` decides whether Harmonist checks your library against
 MusicBrainz on its own. It ships **`off`**, and the only other setting today is

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -462,9 +462,19 @@ want to undo on its own — and it has always had its own Undo in History.
 ### Asking the Cover Art Archive
 
 The album panel carries a **CAA checked** date beside the MusicBrainz one, with
-a control to ask. Nothing is fetched until you press it: the archive is served
-by the Internet Archive and a single check can take many seconds, so it is never
-something a page does on its own.
+a control to ask again — the same pair the MusicBrainz row has, doing the same
+job.
+
+Opening an album's page asks the archive when the stored answer is missing or
+more than a week old, and serves what it already knows otherwise, so browsing
+your library costs nothing after the first look at each album. The archive is
+served by the Internet Archive and a single check can take many seconds, so the
+asking happens **after the page is up**: the Artwork section draws what is known
+first, and the row fills in when the answer arrives. A check that fails leaves
+the previous answer and its date alone — the date not moving is how you know.
+
+Press the control to ask regardless of any of that, for a release whose art you
+have just changed on the archive.
 
 If the release has no cover of its own, Harmonist asks its **release group**,
 which is where the archive very often keeps an album's artwork. A cover found

--- a/src/harmonist/caa_cache.py
+++ b/src/harmonist/caa_cache.py
@@ -1,0 +1,167 @@
+"""A TTL cache in front of the Cover Art Archive's front-cover check (#436).
+
+`mb_cache` for the other service Harmonist asks about a release, and deliberately
+the same shape: **ask when the stored answer is missing or older than a TTL, and
+serve it from the store otherwise.** That is the property that makes the
+MusicBrainz check invisible while browsing, and the reason the archive check was
+not — nothing consulted the stored answer's age, so the choice was between asking
+every single time and asking never, and never was the safe one.
+
+Hence a layer *above* `cover_art` rather than inside it, exactly as `mb_cache`
+sits above `mb_lookup`: `cover_art` stays a plain archive client that knows
+nothing about SQLite, and demo mode keeps working by monkey-patching its
+functions — this module calls `check_front` through the module attribute, so a
+patched check is still what gets called.
+
+## Where the two services differ, and why the TTL is so much longer
+
+MusicBrainz rate-limits **per request**, so a conditional GET saves nothing and
+not asking is the only real economy. The archive's constraint is the opposite:
+its cost is *bytes and seconds*. A check is up to three requests, it is served
+from the Internet Archive, and one measured **sixteen seconds** over a remote
+link — while `If-None-Match` genuinely works (a 304 with zero bytes), because
+unlike MusicBrainz's, the archive's ETag is a real content validator.
+
+Two consequences:
+
+* **the TTL is days, not hours.** An album's cover art changes far less often
+  than its tags, and the archive is the slowest thing Harmonist talks to;
+* **a stale row is still worth sending back.** `check_front` is given the stored
+  answer whatever its age, so a re-check of a release whose art has not changed
+  costs one request and no transfer. Expiry means "ask again", never "forget" —
+  the same rule `mb_cache` states, reached from the other direction.
+
+## Storing "the archive has nothing" is safe *because* of the TTL
+
+`musicbrainz-query` rule 3 forbids caching a negative, and this module does cache
+one: "no front cover for this release" is the commonest answer for a private
+Bandcamp release, and #276 stores it so the next check does not ask again. What
+makes that survivable here is exactly what was missing before — the answer now
+expires. A cover uploaded to the archive today is found within a TTL by itself,
+and the album page's control (#419) is the way to not wait.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from . import activity_store, cover_art, timing
+
+log = logging.getLogger(__name__)
+
+# How stale a stored answer may be before the page asks again. Configured at
+# startup; the default matches `CoverArtConfig.cache_ttl_seconds` so an
+# unconfigured process (tests, a script) behaves like a default install rather
+# than like a disabled cache.
+_ttl = timedelta(days=7)
+
+# What a caller passes to mean "ask the archive, whatever is stored" — the album
+# page's re-ask control, which exists precisely to say "look again". Named for
+# the reason `mb_cache.FRESH` is: a bare `timedelta(0)` at a call site reads like
+# an oversight rather than a decision.
+#
+# It still goes THROUGH this module rather than round it: a forced check refreshes
+# the stored row, and passes the stored etag, so the forced path is the cheap one
+# too.
+FRESH = timedelta(0)
+
+# When a check is slow enough to be worth a line in the log (#300).
+#
+# Far above `mb_cache._SLOW_FETCH`, because a healthy check here is far slower: it
+# is up to three requests (a release listing, a release-group listing, a ranged
+# read of the image), served through a redirect to the Internet Archive, and one
+# measured sixteen seconds over a remote link. A threshold near MusicBrainz's
+# would warn on ordinary checks, which is the warning nobody reads.
+#
+# Sixty seconds is past the point where two of `cover_art.DEFAULT_TIMEOUT`'s
+# thirty-second windows have gone by — so the line means "this did not merely
+# take the long path", which is the only thing worth waking someone for.
+_SLOW_CHECK = timedelta(seconds=60)
+
+
+def configure(ttl: timedelta) -> None:
+    """Set the freshness window (called once from `create_app`).
+
+    A zero (or negative) TTL disables *serving*, so every album page open asks
+    the archive — the same meaning `mb_cache.configure` gives it, and a costlier
+    one here. The check lands out of band either way, so the page still paints.
+    """
+    global _ttl
+    _ttl = ttl
+
+
+def _fresh(known: activity_store.CachedCoverArt, max_age: timedelta) -> bool:
+    """Whether a stored answer may be served without asking.
+
+    The same predicate as `mb_cache._fresh`, negative age included — a row
+    stamped in the future is a clock that has gone backwards, which on a NAS
+    after an NTP correction is ordinary, and treating it as stale means the worst
+    a bad clock can do is cost a request. Its own six lines rather than a shared
+    helper: the two caches store different types, and neither module has any
+    other reason to import the other.
+    """
+    if max_age <= timedelta(0):
+        return False
+    age = datetime.now(UTC) - known.fetched_at
+    return timedelta(0) <= age < max_age
+
+
+def stored(mbid: str) -> activity_store.CachedCoverArt | None:
+    """What the archive last said about `mbid`, or None if we never asked.
+
+    **Reads the store and never the network**, whatever the row's age — what
+    every render of the Artwork section uses, so drawing a page costs nothing
+    however old the answer is. Age is the caller's to report, not this
+    function's to act on: the panel says how old it is (#276) and offers the
+    control that gets a newer one (#419).
+    """
+    return activity_store.cached_cover_art(mbid)
+
+
+def due(mbid: str) -> bool:
+    """Whether this release is worth asking the archive about again.
+
+    Asked by the album page to decide whether to send the out-of-band check —
+    which is why it is a question of its own rather than a side effect of
+    `front`. The section must render from what is known *before* anything leaves
+    the machine, so the decision has to be made without making the request.
+    """
+    known = stored(mbid)
+    return known is None or not _fresh(known, _ttl)
+
+
+def front(
+    mbid: str,
+    *,
+    release_group_mbid: str | None = None,
+    keep_if_wider_than: int | None = None,
+    max_age: timedelta | None = None,
+) -> activity_store.CachedCoverArt:
+    """`cover_art.check_front`, served from the store when it is fresh enough.
+
+    `max_age=FRESH` forces a live check and refreshes the stored row — what the
+    album page's re-ask control passes.
+
+    `CoverArtError` propagates untouched. A transport failure must never be
+    recorded as "the archive has nothing": those are different facts, and the
+    caller's job is to leave the stored answer — and its timestamp — exactly
+    where they were, which is the honest signal that the check did not happen.
+    """
+    known = stored(mbid)
+    if known is not None and _fresh(known, _ttl if max_age is None else max_age):
+        return known
+    with timing.warn_if_slow("Cover Art Archive check", _SLOW_CHECK, mbid=mbid):
+        # Through the module attribute, so demo mode's patch lands.
+        #
+        # `known` is passed even though it was too old to serve: it carries the
+        # etag, and an unchanged listing then answers 304 with no body. Staleness
+        # decides whether to ASK, not whether the previous answer is of any use.
+        answer = cover_art.check_front(
+            mbid,
+            release_group_mbid=release_group_mbid,
+            known=known,
+            keep_if_wider_than=keep_if_wider_than,
+        )
+    activity_store.store_cover_art(mbid, answer)
+    return answer

--- a/src/harmonist/config.py
+++ b/src/harmonist/config.py
@@ -66,6 +66,17 @@ class AuthConfig(BaseModel):
 
 class CoverArtConfig(BaseModel):
     size: CoverArtSize = "original"
+    # How long a stored Cover Art Archive answer may be re-served before an album
+    # page asks again (#436). The same knob `musicbrainz.cache_ttl_seconds` is,
+    # for the other service Harmonist asks about a release.
+    #
+    # A WEEK, where MusicBrainz gets an hour. An album's cover art changes far
+    # less often than its tags, and the archive is the slowest thing Harmonist
+    # talks to — a check is up to three requests through a redirect to the
+    # Internet Archive, and one measured sixteen seconds over a remote link. 0
+    # disables serving from the store, so every album page open asks; the check
+    # lands out of band either way, so the page still paints.
+    cache_ttl_seconds: int = Field(default=7 * 24 * 3600, ge=0)
 
 
 class ArtworkStoreConfig(BaseModel):

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -1260,6 +1260,30 @@ def ensure_cover(
     return None
 
 
+def check_front(
+    release_mbid: str,
+    *,
+    release_group_mbid: str | None = None,
+    known: activity_store.CachedCoverArt | None = None,
+    keep_if_wider_than: int | None = None,
+    client: Any = None,
+) -> activity_store.CachedCoverArt:
+    """Demo answer from the Cover Art Archive: it holds nothing for this release.
+
+    A real answer, and the commonest one for a private Bandcamp release — the
+    Artwork section draws it as a muted row reading "no front cover for this
+    release", so the demo shows the shape of the feature without inventing a
+    picture that does not exist.
+
+    It exists at all because the check is no longer something a user presses:
+    since #436 an album page asks the archive by itself when the stored answer
+    is stale, so an unpatched `check_front` would have demo mode making live
+    requests to coverartarchive.org just for opening an album — the one thing
+    demo mode promises it will never do.
+    """
+    return activity_store.CachedCoverArt(fetched_at=datetime.now(UTC))
+
+
 def install() -> None:
     """Monkey-patch demo implementations into the modules the web routes use.
 
@@ -1274,6 +1298,7 @@ def install() -> None:
     mb_lookup.browse_release_group_releases = browse_release_group_releases
     mb_search.search_releases = search_releases
     cover_art.ensure_cover = ensure_cover
+    cover_art.check_front = check_front
     log.info("demo mode: monkey-patched mb_lookup, mb_search, cover_art")
 
 

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -4288,6 +4288,13 @@ def _register_routes(app: FastAPI) -> None:
             # that failed the write it was just asked for) — "read just now" is
             # then still true of the fetch that produced this response.
             mb_read_at=mb_cache.fetched_at(mbid) or datetime.now(UTC),
+            # …and the Cover Art Archive's date beside it, which this response
+            # has nothing to do with and must send anyway (#438). The dates are
+            # ONE out-of-band block: a response that sends half of it blanks the
+            # other half, and this one is the slowest on the page, so its swap
+            # lands last and wins. The Artwork section carries `mb_read_at` for
+            # exactly the same reason. A local SQLite read, no request in it.
+            caa_checked_at=(answer.fetched_at if (answer := caa_cache.stored(mbid)) else None),
             # What the panel's MusicBrainz ids are called (#298). Off the same
             # release the comparison is built from, so an id and the name shown
             # for it can never come from two different payloads — which is the

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -37,6 +37,7 @@ from harmonist import (
     artwork,
     artwork_store,
     audit,
+    caa_cache,
     compare,
     cover_art,
     formats,
@@ -428,6 +429,9 @@ def create_app(
     # How long a fetched MusicBrainz release may be re-served (#127). After the
     # store is initialised, since that is where the rows live.
     mb_cache.configure(timedelta(seconds=cfg.musicbrainz.cache_ttl_seconds))
+    # …and how long the Cover Art Archive's answer may be (#436). The same knob
+    # for the other service, set from the same place, a week rather than an hour.
+    caa_cache.configure(timedelta(seconds=cfg.cover_art.cache_ttl_seconds))
     # Copies of artwork a re-tag overwrote, so replacing it can be undone (#131).
     # `artwork_dir` sandboxes itself in demo mode rather than switching off, so
     # the demo exercises the real path.
@@ -4121,7 +4125,7 @@ def _register_routes(app: FastAPI) -> None:
                 answer.fetched_at
                 if album.sidecar
                 and album.sidecar.mb_release_id
-                and (answer := activity_store.cached_cover_art(album.sidecar.mb_release_id))
+                and (answer := caa_cache.stored(album.sidecar.mb_release_id))
                 else None
             ),
             # The inbox's "you may already own this" pairing, for the action
@@ -4878,30 +4882,48 @@ def _register_routes(app: FastAPI) -> None:
         return JSONResponse(payload)
 
     @app.get("/album/{album_id}/artwork", response_class=HTMLResponse)
-    def album_artwork(request: Request, album_id: str, check: bool = False) -> Response:
+    def album_artwork(
+        request: Request, album_id: str, check: bool = False, reread: bool = False
+    ) -> Response:
         """The Artwork section (#155), fetched after the page paints.
 
         Lazy for the reason Tags and Tracks are — it opens every file in the
         album — but unlike them it is not gated on a MusicBrainz release, and
         renders for an album in any state.
 
-        `?check=1` also asks the Cover Art Archive about this album's release
-        (#276), which is the only thing here that leaves the machine. Never on
-        an ordinary render: the archive is served from the Internet Archive and
-        a measurement took sixteen seconds over a remote link, so a page that
-        asked on every view would be a page that hangs. It is one deliberate
-        press, on one album, and the answer is stored with the time it was
-        established so the panel can say how old it is.
+        Three ways in, and only two of them can leave the machine:
+
+        * **no parameter** — render from what is stored, network untouched.
+          Whatever the archive last said is shown with its age, however old.
+        * **`?check=1`** — ask the archive *if the stored answer is stale*, the
+          way the MusicBrainz comparison asks (#436). This is what the section
+          itself triggers, out of band, once it has rendered: a check took
+          sixteen seconds over a remote link, so it must never be on the path
+          that paints the panel.
+        * **`?reread=1`** — ask regardless. The control beside the "CAA checked"
+          row (#419), whose whole meaning is "look again", spelled the same way
+          the MusicBrainz re-read control spells it.
+
+        Both asking forms go through `caa_cache`, so a forced check still
+        refreshes the stored row and still sends the stored etag.
         """
         album = _refreshed_from_disk(request, _find_album(request, album_id))
         mbid = album.sidecar.mb_release_id if album.sidecar else None
-        if check and mbid:
-            _check_cover_art(mbid, _artwork_view(album))
-        caa = activity_store.cached_cover_art(mbid) if mbid else None
+        asking = check or reread
+        if asking and mbid is not None:
+            _check_cover_art(
+                mbid, _artwork_view(album), max_age=caa_cache.FRESH if reread else None
+            )
+        caa = caa_cache.stored(mbid) if mbid else None
         ctx = _ctx(
             request,
             album=album,
             artwork=_artwork_view(album, caa, _archive_image(mbid)),
+            # Whether this response should ask the browser to come back and put
+            # the question to the archive (#436). Never on a response that has
+            # just tried: a check that failed leaves the answer stale, and a
+            # section that re-triggered on staleness alone would retry forever.
+            caa_check_due=mbid is not None and not asking and caa_cache.due(mbid),
             # The panel's dates ride back out of band, so the timestamp and the
             # answer it describes update together — the same pairing the
             # MusicBrainz control has with the Tags section.
@@ -4914,21 +4936,27 @@ def _register_routes(app: FastAPI) -> None:
         )
         return _templates(request).TemplateResponse(request, "partials/_artwork.html", ctx)
 
-    def _check_cover_art(mbid: str, current: artwork.ArtworkView) -> None:
+    def _check_cover_art(
+        mbid: str, current: artwork.ArtworkView, *, max_age: timedelta | None = None
+    ) -> None:
         """Ask the archive, and remember the answer — including "nothing".
 
         Failure is swallowed here on purpose, and it is the one place in this
-        feature where that is right: the user pressed a button to learn
-        something optional about their artwork, the album page around it is
+        feature where that is right: this is something optional Harmonist wanted
+        to learn about the user's artwork, the album page around it is
         unaffected, and the stored answer keeps whatever it said before rather
         than being overwritten with a failure. Loud in the log, per the
         unattended rule, and the panel's timestamp simply does not move — which
         is the honest signal that the check did not happen.
+
+        That matters more now the check can happen without anyone pressing
+        anything (#436): a page that opened a red banner because the Internet
+        Archive was slow this morning would be reporting a failure the user did
+        not ask for and cannot act on.
         """
         # What the archive has to beat to be worth downloading: the widest image
         # the album already has. A candidate that loses is measured and
-        # forgotten; only a winner costs the full 200 KB–5 MB, and only during a
-        # check the user asked for.
+        # forgotten; only a winner costs the full 200 KB–5 MB.
         best = max(
             (r.image.size.width for r in current.images if r.image and r.image.size),
             default=None,
@@ -4940,16 +4968,14 @@ def _register_routes(app: FastAPI) -> None:
             # costs nothing and fixes itself the moment the page fetches one.
             stored = mb_cache.stored_release(mbid)
             group = (stored.get("release-group") or {}).get("id") if stored else None
-            answer = cover_art.check_front(
+            caa_cache.front(
                 mbid,
                 release_group_mbid=group if isinstance(group, str) else None,
-                known=activity_store.cached_cover_art(mbid),
                 keep_if_wider_than=best,
+                max_age=max_age,
             )
         except cover_art.CoverArtError:
             log.exception("could not ask the Cover Art Archive about release %s", mbid)
-            return
-        activity_store.store_cover_art(mbid, answer)
 
     @app.post("/album/{album_id}/artwork/update", response_class=HTMLResponse)
     def album_artwork_update(request: Request, album_id: str) -> Response:
@@ -4989,7 +5015,7 @@ def _register_routes(app: FastAPI) -> None:
         # Re-read from disk: the files just changed, and the section describes
         # what they carry.
         album = _refreshed_from_disk(request, _find_album(request, album_id))
-        caa = activity_store.cached_cover_art(mbid)
+        caa = caa_cache.stored(mbid)
         return _templates(request).TemplateResponse(
             request,
             "partials/_artwork.html",
@@ -4997,6 +5023,10 @@ def _register_routes(app: FastAPI) -> None:
                 request,
                 album=album,
                 artwork=_artwork_view(album, caa, _archive_image(mbid)),
+                # Stated rather than left undefined: writing artwork changes
+                # what the album carries, not what the archive holds, so this
+                # response has no reason to send anyone back to ask (#436).
+                caa_check_due=False,
             ),
         )
 

--- a/templates/partials/_artwork.html
+++ b/templates/partials/_artwork.html
@@ -198,6 +198,31 @@
 </p>
 {% endif %}
 
+{# Go and ask the archive, now that the section is on screen (#436).
+
+   The album page asks MusicBrainz about a release when it opens and is free to,
+   because `mb_cache` serves a stored answer until a TTL expires. `caa_cache`
+   gives the archive the same treatment, and this is where the asking happens —
+   a second request, after this one has rendered from what is already stored.
+
+   Out of band because of what a check costs: it is up to three requests through
+   a redirect to the Internet Archive, and one measured sixteen seconds. Holding
+   this section's render behind that would hold the file pass behind it too, and
+   the panel would sit empty for the length of somebody else's outage.
+
+   Sent only when the stored answer is missing or past its TTL, and NEVER on the
+   response to this request — `caa_check_due` is false there whatever the answer
+   turned out to be, so a failed check leaves a stale row and no retry rather
+   than a section asking forever.
+
+   The swap replaces this element along with the rest of the section, which is
+   what retires the trigger. Nothing visible: the section is complete as it
+   stands, and the "CAA checked" row swaps in when the answer arrives. #}
+{% if caa_check_due %}
+<div hx-get="/album/{{ album.id }}/artwork?check=1" hx-trigger="load"
+     hx-target="#album-artwork" hx-swap="innerHTML"></div>
+{% endif %}
+
 {# The panel's dates, refreshed alongside — this response may have just asked
    the archive, and the "CAA checked" row it updates lives up in the panel.
    Rendered only when this response carries them, so the ordinary lazy load of

--- a/templates/partials/_checked_at.html
+++ b/templates/partials/_checked_at.html
@@ -106,16 +106,25 @@
     </dd>
     {% else %}
     {# Not a date, so not in the dates' typeface: this says the question has not
-       been put yet, and the control beside it is how you put it. #}
+       been put yet. The Artwork section puts it by itself once it has rendered
+       (#436), so this is what the row reads while that is on its way — and on
+       an album whose check has failed, which is the state this wording was
+       always for. #}
     <dd class="text-muted italic self-baseline whitespace-nowrap">not yet</dd>
     {% endif %}
     <dd class="col-start-3 flex items-center">
         {# Re-asks, and re-renders the Artwork section that reports the answer —
            the same shape as the MusicBrainz control above, which re-fetches into
            Tags. `hx-disabled-elt` because this is a real request to an external
-           service and a double-press would spend two. #}
+           service and a double-press would spend two.
+
+           `reread`, not `check`: the two are different questions now that the
+           section asks on its own. `?check=1` means "ask if the stored answer is
+           stale" and `?reread=1` means "ask regardless" — the same word, meaning
+           the same thing, as the MusicBrainz control above. A control whose
+           whole meaning is "look again" must never be served a stored answer. #}
         <button type="button"
-                hx-get="/album/{{ album.id }}/artwork?check=1"
+                hx-get="/album/{{ album.id }}/artwork?reread=1"
                 hx-target="#album-artwork" hx-swap="innerHTML"
                 hx-disabled-elt="this"
                 title="Ask the Cover Art Archive about this release again"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,6 +22,7 @@ _PRISTINE_GLOBALS = {
     (mb_lookup, "lookup_by_bandcamp_url"): mb_lookup.lookup_by_bandcamp_url,
     (mb_search, "search_releases"): mb_search.search_releases,
     (cover_art, "ensure_cover"): cover_art.ensure_cover,
+    (cover_art, "check_front"): cover_art.check_front,
 }
 
 

--- a/test/e2e/test_artwork_section.py
+++ b/test/e2e/test_artwork_section.py
@@ -92,3 +92,41 @@ def test_every_row_reaches_its_own_image(demo_server: str) -> None:
             assert page.locator(f"#{target}").count() == 1, f"{target} is not a single element"
 
         browser.close()
+
+
+def test_the_archive_is_asked_without_anyone_pressing_anything(demo_server: str) -> None:
+    """The Artwork section triggers its own Cover Art Archive check (#436).
+
+    Only a browser can see this. `test_web.py` can say the response carries an
+    element with `hx-get` and `hx-trigger="load"` — it said exactly that about
+    the #40 button, which had stopped sending anything — and cannot say whether
+    HTMX processed content that arrived inside another swap and fired the
+    trigger, which is the whole question.
+
+    The "CAA checked" row is rendered as "not yet" — the demo store is empty at
+    startup — and becomes a time with nothing clicked.
+
+    Asserted on the row's own `title`, not on the elapsed text: "just now" is
+    also what the MusicBrainz row beside it says, and the transition out of "not
+    yet" is too quick against a local demo server to be caught on the way past.
+
+    Its OWN album, not the one the tests above share. The demo server is
+    module-scoped, and this is the one question here whose answer depends on
+    whether this album has been looked at before — an album a neighbour has
+    already opened has already been asked about.
+    """
+    album_id = "demo-rel-barryjive"
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+
+        page.goto(f"{demo_server}/album/{album_id}")
+        page.wait_for_selector("#album-artwork .art-row")
+
+        dates = page.locator(f"#album-checked-{album_id}")
+        # This element exists only where an answer does: the row renders "not
+        # yet" in its place until the archive has been asked (#419).
+        dates.locator('dd[title^="Cover Art Archive last asked"]').wait_for(state="visible")
+        assert "not yet" not in dates.inner_text()
+
+        browser.close()

--- a/test/e2e/test_mb_reread.py
+++ b/test/e2e/test_mb_reread.py
@@ -25,6 +25,11 @@ playwright_sync = pytest.importorskip("playwright.sync_api")
 
 ALBUM = "demo-rel-dingoes"
 
+#: The MusicBrainz row's value, named by the one thing that distinguishes it from
+#: the Cover Art Archive row beside it (#436): what its hover says it is about.
+#: A bare `dd[title]` matched both and failed Playwright's strict mode.
+_MB_VALUE = 'dd[title^="MusicBrainz release last read"]'
+
 
 def test_read_again_issues_a_compare_request_and_refills_the_panel(demo_server: str) -> None:
     """Click it and a `reread=1` request must actually go out, then land."""
@@ -57,8 +62,9 @@ def test_read_again_issues_a_compare_request_and_refills_the_panel(demo_server: 
         assert page.locator(f"#album-update-{ALBUM} .album-update__legend").is_visible()
         # `dd[title]` is the VALUE. Since #358 the row holds a second <dd> for
         # the re-read control, in the grid's third column, and a bare `dd` here
-        # matches both.
-        assert page.locator(f"#album-checked-{ALBUM} dd[title]").is_visible()
+        # matches both — and since #436 the block holds a Cover Art Archive date
+        # with a title of its own, so the title has to name WHICH service.
+        assert page.locator(f"#album-checked-{ALBUM} {_MB_VALUE}").is_visible()
 
         browser.close()
 
@@ -71,7 +77,7 @@ def test_the_panel_reports_when_it_last_read_musicbrainz(demo_server: str) -> No
         page = browser.new_page()
 
         page.goto(f"{demo_server}/album/{ALBUM}")
-        when = page.locator(f"#album-checked-{ALBUM} dd[title]")
+        when = page.locator(f"#album-checked-{ALBUM} {_MB_VALUE}")
         when.wait_for(timeout=10_000)
 
         # The elapsed time itself is the wrong thing to assert on: `ago` renders
@@ -79,7 +85,10 @@ def test_the_panel_reports_when_it_last_read_musicbrainz(demo_server: str) -> No
         # fetched says nothing containing "ago". What must hold on every run is
         # that the value states WHICH read it is reporting — that is the claim
         # the user checks a stale comparison against.
-        assert page.locator(f"#album-checked-{ALBUM} dt").text_content() == "Checked"
+        #
+        # `.first`: the block lists several dates, and this row is the first of
+        # them (#355 put it there, #436 gave the archive one of its own below).
+        assert page.locator(f"#album-checked-{ALBUM} dt").first.text_content() == "MB checked"
         assert "MusicBrainz release last read" in (when.get_attribute("title") or "")
         assert (when.text_content() or "").strip()
 

--- a/test/test_caa_cache.py
+++ b/test/test_caa_cache.py
@@ -1,0 +1,187 @@
+"""The TTL cache in front of the Cover Art Archive's check (#436).
+
+The mirror of `test_mb_cache.py`, and it counts checks for the same reason: the
+number of times the archive is asked *is* the feature. A cache that returns the
+right answer while still asking has done nothing — and here the cost of asking is
+sixteen seconds of somebody's album page rather than a rate-limit slot.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from harmonist import activity_store, caa_cache, cover_art
+
+MBID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+@pytest.fixture(autouse=True)
+def fresh_store_and_default_ttl(tmp_path):
+    """A file-backed store per test, and the shipped TTL.
+
+    `configure` is process-level state, exactly as it is for `mb_cache`: a test
+    that changed it and did not put it back would quietly change how a LATER
+    test's cache behaves, and tests run in random order.
+    """
+    activity_store.init(tmp_path / "activity.db")
+    caa_cache.configure(timedelta(days=7))
+    yield
+    caa_cache.configure(timedelta(days=7))
+
+
+class _Counter:
+    """A stand-in check that records how many times the archive was asked."""
+
+    def __init__(self, answer: activity_store.CachedCoverArt | None = None):
+        self.answer = answer
+        self.calls = 0
+        self.known: list[activity_store.CachedCoverArt | None] = []
+
+    def __call__(self, mbid, *, release_group_mbid=None, known=None, keep_if_wider_than=None):
+        self.calls += 1
+        self.known.append(known)
+        return self.answer or activity_store.CachedCoverArt(
+            fetched_at=datetime.now(UTC), image_url="https://caa.example/front.jpg", width=1400
+        )
+
+
+def _stored(age: timedelta, **kw) -> None:
+    activity_store.store_cover_art(
+        MBID, activity_store.CachedCoverArt(fetched_at=datetime.now(UTC) - age, **kw)
+    )
+
+
+def test_a_second_look_inside_the_ttl_does_not_ask_the_archive(monkeypatch):
+    """The whole point. Opening an album page twice must cost one check."""
+    check = _Counter()
+    monkeypatch.setattr(cover_art, "check_front", check)
+
+    first = caa_cache.front(MBID)
+    second = caa_cache.front(MBID)
+
+    assert check.calls == 1
+    assert first.image_url == second.image_url == "https://caa.example/front.jpg"
+
+
+def test_an_answer_past_the_ttl_is_asked_again(monkeypatch):
+    check = _Counter()
+    monkeypatch.setattr(cover_art, "check_front", check)
+    _stored(timedelta(days=8), image_url="https://caa.example/old.jpg")
+
+    answer = caa_cache.front(MBID)
+
+    assert check.calls == 1
+    assert answer.image_url == "https://caa.example/front.jpg"
+
+
+def test_a_stale_answer_is_still_handed_back_for_its_etag(monkeypatch):
+    """Expiry means "ask again", never "forget". The archive's ETag is a real
+    content validator, so a re-check of unchanged art costs one request and no
+    transfer — but only if the stale row goes back out with the question."""
+    check = _Counter()
+    monkeypatch.setattr(cover_art, "check_front", check)
+    _stored(timedelta(days=30), etag='"unchanged"', image_url="https://caa.example/old.jpg")
+
+    caa_cache.front(MBID)
+
+    assert check.known[0] is not None
+    assert check.known[0].etag == '"unchanged"'
+
+
+def test_fresh_forces_a_check_the_stored_answer_would_have_served(monkeypatch):
+    """What the album page's re-ask control passes. Serving it a stored answer
+    would make the one control that means "look again" a silent no-op."""
+    check = _Counter()
+    monkeypatch.setattr(cover_art, "check_front", check)
+    _stored(timedelta(minutes=1), image_url="https://caa.example/old.jpg")
+
+    answer = caa_cache.front(MBID, max_age=caa_cache.FRESH)
+
+    assert check.calls == 1
+    assert answer.image_url == "https://caa.example/front.jpg"
+
+
+def test_the_answer_is_stored_so_the_next_process_starts_warm(monkeypatch):
+    check = _Counter()
+    monkeypatch.setattr(cover_art, "check_front", check)
+
+    caa_cache.front(MBID)
+
+    kept = activity_store.cached_cover_art(MBID)
+    assert kept is not None
+    assert kept.image_url == "https://caa.example/front.jpg"
+
+
+def test_nothing_in_the_archive_is_an_answer_that_stops_the_asking(monkeypatch):
+    """ "No front cover" is the commonest answer for a private Bandcamp release,
+    and #276 stores it. What makes caching that negative survivable is the TTL —
+    so it must be served inside the window, and asked again outside it."""
+    check = _Counter(activity_store.CachedCoverArt(fetched_at=datetime.now(UTC)))
+    monkeypatch.setattr(cover_art, "check_front", check)
+
+    caa_cache.front(MBID)
+    caa_cache.front(MBID)
+
+    assert check.calls == 1
+    assert caa_cache.stored(MBID).has_art is False
+
+
+def test_a_failed_check_leaves_the_previous_answer_and_its_timestamp(monkeypatch):
+    """ "I could not ask" and "there is nothing there" must not be recorded as the
+    same thing: the timestamp not moving is what tells the user the check did not
+    happen."""
+
+    def boom(mbid, **kw):
+        raise cover_art.CoverArtError("the archive is down")
+
+    monkeypatch.setattr(cover_art, "check_front", boom)
+    _stored(timedelta(days=30), image_url="https://caa.example/old.jpg")
+    before = activity_store.cached_cover_art(MBID)
+
+    with pytest.raises(cover_art.CoverArtError):
+        caa_cache.front(MBID)
+
+    after = activity_store.cached_cover_art(MBID)
+    assert after.image_url == "https://caa.example/old.jpg"
+    assert after.fetched_at == before.fetched_at
+
+
+def test_due_says_what_the_page_should_do_without_asking_anything(monkeypatch):
+    """The page has to decide whether to send the check BEFORE anything leaves
+    the machine, so this question must not answer it by making the request."""
+
+    def boom(mbid, **kw):
+        raise AssertionError("`due` asked the archive")
+
+    monkeypatch.setattr(cover_art, "check_front", boom)
+
+    assert caa_cache.due(MBID) is True  # never asked
+    _stored(timedelta(days=30))
+    assert caa_cache.due(MBID) is True  # asked, long ago
+    _stored(timedelta(hours=1))
+    assert caa_cache.due(MBID) is False  # asked within the window
+
+
+def test_a_row_stamped_in_the_future_is_stale_rather_than_immortal(monkeypatch):
+    """A NAS whose clock has just been corrected backwards must cost a request,
+    not an answer that can never expire."""
+    check = _Counter()
+    monkeypatch.setattr(cover_art, "check_front", check)
+    _stored(-timedelta(days=365))
+
+    assert caa_cache.due(MBID) is True
+    caa_cache.front(MBID)
+    assert check.calls == 1
+
+
+def test_a_zero_ttl_asks_every_time(monkeypatch):
+    check = _Counter()
+    monkeypatch.setattr(cover_art, "check_front", check)
+    caa_cache.configure(timedelta(0))
+
+    caa_cache.front(MBID)
+    caa_cache.front(MBID)
+
+    assert check.calls == 2

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -8914,7 +8914,10 @@ def test_the_cover_art_check_is_reachable_before_it_has_ever_run(client, cfg):
     assert r.status_code == 200
     rendered = " ".join(r.text.split())
     assert "CAA checked" in rendered
-    assert f"/album/{album_id}/artwork?check=1" in rendered
+    # `reread`, not `check`: the section asks on its own when the stored answer
+    # is stale (#436), so this control is the one that asks REGARDLESS — the
+    # same word the MusicBrainz re-read control beside it uses.
+    assert f"/album/{album_id}/artwork?reread=1" in rendered
 
 
 def test_the_artwork_action_is_offered_only_when_something_would_change(client, cfg):
@@ -9029,3 +9032,112 @@ def test_an_archive_with_nothing_gets_its_own_placeholder(client, cfg):
     assert "art-rows--muted" in rendered
     assert "not loaded" not in rendered  # nothing to load, so not that word
     assert 'class="text-sm text-mb-purple"' not in rendered
+
+
+def test_the_artwork_section_sends_the_page_back_to_ask_the_archive(client, cfg):
+    """The archive is asked on page open now, the way MusicBrainz is (#436) —
+    but out of band, from a second request the section triggers once it has
+    rendered from what is stored."""
+    d = _make_tagged_album(cfg, "Unasked", mbid="rel-unasked", tagged_at=datetime.now(UTC))
+    album_id = _id_for(cfg, d)
+
+    rendered = " ".join(client.get(f"/album/{album_id}/artwork").text.split())
+
+    assert f'hx-get="/album/{album_id}/artwork?check=1"' in rendered
+    assert 'hx-trigger="load"' in rendered
+
+
+def test_a_stored_archive_answer_inside_the_ttl_sends_nobody_back(client, cfg):
+    """The property that makes this invisible: browsing an album a second time
+    costs nothing. The trigger is what would spend sixteen seconds, so its
+    absence is the assertion."""
+    from harmonist import activity_store
+
+    d = _make_tagged_album(cfg, "Asked", mbid="rel-asked", tagged_at=datetime.now(UTC))
+    album_id = _id_for(cfg, d)
+    activity_store.store_cover_art(
+        "rel-asked", activity_store.CachedCoverArt(fetched_at=datetime.now(UTC))
+    )
+
+    rendered = " ".join(client.get(f"/album/{album_id}/artwork").text.split())
+
+    assert f"/album/{album_id}/artwork?check=1" not in rendered
+
+
+def test_an_album_with_no_release_asks_the_archive_nothing(client, cfg):
+    """There is no release to ask about. The section renders — artwork facts are
+    disk facts — and nothing leaves the machine."""
+    d = _album_with_art(cfg, "Unidentified", covers=[_png(1)])
+    album_id = _id_for(cfg, d)
+
+    rendered = " ".join(client.get(f"/album/{album_id}/artwork").text.split())
+
+    assert "art-row" in rendered
+    assert f"/album/{album_id}/artwork?check=1" not in rendered
+
+
+def test_a_check_that_failed_does_not_ask_the_page_to_try_again(client, cfg, monkeypatch):
+    """The loop this feature could have been: a failed check leaves the stored
+    answer stale, and a section that re-triggered on staleness alone would ask
+    the archive forever, once per response, for as long as it stayed down."""
+    from harmonist import cover_art
+
+    def boom(mbid, **kw):
+        raise cover_art.CoverArtError("the archive is down")
+
+    monkeypatch.setattr(cover_art, "check_front", boom)
+    d = _make_tagged_album(cfg, "Downed", mbid="rel-downed", tagged_at=datetime.now(UTC))
+    album_id = _id_for(cfg, d)
+
+    r = client.get(f"/album/{album_id}/artwork?check=1")
+    rendered = " ".join(r.text.split())
+
+    # The page still renders, and says the question has not been answered —
+    # loud in the log, silent in the UI.
+    assert r.status_code == 200
+    assert "not yet" in rendered
+    assert f"/album/{album_id}/artwork?check=1" not in rendered
+
+
+def test_the_page_open_check_is_served_from_the_store_when_it_is_fresh(client, cfg, monkeypatch):
+    """`?check=1` goes through the cache, so two tabs opened at once cost one
+    check rather than two. The request count is the feature."""
+    from harmonist import activity_store, cover_art
+
+    calls: list[str] = []
+
+    def counting(mbid, **kw):
+        calls.append(mbid)
+        return activity_store.CachedCoverArt(fetched_at=datetime.now(UTC))
+
+    monkeypatch.setattr(cover_art, "check_front", counting)
+    d = _make_tagged_album(cfg, "Twice", mbid="rel-twice", tagged_at=datetime.now(UTC))
+    album_id = _id_for(cfg, d)
+
+    client.get(f"/album/{album_id}/artwork?check=1")
+    client.get(f"/album/{album_id}/artwork?check=1")
+
+    assert calls == ["rel-twice"]
+
+
+def test_the_re_ask_control_asks_even_when_the_stored_answer_is_fresh(client, cfg, monkeypatch):
+    """The other half of the same rule: a control whose whole meaning is "look
+    again" must never be served a stored answer (#419)."""
+    from harmonist import activity_store, cover_art
+
+    calls: list[str] = []
+
+    def counting(mbid, **kw):
+        calls.append(mbid)
+        return activity_store.CachedCoverArt(fetched_at=datetime.now(UTC))
+
+    monkeypatch.setattr(cover_art, "check_front", counting)
+    d = _make_tagged_album(cfg, "Forced", mbid="rel-forced", tagged_at=datetime.now(UTC))
+    album_id = _id_for(cfg, d)
+    activity_store.store_cover_art(
+        "rel-forced", activity_store.CachedCoverArt(fetched_at=datetime.now(UTC))
+    )
+
+    client.get(f"/album/{album_id}/artwork?reread=1")
+
+    assert calls == ["rel-forced"]

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -9141,3 +9141,31 @@ def test_the_re_ask_control_asks_even_when_the_stored_answer_is_fresh(client, cf
     client.get(f"/album/{album_id}/artwork?reread=1")
 
     assert calls == ["rel-forced"]
+
+
+def test_the_comparison_keeps_the_archive_date_it_swaps_over(client, cfg, monkeypatch):
+    """The panel's dates are ONE out-of-band block, so a response that sends half
+    of it blanks the other half (#438).
+
+    `/compare` has nothing to do with the Cover Art Archive and is the slowest
+    fetch on the page, so its swap lands last — and used to land with the CAA row
+    reading *not yet* over an answer the store had all along.
+    """
+    from harmonist import activity_store
+
+    d = _make_tagged_album(cfg, "Dated", mbid="rel-dated", tagged_at=datetime.now(UTC))
+    activity_store.store_cover_art(
+        "rel-dated", activity_store.CachedCoverArt(fetched_at=datetime.now(UTC))
+    )
+
+    def fake_release(mbid):
+        return {"id": mbid, "title": "Dated", "medium-list": []}
+
+    monkeypatch.setattr("harmonist.web.main.mb_lookup.fetch_release", fake_release)
+
+    rendered = " ".join(client.get(f"/library/{_id_for(cfg, d)}/compare").text.split())
+
+    assert "Cover Art Archive last asked" in rendered
+    # The wording the row falls back to, which this album is past — and which the
+    # same block still renders for an album nobody has asked about.
+    assert "not yet" not in rendered


### PR DESCRIPTION
Opening an album page asked MusicBrainz about the release and asked the archive about nothing — the **CAA checked** row read *not yet* until someone pressed the control beside it. That asymmetry was a consequence rather than a decision: MusicBrainz is free on page open only because of `mb_cache`, and nothing consulted the archive answer's age, so the choice was between asking every single time and asking never.

## `caa_cache`

The missing half, and deliberately the same shape as `mb_cache`: a TTL over `cover_art.check_front`, serving the stored answer inside the window and asking outside it. Browsing then costs nothing after the first look at each album, which is the property that makes the MusicBrainz check invisible.

Where the two services differ, the layer differs with them. MusicBrainz's limit is per *request*, so a conditional GET buys nothing; the archive's cost is *bytes and seconds*, and its ETag is a real content validator. So the TTL is a **week** rather than an hour (`[cover_art] cache_ttl_seconds`), and a stale row still goes back out with the question, carrying its etag, so a re-check of unchanged art costs one request and no transfer.

## Out of band, and never in a loop

The asking cannot sit on a render — a check took sixteen seconds over a remote link, and the Artwork section already opens every file in the album. So the section draws what is stored and then triggers a second request that does the asking, which is the shape #387 wants for the MusicBrainz comparison.

A response to that request never asks for another: a failed check leaves the answer stale, and re-triggering on staleness alone would be a page that asks forever for as long as the archive was down.

`?check=1` now means "ask if the stored answer is stale" and `?reread=1` means "ask regardless" — the same word the MusicBrainz re-read control uses, and what the CAA control now sends, since a control meaning "look again" must never be served a stored answer.

## Two things that fell out of it

- **Fixes #438.** `/compare` was sending half the panel's out-of-band dates block, so its swap drew **CAA checked** as *not yet* over an answer the store had. Invisible while a press was the only way to ask; fatal once the page asks by itself.
- **Demo mode needed a `check_front` patch.** Without one, opening a demo album page would make live requests to coverartarchive.org — the one thing demo mode promises it will never do.

## On storing a negative

"No front cover for this release" is a cached negative, which `musicbrainz-query` rule 3 forbids. It is survivable here only because of the TTL: art uploaded to the archive today is now found within a week by itself, where before it was invisible until someone pressed the button.

## Proof

Three rungs. `test_caa_cache.py` counts checks — the request count is the feature. `test_web.py` covers the trigger, the loop guard, and that `?reread=1` is not served from the store. A Playwright test watches the row fill in with nothing clicked, which is the only rung that can see whether HTMX fired a trigger that arrived inside another swap; it and the #438 test were both mutation-checked red.

`make check` green; `make e2e` green apart from `test_every_row_reaches_its_own_image`, which fails identically on `main` and is untouched here.

## Known follow-up

#439 — the candidate-image cache has no size cap, and this change is what makes it fill without being asked.

Fixes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH