### PR TITLE
Don't let a Cover Art Archive outage abandon a tagging run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ versions follow [semantic versioning](https://semver.org).
   answer MusicBrainz gave, and refreshes it in the background instead of making
   you wait for the fetch (#387).
 
+- A Cover Art Archive outage no longer abandons a re-tag. Harmonist falls
+  through to the release group and then to the artwork already in your files,
+  and if none of those serve an image it tags the album anyway and says the
+  cover was unavailable (#458).
+
 ## [1.16.0] - 2026-09-09
 
 ### Added

--- a/src/harmonist/cover_art.py
+++ b/src/harmonist/cover_art.py
@@ -54,15 +54,35 @@ def ensure_cover(
     for fresh / private Bandcamp releases not yet in CAA), fall back to art
     already embedded in the album's audio files. Returns None only when no
     cover is available from any source.
+
+    Raises `CoverArtError` only when the archive could not be *asked* and no
+    other rung served an image (#458). "I could not ask" and "there is nothing
+    there" are different answers, and collapsing them into None would let a
+    caller — and later #269's probe backoff — record an outage as a fact about
+    the release. Every rung is tried before that error is raised, because the
+    one that needs no network is the last one and it is the one an outage makes
+    most useful.
     """
     if cached := cached_cover(album_dir):
         return cached
 
-    fetched = _fetch_to_disk(album_dir, release_mbid, release_group_mbid, size, client=client)
+    # Remembered rather than propagated: the rung below needs no network, so an
+    # archive that cannot answer must not skip it. Re-raised at the end only if
+    # nothing else served an image.
+    unreachable: CoverArtError | None = None
+    try:
+        fetched = _fetch_to_disk(album_dir, release_mbid, release_group_mbid, size, client=client)
+    except CoverArtError as e:
+        unreachable = e
+        fetched = None
     if fetched is not None:
         return fetched
 
-    return _extract_embedded_cover(album_dir)
+    if (embedded := _extract_embedded_cover(album_dir)) is not None:
+        return embedded
+    if unreachable is not None:
+        raise unreachable
+    return None
 
 
 def _extract_embedded_cover(album_dir: Path) -> Path | None:
@@ -104,13 +124,25 @@ def _fetch_to_disk(
     owns_client = client is None
     http = client or httpx.Client(follow_redirects=True, timeout=DEFAULT_TIMEOUT)
 
+    # The first rung that failed for a reason that is NOT an answer. A 404 says
+    # "this release has no front cover" and the loop moves on having learned
+    # something; anything else says only that the archive could not be reached,
+    # which is not grounds for abandoning the rungs below it (#458). Kept so the
+    # caller can still tell the two apart once every rung is exhausted.
+    failure: CoverArtError | None = None
+
     try:
         for kind, mbid in targets:
             url = f"{CAA_BASE}/{kind}/{mbid}/front{suffix}"
             try:
                 resp = http.get(url)
             except httpx.HTTPError as e:
-                raise CoverArtError(f"CAA request failed for {url}: {e}") from e
+                # WARNING, not ERROR: another rung may still serve this album,
+                # and the caller raises if none does. `exc_info` here rather than
+                # on the eventual raise — this is where the traceback is.
+                log.warning("CAA: %s/%s unreachable (%s)", kind, mbid, e, exc_info=True)
+                failure = failure or CoverArtError(f"CAA request failed for {url}: {e}")
+                continue
 
             if resp.status_code == 404:
                 log.debug("CAA: no cover for %s/%s (404)", kind, mbid)
@@ -130,7 +162,10 @@ def _fetch_to_disk(
                 )
                 log.debug("CAA: wrote %s (%d bytes)", target, len(resp.content))
                 return target
-            raise CoverArtError(f"CAA returned status {resp.status_code} for {url}")
+            log.warning("CAA: %s/%s returned status %d", kind, mbid, resp.status_code)
+            failure = failure or CoverArtError(f"CAA returned status {resp.status_code} for {url}")
+        if failure is not None:
+            raise failure
         return None
     finally:
         if owns_client:

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -3174,12 +3174,35 @@ def _tag_with_release(
     # fact arriving beside them.
     requested_mbid, mbid = mbid, release["id"]
     rg = release.get("release-group") or {}
-    cover_path = cover_art.ensure_cover(
-        album_path,
-        release_mbid=release["id"],
-        release_group_mbid=rg.get("id"),
-        size=cfg.cover_art.size,
-    )
+    try:
+        cover_path = cover_art.ensure_cover(
+            album_path,
+            release_mbid=release["id"],
+            release_group_mbid=rg.get("id"),
+            size=cfg.cover_art.size,
+        )
+    except cover_art.CoverArtError:
+        # Tagging is the work; the cover is a side effect of it (#458). Design
+        # §"Cover art (mandatory)" already rules that an album with no cover
+        # available is tagged anyway — so an archive that could not ANSWER must
+        # not produce a worse outcome than one that answered "there is none".
+        # Losing a whole re-tag to a transient 503 is exactly that inversion.
+        #
+        # `cover_path=None` is a value the tagger already handles: `_prepare`
+        # reads no bytes, `write_tags` leaves every file's existing art alone,
+        # and no artwork change is recorded because none happens.
+        #
+        # Loud in both channels, because the two readers are different: the log
+        # is all there is at 3am, and the activity line is how someone who
+        # pressed a button finds out their album is now tagged without the cover
+        # it should have. Neither is a failure of the tagging, so neither claims
+        # to be one.
+        log.exception("cover art unavailable for %s — tagging without it", album_path)
+        activity.warning(
+            "Cover art unavailable — tagged without it",
+            album_id=sidecar_mod.album_id_for(album_path),
+        )
+        cover_path = None
     tagger.tag_album(
         album_path,
         release,

--- a/test/test_cover_art.py
+++ b/test/test_cover_art.py
@@ -165,6 +165,42 @@ def test_ensure_cover_returns_none_when_release_404_and_no_release_group(tmp_pat
     assert result is None
 
 
+def test_ensure_cover_falls_back_to_release_group_when_the_release_endpoint_is_down(tmp_path):
+    """#458: a 503 says nothing about whether this release has a cover, so it
+    must not end the ladder the way a 404's definitive "there is none" does.
+    The release-group rung is still worth asking."""
+    seen_urls = []
+
+    def handler(req):
+        seen_urls.append(str(req.url))
+        if "release-group" in str(req.url):
+            return httpx.Response(200, content=b"RG_JPEG", headers={"content-type": "image/jpeg"})
+        return httpx.Response(503)
+
+    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
+    assert result == tmp_path / "cover.jpg"
+    assert result.read_bytes() == b"RG_JPEG"
+    assert seen_urls == [
+        "https://coverartarchive.org/release/rel-123/front",
+        "https://coverartarchive.org/release-group/rg-456/front",
+    ]
+
+
+def test_ensure_cover_falls_back_to_release_group_after_a_transport_failure(tmp_path):
+    """#458, the other way the first rung fails. A refused connection reaches
+    `_fetch_to_disk` as an httpx error rather than a status, and used to raise
+    from a different line — so it needs its own proof that it now falls through."""
+
+    def handler(req):
+        if "release-group" in str(req.url):
+            return httpx.Response(200, content=b"RG_JPEG", headers={"content-type": "image/jpeg"})
+        raise httpx.ConnectError("connection refused")
+
+    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
+    assert result == tmp_path / "cover.jpg"
+    assert result.read_bytes() == b"RG_JPEG"
+
+
 # ---------- fallback to embedded art ----------
 
 
@@ -175,6 +211,20 @@ def test_ensure_cover_extracts_embedded_art_when_caa_misses(tmp_path):
 
     def handler(req):
         return httpx.Response(404)
+
+    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
+    assert result == tmp_path / "cover.jpg"
+    assert result.read_bytes() == _TINY_JPEG
+
+
+def test_ensure_cover_extracts_embedded_art_when_caa_is_down(tmp_path):
+    """#458: the embedded-art rung is the one that needs no network at all, so an
+    archive that cannot answer is the case it is most useful in — and the case it
+    used to be skipped in, because the 503 propagated past it."""
+    _flac_with_embedded_art(tmp_path, _TINY_JPEG)
+
+    def handler(req):
+        return httpx.Response(503)
 
     result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
     assert result == tmp_path / "cover.jpg"
@@ -210,6 +260,13 @@ def test_ensure_cover_none_when_caa_misses_and_audio_has_no_art(tmp_path):
 
 
 def test_ensure_cover_raises_on_non_404_failure(tmp_path):
+    """Once every rung has been tried and none of them served an image, the
+    archive's silence is reported rather than swallowed — "I could not ask" and
+    "there is nothing there" must not arrive as the same answer (#458). The
+    404 tests above are the other half of that pair: they return None, because a
+    404 IS an answer. `tmp_path` holds no audio, so the embedded rung has nothing
+    to offer and this really is the end of the ladder."""
+
     def handler(req):
         return httpx.Response(500, content=b"server explosion")
 
@@ -223,6 +280,20 @@ def test_ensure_cover_raises_on_network_error(tmp_path):
 
     with pytest.raises(CoverArtError):
         ensure_cover(tmp_path, "rel-123", client=_client(handler))
+
+
+def test_a_later_404_does_not_erase_an_earlier_could_not_ask(tmp_path):
+    """The release rung was unreachable and the release-group rung answered "no
+    art here". The album still has no cover AND the archive was never properly
+    asked about it, so this must raise rather than return None: returning None
+    would report a definitive "there is nothing for this release" that only one
+    of the two rungs is entitled to say (#458)."""
+
+    def handler(req):
+        return httpx.Response(404 if "release-group" in str(req.url) else 503)
+
+    with pytest.raises(CoverArtError):
+        ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
 
 
 # ---------- the candidate cache (#276) ----------

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3320,6 +3320,81 @@ def test_retag_re_runs_tagger(client, cfg, monkeypatch):
     assert loaded.tagged_at > datetime(2026, 1, 1, tzinfo=UTC)
 
 
+def test_retag_proceeds_when_the_cover_art_archive_is_unreachable(client, cfg, monkeypatch):
+    """#458: a CAA outage abandoned the whole tagging run — "Re-tag failed", no
+    tags written — for work that never needed the archive to answer. Design
+    §"Cover art (mandatory)" already settled it: with no cover available the
+    album is tagged anyway, without one."""
+    from datetime import datetime
+
+    from harmonist.cover_art import CoverArtError
+
+    d = _make_tagged_album(
+        cfg, "CaaDown", mbid="rel-1", tagged_at=datetime(2026, 1, 1, tzinfo=UTC), item_id=1
+    )
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release",
+        lambda mbid: _release_for_match(mbid, n_tracks=1),
+    )
+
+    def down(*a, **kw):
+        raise CoverArtError("CAA returned status 503 for https://coverartarchive.org/…/front")
+
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", down)
+
+    r = client.post(f"/retag/{_id_for(cfg, d)}")
+    assert r.status_code == 200
+    assert "Re-tag failed" not in r.text
+    # The tags are the point: the run has to have actually happened, not merely
+    # to have reported success.
+    loaded = sc.read(d)
+    assert loaded is not None
+    assert loaded.tagged_at is not None
+    assert loaded.tagged_at > datetime(2026, 1, 1, tzinfo=UTC)
+    # Degraded VISIBLY: the album is now tagged without the cover it should
+    # have, and the only way anyone finds that out is this line. Succeeding
+    # quietly here would trade a loud wrong outcome for a silent one.
+    assert [
+        e
+        for e in activity.recent(20)
+        if e.level == "warning" and "Cover art unavailable" in e.message
+    ]
+
+
+def test_retagging_with_the_archive_down_stays_a_no_op_the_second_time(client, cfg, monkeypatch):
+    """The degraded path has to be idempotent like the healthy one. Tagging
+    without a cover must not make the files look different on every attempt —
+    a re-tag that finds nothing changed writes nothing, CAA reachable or not."""
+    from datetime import datetime
+
+    from harmonist.activity_store import Source
+    from harmonist.cover_art import CoverArtError
+
+    d = _make_tagged_album(
+        cfg, "CaaDownTwice", mbid="rel-1", tagged_at=datetime(2026, 1, 1, tzinfo=UTC), item_id=1
+    )
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release",
+        lambda mbid: _release_for_match(mbid, n_tracks=1),
+    )
+
+    def down(*a, **kw):
+        raise CoverArtError("CAA returned status 503")
+
+    monkeypatch.setattr("harmonist.cover_art.ensure_cover", down)
+
+    def track_writes() -> int:
+        return len(
+            [e for e in activity_store.recent(200, source=Source.AUDIT) if "tag.track" in e.message]
+        )
+
+    aid = _id_for(cfg, d)
+    assert client.post(f"/retag/{aid}").status_code == 200
+    after_first = track_writes()
+    assert client.post(f"/retag/{aid}").status_code == 200
+    assert track_writes() == after_first
+
+
 def test_retag_works_on_an_album_confirmed_as_incomplete(client, cfg, monkeypatch):
     """#133: the tagger refuses file_count < track_count unless told the album is
     knowingly incomplete. /retag never told it, so re-tagging failed for exactly


### PR DESCRIPTION
A 503 from the Cover Art Archive aborted the whole re-tag — "Re-tag failed", no tags written — for work that never needed the archive to answer. One unreachable host cost three separate rungs and the operation the user actually asked for.

## What was wrong

`_fetch_to_disk` treated any non-2xx that wasn't a 404 as fatal. That is backwards: a 404 is a definitive *"this release has no front cover"* and the loop rightly moved on, while a 503 says only that the archive could not be reached. Raising on it skipped the release-group rung, propagated past `_extract_embedded_cover` — the rung that needs no network, and so the one an outage makes most useful — and finally out of `_tag_with_release` to the route's `except Exception`. On the album that prompted this, all 20 tracks carried the same embedded image that fallback would have used.

## What changed

**In the ladder.** A non-definitive answer (5xx, transport error) is remembered rather than raised, every rung is tried, and `CoverArtError` surfaces only once none of them served an image. Each failed rung logs at WARNING, since a later rung may still succeed.

This keeps *"I could not ask"* distinct from *"there is nothing there"* — the distinction `check_front` and `caa_cache` already guard, and the one #269's probe backoff will need. A 404 still returns `None`; only an unanswerable archive raises.

**At the call site.** `_tag_with_release` treats a cover it could not fetch as incidental to the work in progress (error-handling skill §2): log it with the traceback, record an activity warning against the album, and tag with `cover_path=None` — a value the tagger already handles, leaving every file's existing art alone. Design §"Cover art (mandatory)" already ruled that an album with no cover available is tagged anyway; an archive that could not answer must not produce a worse outcome than one that answered "none".

Deliberately *not* done: no swallowed `CoverArtError`, no widened catch, and no retry/backoff — that is a policy decision of its own and belongs in its own change.

## Proof

Four tests written red-first, each failing for the predicted reason (the cover-art ones at `cover_art.py:133`, the web one rendering the reported 503 string):

- release rung 503s → release-group rung still asked
- release rung refuses the connection → release-group rung still asked (a different raise site)
- CAA down at every rung → cover written from embedded art
- CAA unreachable → the re-tag completes and the tags land

Three assertions written *after* the fix, each mutation-checked to red and restored: the deferred `raise`, the activity warning, and the tagger's no-op guard. The last backs a review-gate item 7 idempotency test — a second re-tag with CAA still down writes no further `tag.track` rows.

`make check`: exit 0, 1856 passed.

## Notes for review

- This **widens #456's exposure**: the embedded-art fallback now fires where the 503 previously aborted, so there will be more `cover.write` audit rows — and they still carry no `album_id`, so they stay invisible on the album's History. Not a regression from this diff, but it makes #456 the natural next fix.
- **CAA requests on the failure path go from 1 to 2**, since the release-group rung is now tried after a 503. Bounded by a constant and identical to what the 404 path always spent, but it is more traffic to a service that just reported itself overloaded.
- **The activity warning repeats on every attempt** while CAA stays down. Judged honest rather than noisy — each attempt genuinely re-asked and genuinely failed — but easy to make once-per-album instead.

Fixes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
