### PR TITLE
Let the archive win on an album with no folder cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- **An album with no `cover.jpg` can now take the Cover Art Archive's cover.**
+  Art embedded in the files with no cover file beside them — the shape an
+  adopted library arrives in — was ruled out before its size was even
+  considered, so the archive's cover was reported as an also-ran however much
+  better it was. It is now judged against the tracks' own image, and written to
+  them when it wins; no `cover.jpg` is created where none existed. A
+  compilation's per-track artwork is still never overwritten, and now says so in
+  the album's History (#442).
+
 - **A release you have two copies of now has two tiles that open two albums.**
   Both copies were addressed by the release's MusicBrainz id, so either tile
   opened the same one and a re-tag or a re-download taken from the second copy

--- a/src/harmonist/artwork.py
+++ b/src/harmonist/artwork.py
@@ -490,7 +490,11 @@ def summarise(
         by_digest.setdefault(tags.art.digest, []).append(ref)
         art_of.setdefault(tags.art.digest, tags.art)
 
-    preserved = cover is None or has_per_track_art(by_digest)
+    # Per-track artwork is user data, and nothing overwrites it — not the folder
+    # cover, not the archive, however large. Its own name because it is its own
+    # rule: `preserved` below adds "and there is nothing to write anyway", which
+    # is a different fact and used to be conflated with this one (#442).
+    per_track = has_per_track_art(by_digest)
     # More than one disc is a property of the ALBUM, not of a row: a box set
     # whose images each sit on one disc still needs every label to name its disc,
     # or two discs' track 1 read as one repeated row (#400).
@@ -534,6 +538,37 @@ def summarise(
     album_image = next(iter(art_of.values())) if len(art_of) == 1 else None
     ours = album_image.size if album_image else None
     theirs = cover.image.size if cover else None
+
+    # The best image the album ALREADY has, from either carrier — what a
+    # candidate from outside has to beat. An image that cannot be measured
+    # loses, exactly as `beats` reads a None.
+    #
+    # A folder cover that cannot be measured is the exception, and makes the
+    # answer unknown rather than "the tracks' one": something is there, its size
+    # is not, and leaving it alone is the safe reading of that.
+    album_best = (
+        None
+        if cover is not None and theirs is None
+        else ours
+        if theirs is None or (ours is not None and beats(ours, theirs))
+        else theirs
+    )
+
+    # The archive is the third candidate, and it displaces both when it beats
+    # them (#276). It needs NO FOLDER COVER to be one: it is an image from
+    # outside the album, and the folder file is not what carries it — requiring
+    # one ruled the archive out on exactly the albums #276 said the wins were in,
+    # art embedded in the files and no cover.jpg beside them (#442).
+    #
+    # Asked in the same order and by the same `beats` as `tagger.decide_artwork`,
+    # because this is the page saying what that code will do.
+    archive_wins = not per_track and archive is not None and beats(archive.size, album_best)
+
+    # Nothing is written when the album's own artwork is protected, or when
+    # there is nothing to write from: the folder cover normally, and the archive
+    # when it has beaten everything.
+    preserved = per_track or (cover is None and not archive_wins)
+
     # What goes on the tracks: the folder cover has to actually be better to be
     # written over what the album already carries, and both sizes have to be
     # readable for that to be established at all (#397, #410).
@@ -551,16 +586,6 @@ def summarise(
     #: …and the image those words name.
     gap_image = album_image if keep_ours else (cover.image if cover else None)
 
-    # The archive is the third candidate, and it displaces both when it beats
-    # them (#276). Asked in the same order and by the same `beats` as
-    # `tagger._prepare`, because this is the page saying what that code will do.
-    local_best = gap_image.size if gap_image else None
-    archive_wins = (
-        not preserved
-        and archive is not None
-        and cover is not None
-        and beats(archive.size, local_best)
-    )
     if archive_wins:
         assert archive is not None  # narrowed by `archive_wins`
         keep_ours = False

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -532,7 +532,11 @@ class ArtworkPlan:
     #: none. The gaps are the None entries.
     before: dict[Path, str | None]
     #: The image that ought to be on every track, or None when nothing should be
-    #: written at all — no folder cover, or per-track artwork worth preserving.
+    #: written at all — per-track artwork worth preserving, or an album with
+    #: nothing outside its tracks to consider (no folder cover and no cached
+    #: archive image). An album with no folder cover DOES still have a winner
+    #: when it has one image of its own: it is the incumbent the archive has to
+    #: beat, and what a tagging fills that album's gaps from (#442).
     winner: bytes | None
     #: The image the folder cover should become, when something beats it.
     promote_cover: bytes | None = None
@@ -583,23 +587,31 @@ def decide_artwork(
     what must not happen.
     """
     cover = cover_path.read_bytes() if cover_path else None
-    before = _art_digests(files) if cover is not None else {}
+    # The archive's image, from the LOCAL CACHE only.
+    archive = _archive_candidate(release)
+    # Read what the tracks carry whenever ANYTHING could overwrite it. The read
+    # used to be skipped when there was no folder cover, which was safe only
+    # while the cover was the sole candidate: `before` is what the per-track-art
+    # guard below consults, so an album with no cover and an archive candidate
+    # would have been judged on an empty dict and its sleeves flattened (#442).
+    before = _art_digests(files) if (cover is not None or archive is not None) else {}
 
     # DATA SAFETY: if the tracks carry DIFFERENT embedded art (a per-track-art
     # album, e.g. a compilation), embedding one album cover would destroy those
     # images. Preserve them — the folder cover.* is still written separately.
-    preserves = (
-        cover is not None and not overwrite_art and artwork.has_per_track_art(before.values())
-    )
+    preserves = not overwrite_art and artwork.has_per_track_art(before.values())
     if preserves:
         return ArtworkPlan(before=before, winner=None, preserves_per_track_art=True)
-    if cover is None or overwrite_art:
+    if overwrite_art:
+        # Asking for the folder cover to be embedded is not asking for it to be
+        # judged — and with no cover to embed there is nothing to do.
         return ArtworkPlan(before=before, winner=cover)
+    if cover is None and archive is None:
+        # Nothing from outside the tracks, so nothing can change.
+        return ArtworkPlan(before=before, winner=None)
 
-    folder_size = images.dimensions(cover)
+    folder_size = images.dimensions(cover) if cover is not None else None
     own = _album_image(before)
-    # The archive's image, from the LOCAL CACHE only.
-    archive = _archive_candidate(release)
 
     # Ordered worst-first so each candidate has to genuinely beat the one before
     # it to displace it — ties go to what is already there, because a same-sized
@@ -609,7 +621,10 @@ def decide_artwork(
     if own is not None:
         _, mine = own
         ours = images.dimensions(mine)
-        if ours is not None and folder_size is not None and not artwork.beats(folder_size, ours):
+        # With no folder cover the tracks' own image is the incumbent rather
+        # than a challenger — there is nothing for it to beat, and it is what
+        # the archive then has to beat.
+        if ours is not None and (folder_size is None or not artwork.beats(folder_size, ours)):
             winner, winner_size = mine, ours
     if archive is not None:
         theirs = images.dimensions(archive)

--- a/test/test_artwork.py
+++ b/test/test_artwork.py
@@ -514,6 +514,57 @@ class TestArchiveWins:
 
         assert not any(r.writes for r in view.rows)
 
+    def test_it_wins_on_an_album_that_has_no_folder_cover(self) -> None:
+        """The population #276 said the wins were in: art embedded in the files,
+        no `cover.jpg` beside them, which is how an adopted library arrives.
+
+        The archive needs no folder cover to be a candidate — it is an image
+        from outside, and the folder file is not what carries it (#442).
+        """
+        mine = art_of(1, width=600, height=600)
+        archive = art_of(2, width=1400, height=1400)
+
+        view = artwork.summarise(album(mine, mine), None, archive=archive)
+
+        assert [r.outcome for r in view.rows] == [artwork.Outcome.REPLACED]
+        assert view.rows[0].written_from == "the Cover Art Archive"
+        assert view.rows[0].written_image == archive
+        assert view.rows[0].from_archive is True
+
+    def test_it_must_still_beat_the_tracks_when_there_is_no_folder_cover(self) -> None:
+        """With no cover file there is nothing else to compare against, so the
+        tracks' own image is the incumbent — and ties go to what is there."""
+        mine = art_of(1, width=1400, height=1400)
+
+        same = artwork.summarise(
+            album(mine, mine), None, archive=art_of(2, width=1400, height=1400)
+        )
+        smaller = artwork.summarise(
+            album(mine, mine), None, archive=art_of(3, width=600, height=600)
+        )
+
+        assert not any(r.writes for r in same.rows)
+        assert not any(r.writes for r in smaller.rows)
+
+    def test_per_track_artwork_survives_having_no_folder_cover(self) -> None:
+        """The promise, on the album shape #442 opened up.
+
+        Two things hold it, and the second is the one doing the work here: the
+        `not per_track` guard on `archive_wins` (which is what protects a
+        compilation that HAS a folder cover), and — with no cover — the fact
+        that an album with more than one image has no single `album_image`, so
+        `album_best` cannot be measured and there is nothing for the archive to
+        beat. Removing either leaves this passing; removing both does not, and
+        the promise is worth pinning by its outcome rather than its mechanism.
+        """
+        view = artwork.summarise(
+            album(art_of(1, width=500, height=500), art_of(2, width=500, height=500)),
+            None,
+            archive=art_of(3, width=3000, height=3000),
+        )
+
+        assert not any(r.writes for r in view.rows)
+
 
 def test_a_track_row_replaced_by_the_cover_shows_the_incoming_image() -> None:
     """The gap this missed until #276: only the gap and folder rows carried an

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -2571,3 +2571,137 @@ def test_tagging_never_asks_the_archive(album_with_tracks, tmp_path, monkeypatch
     cover.write_bytes(_sized_jpeg(800, 800))
 
     tagger.tag_album(album_dir, _single_track_release(), cover_path=cover)
+
+
+def test_a_larger_archive_image_wins_with_no_folder_cover(album_with_tracks, tmp_path):
+    """The album shape an adopted library arrives in: art embedded in the files,
+    no `cover.jpg` beside them (#442).
+
+    The archive needs no folder cover to be a candidate — the folder file is not
+    what carries it — so it is judged against the tracks' own image and written
+    when it wins. The page says the same thing, through the same `beats`.
+    """
+    from harmonist import artwork_store, cover_art
+
+    artwork_store.configure(tmp_path / "artwork")
+    cover_art.configure_cache(tmp_path / "caa")
+    album_dir = album_with_tracks(2)
+    mine = _sized_jpeg(500, 500)
+    for track in ("01 Track 1.m4a", "02 Track 2.m4a"):
+        _embed_cover(album_dir / track, mine)
+    theirs = _sized_jpeg(1400, 1400)
+    release = _release_2_tracks()
+    cover_art.cache_image(release["id"], theirs, "image/jpeg")
+
+    changed = tagger.update_artwork(album_dir, release, None)
+
+    assert changed == 2
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == theirs
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == theirs
+    # No cover.jpg is created. Writing a new file into the user's album dir is
+    # an additive behaviour of its own, and `promote_cover` asks for a strict
+    # improvement on a folder cover that is not there to be improved on.
+    assert not (album_dir / "cover.jpg").exists()
+    # What it replaced is recoverable. This album has no folder cover, so
+    # everything overwritten here is EMBEDDED art — the half the store keeps —
+    # which makes this the reversible case rather than #276's hazardous one.
+    assert artwork_store.path_for(artwork_store.digest(mine)) is not None
+    # …and pressing again finds the winner already everywhere.
+    assert tagger.update_artwork(album_dir, release, None) == 0
+
+
+def test_a_smaller_archive_image_is_ignored_with_no_folder_cover(album_with_tracks, tmp_path):
+    """With no cover file the tracks' own image is the incumbent, and it keeps
+    the tie: a same-sized different picture is not an improvement."""
+    from harmonist import artwork_store, cover_art
+
+    artwork_store.configure(tmp_path / "artwork")
+    cover_art.configure_cache(tmp_path / "caa")
+    album_dir = album_with_tracks(1)
+    mine = _sized_jpeg(1400, 1400)
+    _embed_cover(album_dir / "01 Track 1.m4a", mine)
+    release = _single_track_release()
+    cover_art.cache_image(release["id"], _sized_jpeg(1400, 1400) + b"_other", "image/jpeg")
+
+    assert tagger.update_artwork(album_dir, release, None) == 0
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == mine
+
+
+def test_per_track_artwork_survives_an_archive_cover_with_no_folder_cover(
+    album_with_tracks, tmp_path
+):
+    """The promise, and the report that says Harmonist made a decision.
+
+    The sleeves survive structurally — an album with more than one image has no
+    single `_album_image`, so nothing measurable is on offer for the archive to
+    beat — and that held before this change too. What changes is that the album
+    now SAYS so: the per-track-art guard used to be keyed on there being a
+    folder cover, so a coverless compilation fell out through the early return
+    with the flag unset, and its History recorded nothing about the images
+    Harmonist chose not to touch (#260, #442).
+    """
+    from harmonist import artwork_store, cover_art
+
+    artwork_store.configure(tmp_path / "artwork")
+    cover_art.configure_cache(tmp_path / "caa")
+    album_dir = album_with_tracks(2)
+    first, second = _sized_jpeg(500, 500), _sized_jpeg(500, 500) + b"_different"
+    _embed_cover(album_dir / "01 Track 1.m4a", first)
+    _embed_cover(album_dir / "02 Track 2.m4a", second)
+    release = _release_2_tracks()
+    cover_art.cache_image(release["id"], _sized_jpeg(3000, 3000), "image/jpeg")
+
+    assert tagger.update_artwork(album_dir, release, None) == 0
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == first
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == second
+    # …and it is reported as the decision it is, rather than as nothing having
+    # happened. This is the half the guard change actually moves.
+    plan = tagger.decide_artwork(sorted(album_dir.glob("*.m4a")), release, cover_path=None)
+    assert plan.preserves_per_track_art is True
+
+
+def test_a_coverless_album_with_no_candidate_still_reads_no_artwork(album_with_tracks, tmp_path):
+    """The gardener's path must not get more expensive (#442).
+
+    `plan_album` reaches `decide_artwork` for every album in the library, and
+    `_art_digests` opens every file. An album with no folder cover and no cached
+    archive image has nothing that could overwrite its tracks, so it is decided
+    without reading any of them — which is why the widened read is conditional
+    on there being a candidate rather than unconditional.
+    """
+    from harmonist import cover_art
+
+    cover_art.configure_cache(tmp_path / "caa")  # configured, and empty
+    album_dir = album_with_tracks(2)
+    _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(500, 500))
+
+    plan = tagger.decide_artwork(
+        sorted(album_dir.glob("*.m4a")), _release_2_tracks(), cover_path=None
+    )
+
+    assert plan.winner is None
+    assert plan.before == {}
+
+
+def test_a_losing_archive_still_lets_the_albums_own_art_fill_a_gap(album_with_tracks, tmp_path):
+    """The consequence of making the tracks' image the incumbent (#442).
+
+    Once there is a candidate to weigh, the album's own image is a real winner
+    rather than the None a coverless album used to get — so #397's rule reaches
+    an album with no `cover.jpg`, and the track that lost its art is filled from
+    the rest. Additive: the track that HAS art keeps exactly what it had.
+    """
+    from harmonist import artwork_store, cover_art
+
+    artwork_store.configure(tmp_path / "artwork")
+    cover_art.configure_cache(tmp_path / "caa")
+    album_dir = album_with_tracks(2)
+    mine = _sized_jpeg(500, 500)
+    _embed_cover(album_dir / "01 Track 1.m4a", mine)  # …and track 2 has none
+    release = _release_2_tracks()
+    cover_art.cache_image(release["id"], _sized_jpeg(300, 300), "image/jpeg")
+
+    tagger.tag_album(album_dir, release)
+
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == mine
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == mine


### PR DESCRIPTION
An album whose tracks carry embedded art with no `cover.jpg` beside them — the shape an adopted library arrives in, and exactly the population #276 said the real wins were in — was ruled out before the archive's size was even considered. Two guards did it, both inherited from when the folder cover was the only thing that could be written: `preserved` was defined as *"no cover OR per-track art"*, and `archive_wins` asked for `cover is not None` on top of that.

The archive needs no folder cover to be a candidate. It is an image from outside the album, and the folder file is not what carries it.

## The page

`preserved` is split into the two facts it was conflating: `per_track`, the rule protecting user data, and "there is nothing to write from", which is about the folder cover and no longer stands in for the first. `album_best` is the album's own best from either carrier, so with no cover the tracks' image is the incumbent the archive has to beat.

A folder cover that cannot be **measured** still makes the answer unknown, deliberately: something is there, its size is not, and leaving it alone is the safe reading of that. That case is unchanged.

## The tagger, which could not ship separately

`decide_artwork` needed the same change or the page would promise what the button would not do (#283, #346). It also needed the read that feeds the per-track-art guard widened: `before` was gathered only when a folder cover existed — safe while the cover was the sole candidate, and it would have judged a coverless compilation on an empty dict.

The two halves are coupled. Widening the read is what lets the archive win at all, so neither ships alone, and the guard is no longer keyed on a folder cover being present.

## Deliberately not included

**Creating a `cover.jpg` where none exists.** Writing a new file into the user's album directory is an additive behaviour of its own, and `promote_cover` asks for a strict improvement on a folder cover that is not there to be improved on. Page and button agree on that too, and a test pins it.

**An album with no artwork at all.** `beats` needs both sizes to answer, so the archive still has to beat something measurable. That remains #269.

## Two consequences worth naming

- A coverless compilation now **reports** that it preserved per-track artwork, where it used to fall out through the early return and record nothing in the album's History (#260).
- Once there is a candidate to weigh, the album's own image is a real winner rather than the `None` a coverless album used to get — so #397's gap-filling reaches such an album. Additive, and only for tracks carrying nothing.

The gardener's path is unchanged in cost: an album with no cover and no cached archive image is still decided without opening a single file, and a test pins that too.

## Proof

Red-first on both rungs — the page (`test_artwork.py`) and the tagger (`test_tagger.py`) — and every new test mutation-checked. Two of them turned out to be held up by a mechanism other than the one their docstrings claimed; those docstrings now name what actually protects them, and the tagger's per-track test gained the assertion that does depend on the guard this changes.

`make check` green (1830 passed).

Fixes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH