### PR TITLE
Stop the CAA-unavailable warning reaching the feed twice

### DIFF
--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -3197,7 +3197,16 @@ def _tag_with_release(
         # pressed a button finds out their album is now tagged without the cover
         # it should have. Neither is a failure of the tagging, so neither claims
         # to be one.
-        log.exception("cover art unavailable for %s — tagging without it", album_path)
+        #
+        # `_LOG_ONLY` because `_ActivityLogHandler` mirrors every WARNING+ record
+        # on the `harmonist` logger into the feed, so without it this line lands
+        # there too and the album gets the same news twice (#461). The mirror is
+        # the copy worth losing: it carries this raw absolute path — a container
+        # path under Docker, which is why audit records are relativised — and no
+        # album id, so it floats attributed to nothing.
+        log.exception(
+            "cover art unavailable for %s — tagging without it", album_path, extra=_LOG_ONLY
+        )
         activity.warning(
             "Cover art unavailable — tagged without it",
             album_id=sidecar_mod.album_id_for(album_path),

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -3354,11 +3354,16 @@ def test_retag_proceeds_when_the_cover_art_archive_is_unreachable(client, cfg, m
     # Degraded VISIBLY: the album is now tagged without the cover it should
     # have, and the only way anyone finds that out is this line. Succeeding
     # quietly here would trade a loud wrong outcome for a silent one.
-    assert [
-        e
-        for e in activity.recent(20)
-        if e.level == "warning" and "Cover art unavailable" in e.message
-    ]
+    #
+    # Exactly ONE line, though (#461). `_ActivityLogHandler` mirrors every
+    # WARNING+ record on the `harmonist` logger into the feed, so the deliberate
+    # entry used to arrive beside an automatic copy of the `log.exception` —
+    # carrying a raw absolute path and no album, which is the one of the two a
+    # reader would have found least useful.
+    unavailable = [e for e in activity.recent(20) if "over art unavailable" in e.message]
+    assert len(unavailable) == 1, [e.message for e in unavailable]
+    assert unavailable[0].level == "warning"
+    assert unavailable[0].album_id, "attributed, so it reaches the album's History"
 
 
 def test_retagging_with_the_archive_down_stays_a_no_op_the_second_time(client, cfg, monkeypatch):


### PR DESCRIPTION
One re-tag against an unreachable Cover Art Archive put two entries in the Activity feed for the same fact:

```
ERROR   harmonist.activity: cover art unavailable for /private/var/.../music/Artist/CaaDown — tagging without it
WARNING harmonist.activity: Cover art unavailable — tagged without it
```

`_ActivityLogHandler` mirrors every WARNING+ record on the `harmonist` logger into the feed, so the `log.exception` added in #458 landed there beside the deliberate `activity.warning`.

The mirrored copy was the one worth losing. It carried the **raw absolute album path** — under Docker a container path that means nothing to the reader, which is precisely why `audit._rel` renders paths relative to the library root — and it had **no album id**, so it floated in the global feed attributed to nothing while the entry beside it was correctly attached to the album.

`extra=_LOG_ONLY` suppresses the mirror and nothing else. The server log keeps its ERROR and its traceback, which is all there is when this happens unattended at 3am:

```
ERROR   harmonist.web.main: cover art unavailable for … — tagging without it   (+ traceback)
WARNING harmonist.activity: Cover art unavailable — tagged without it
INFO    harmonist.activity: Re-tagged
```

## Proof

Red first: the existing #458 test now asserts **exactly one** feed entry mentions the unavailable cover, rather than merely that one exists. It failed with `assert 2 == 1`, printing both messages — which is also what confirmed the mirrored copy was the unattributed one.

Strengthening that assertion rather than adding a test: "there exists a warning" could never have caught this, and the two assertions would otherwise cover one path twice.

`make check`: exit 0, 1859 passed.

## No changelog entry

#458 has not shipped, so its `[Unreleased]` line already describes the behaviour users will actually meet, and no release ever carried the duplicate. An entry here would describe a bug nobody could have seen.

## Note for #344

This is the first instance of the duplicate-entry shape since #342, and it is one that #344's recommended guard cannot see — the duplication is one call deep, inside `_tag_with_release`, not on a handler's own return path. Commented there.

Fixes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
