### PR TITLE
Record cover writes against the album they land in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ versions follow [semantic versioning](https://semver.org).
   and if none of those serve an image it tags the album anyway and says the
   cover was unavailable (#458).
 
+- When Harmonist writes a `cover.jpg` into an album folder, that now shows up in
+  the album's own History like any other file it writes. The record was being
+  kept, but not against the album, so the one page you would look at never
+  showed it (#456).
+
 ## [1.16.0] - 2026-09-09
 
 ### Added

--- a/src/harmonist/cover_art.py
+++ b/src/harmonist/cover_art.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import httpx
 
-from . import activity_store, album_files, audit, formats, images
+from . import activity_store, album_files, audit, formats, id_registry, images, sidecar
 
 CAA_BASE = "https://coverartarchive.org"
 DEFAULT_TIMEOUT = 30.0
@@ -66,26 +66,56 @@ def ensure_cover(
     if cached := cached_cover(album_dir):
         return cached
 
+    album_id = _album_id_for_record(album_dir)
+
     # Remembered rather than propagated: the rung below needs no network, so an
     # archive that cannot answer must not skip it. Re-raised at the end only if
     # nothing else served an image.
     unreachable: CoverArtError | None = None
     try:
-        fetched = _fetch_to_disk(album_dir, release_mbid, release_group_mbid, size, client=client)
+        fetched = _fetch_to_disk(
+            album_dir, release_mbid, release_group_mbid, size, client=client, album_id=album_id
+        )
     except CoverArtError as e:
         unreachable = e
         fetched = None
     if fetched is not None:
         return fetched
 
-    if (embedded := _extract_embedded_cover(album_dir)) is not None:
+    if (embedded := _extract_embedded_cover(album_dir, album_id)) is not None:
         return embedded
     if unreachable is not None:
         raise unreachable
     return None
 
 
-def _extract_embedded_cover(album_dir: Path) -> Path | None:
+def _album_id_for_record(album_dir: Path) -> str:
+    """The id this album answers to right now, for the `cover.write` records
+    below (#456).
+
+    Read ONCE by `ensure_cover` and handed to whichever rung ends up writing.
+    Both rungs put a file in the user's album directory and both record it as
+    `cover.write`; taking the id in one place is what stops them drifting into
+    recording it differently, or a third rung arriving that forgets it entirely.
+
+    Mirrors `scanner._album_id`: the sidecar's MBID, else its temp_uid, else the
+    path-derived id. That last fall-back is the load-bearing part. A cover is
+    fetched BEFORE the tagging that will write the album's first sidecar, so on a
+    first tag `album_id_for` has nothing to read — and a bare None there would
+    leave exactly the albums most likely to gain a cover with no record of having
+    gained one. `id_registry.peek` is not a guess: it is a pure hash of the path,
+    it is what `sidecar.write()` then persists as `temp_uid`, and it is what the
+    scanner already calls the album meanwhile. So the record lands on the id the
+    album has, and the alias chain carries it forward when tagging replaces that
+    id with the MBID.
+
+    Deliberately NOT folded into `sidecar.album_id_for`, whose None means "this
+    album has no sidecar" — a distinction its other callers rely on.
+    """
+    return sidecar.album_id_for(album_dir) or id_registry.peek(album_dir)
+
+
+def _extract_embedded_cover(album_dir: Path, album_id: str) -> Path | None:
     """Write a folder cover from the first audio file that carries embedded
     art. Ensures a `cover.*` exists on disk even when CAA has no match."""
     for path in album_files.audio_files(album_dir):
@@ -101,7 +131,12 @@ def _extract_embedded_cover(album_dir: Path) -> Path | None:
         overwrote = target.exists()
         target.write_bytes(data)
         audit.record(
-            "cover.write", album=album_dir, file=target.name, source="embedded", overwrote=overwrote
+            "cover.write",
+            album_id=album_id,
+            album=album_dir,
+            file=target.name,
+            source="embedded",
+            overwrote=overwrote,
         )
         log.debug("cover: extracted embedded art from %s -> %s", path.name, target.name)
         return target
@@ -115,6 +150,7 @@ def _fetch_to_disk(
     size: str,
     *,
     client: httpx.Client | None,
+    album_id: str,
 ) -> Path | None:
     suffix = "" if size == "original" else f"-{size}"
     targets = [("release", release_mbid)]
@@ -153,6 +189,7 @@ def _fetch_to_disk(
                 target.write_bytes(resp.content)
                 audit.record(
                     "cover.write",
+                    album_id=album_id,
                     album=album_dir,
                     file=target.name,
                     source="caa",

--- a/test/test_cover_art.py
+++ b/test/test_cover_art.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+from harmonist import id_registry
 from harmonist.cover_art import CoverArtError, cached_cover, ensure_cover
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -72,11 +73,69 @@ def test_caa_cover_write_is_audited(tmp_path):
     album.mkdir()
     assert ensure_cover(album, "rel-1", client=_client(handler)) == album / "cover.jpg"
 
-    rows = [e.message for e in activity_store.recent(10, source=Source.AUDIT)]
-    line = next(m for m in rows if m.startswith("cover.write"))
-    assert "source=caa" in line
-    assert "overwrote=False" in line  # created, not replaced
-    assert "bytes=10" in line
+    rows = [e for e in activity_store.recent(10, source=Source.AUDIT)]
+    row = next(e for e in rows if e.message.startswith("cover.write"))
+    assert "source=caa" in row.message
+    assert "overwrote=False" in row.message  # created, not replaced
+    assert "bytes=10" in row.message
+    # The COLUMN, not the message (#456). Asserting the message alone is what let
+    # this ship: every field above was right while `album_id` was NULL, so the
+    # row was real, correct, and unreachable from the album whose directory it
+    # describes — `album_history` selects by id.
+    assert row.album_id == id_registry.peek(album)
+
+
+def test_embedded_cover_write_is_audited_against_the_album(tmp_path):
+    """The other rung that writes a file, and it needs the id just as much (#456)
+    — more, arguably, since it fires exactly when CAA had nothing to say and the
+    user is most likely to wonder where the image came from."""
+    from harmonist import activity_store
+    from harmonist.activity_store import Source
+
+    activity_store.init(tmp_path / "audit.db")
+    album = tmp_path / "album"
+    album.mkdir()
+    _flac_with_embedded_art(album, _TINY_JPEG)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    assert ensure_cover(album, "rel-1", client=_client(handler)) == album / "cover.jpg"
+
+    row = next(
+        e
+        for e in activity_store.recent(10, source=Source.AUDIT)
+        if e.message.startswith("cover.write")
+    )
+    assert "source=embedded" in row.message
+    assert row.album_id == id_registry.peek(album)
+
+
+def test_cover_write_is_recorded_against_the_sidecars_id_when_there_is_one(tmp_path):
+    """An album that already has an identity is recorded under THAT, not under
+    the path hash — otherwise the row lands on an id the album stopped answering
+    to the moment it was tagged, and `album_history` would need an alias that
+    was never recorded because the id never actually moved."""
+    from harmonist import activity_store, sidecar
+    from harmonist.activity_store import Source
+    from harmonist.models import Sidecar
+
+    activity_store.init(tmp_path / "audit.db")
+    album = tmp_path / "album"
+    album.mkdir()
+    sidecar.write(album, Sidecar(mb_release_id="rel-already-tagged"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"img", headers={"content-type": "image/jpeg"})
+
+    ensure_cover(album, "rel-already-tagged", client=_client(handler))
+
+    row = next(
+        e
+        for e in activity_store.recent(10, source=Source.AUDIT)
+        if e.message.startswith("cover.write")
+    )
+    assert row.album_id == "rel-already-tagged"
 
 
 def test_ensure_cover_uses_cache_without_network(tmp_path):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3718,6 +3718,62 @@ def test_activity_shows_album_label_even_when_link_is_dead(client, cfg):
     assert 'href="/album/' not in body  # ...but not a link
 
 
+def test_a_cover_written_before_tagging_reaches_the_albums_history(client, cfg, monkeypatch):
+    """#456, end to end and in the order it really happens.
+
+    The cover is fetched BEFORE the tagging that renames the album, so the row is
+    written under the temp_uid and the album answers to the MBID by the time
+    anyone looks. Both halves have to hold for the user to find it: the record
+    must carry an id at all, and the alias chain must carry that id forward.
+
+    The identity genuinely moves here — asserted, because a fixture whose id
+    never changed would pass this with the fix reverted, which is exactly how
+    #65's first regression test managed to prove nothing.
+    """
+    import httpx
+
+    from harmonist import cover_art
+
+    d = _make_album(cfg, "CoverThenTag")
+    sc.write(
+        d,
+        Sidecar(
+            store_url="https://x.bandcamp.com/album/cover-then-tag",
+            mb_match_candidate=MatchCandidate(
+                mb_release_id="rel-cover", confidence="exact", file_count=1, track_count=1
+            ),
+        ),
+    )
+    old_id = _id_for(cfg, d)
+    activity_store.clear()
+
+    # The cover lands first, under whatever the album is called right now.
+    cover_art.ensure_cover(
+        d,
+        "rel-cover",
+        client=httpx.Client(
+            transport=httpx.MockTransport(
+                lambda req: httpx.Response(
+                    200, content=b"COVERBYTES", headers={"content-type": "image/jpeg"}
+                )
+            ),
+            follow_redirects=True,
+        ),
+    )
+    assert (d / "cover.jpg").exists()
+
+    # Confirming tags it: temp_uid is dropped for the MBID and the old id dies.
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
+    )
+    assert client.post(f"/confirm/{old_id}").status_code == 200
+    new_id = _id_for(cfg, d)
+    assert new_id != old_id, "the identity has to move, or this proves nothing"
+
+    history = [e.message for e in activity_store.album_history(new_id)]
+    assert [m for m in history if m.startswith("cover.write")], history
+
+
 def test_album_page_shows_history_from_before_the_album_was_re_identified(client, cfg):
     """#103's reason for existing, and the consumer the alias table (#73) was
     built for: an album's records are spread across every id it has ever had.


### PR DESCRIPTION
A `cover.jpg` fetched into a user's album directory was audited without an `album_id`. The row was real, correct and durable — and unreachable from the one page anyone would look at, because `album_history` selects by id and this one had NULL. Harmonist was putting a 3 MB file into a music folder and the album's own History had nothing to say about it.

Found while re-tagging `XTC / Fossil Fuel: The XTC Singles 1977–92`, which gained a folder cover it never had.

## What changed

Both write paths — the CAA fetch and the embedded-art fallback — now record the album id. It is read **once** in `ensure_cover` and handed down, so the two paths cannot drift into recording it differently and a third rung cannot quietly arrive without one.

The id falls back to `id_registry.peek` when there is no sidecar to read. That half is load-bearing rather than defensive: the cover is fetched **before** the tagging that writes an album's first sidecar, so on a first tag there is nothing on disk to ask — and those are exactly the albums most likely to gain a cover. `peek` is not a guess. It is a pure hash of the path, it is the value `sidecar.write()` then persists as `temp_uid`, and it is already what the scanner calls the album meanwhile. So the record lands on the id the album really has, and the alias chain carries it forward when tagging swaps in the MBID.

## Why it shipped

`test_caa_cover_write_is_audited` asserted the message and never the column — and every field it checked was right. A partial record hides a gap better than no record does (`event-recording` §7). It now asserts the column.

#269 also states in its body that "both write paths already audit … so the record is in place", a conclusion reached by finding `audit.record` inside the function. That is corrected in a comment there.

## Proof

| Mutation | Expected | Result |
|---|---|---|
| helper returns `None` (the original bug) | all 4 tests red | 4 red |
| drop only the `peek` fallback | the 2 no-sidecar tests red, the sidecar'd ones green | exactly that |

The end-to-end test drives a real `temp_uid → MBID` transition and asserts the identity actually moved. `event-recording` §2 flags that a fixture whose id never changes passes this kind of test with the fix reverted — which is how #65's first regression test managed to prove nothing.

`make check`: exit 0, 1859 passed.

## Note for review

`scanner._album_id`'s rule (MBID, else temp_uid, else path hash) is now spelled out in a second place. The mirror is documented in `_album_id_for_record`'s docstring rather than unified, because folding the fallback into `sidecar.album_id_for` would change what its `None` means for its other callers. Worth a second opinion.

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
