### PR TITLE
Say when a re-tag is going to create a folder cover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ versions follow [semantic versioning](https://semver.org).
   kept, but not against the album, so the one page you would look at never
   showed it (#456).
 
+- An album page now says when a re-tag is going to create a `cover.jpg` the
+  album hasn't got, and where the image would come from — so the file arriving
+  is something you were told about rather than something you find afterwards
+  (#457).
+
 ## [1.16.0] - 2026-09-09
 
 ### Added

--- a/src/harmonist/artwork.py
+++ b/src/harmonist/artwork.py
@@ -334,6 +334,43 @@ class ArtworkView:
         return tuple(r for r in self.rows if r.image is not None)
 
     @property
+    def creates_cover_from(self) -> str | None:
+        """Where a RE-TAG would get the folder cover this album hasn't got,
+        named — or None when it has one, or when nothing could make one (#457).
+
+        Mirrors `cover_art.ensure_cover`'s ladder, which is the code that
+        actually writes the file: the archive first, then art already embedded
+        in the album's audio files.
+
+        Deliberately NOT a row, and deliberately not counted by `writes`. Rows
+        say what the album's images become and `writes` draws the Update artwork
+        button — and that button cannot do this. `tagger.update_artwork` only
+        ever promotes OVER an existing cover (it needs a `cover_path`); creating
+        one is `ensure_cover`, which only a tagging calls. A row would put a
+        button on the page promising a file it would not write, which is the one
+        thing this module exists to prevent.
+
+        A property rather than a field because `cover_unreadable` is applied by
+        `replace()` AFTER `summarise` returns. Computed here, the unreadable case
+        can never claim a cover is coming: there is a file on disk, `ensure_cover`
+        returns it without reading it, and nothing is written. As a field that
+        distinction depended on the caller setting two things in the right order.
+        """
+        if self.cover is not None or self.cover_unreadable:
+            return None
+        files = "the artwork already in your files"
+        tracks_have_art = bool(self.images)
+        if self.caa is None:
+            # Nobody has asked the archive. Both rungs are live, and the wording
+            # carries that rather than resolving it in either direction.
+            if tracks_have_art:
+                return f"the Cover Art Archive, or {files}"
+            return "the Cover Art Archive, if it has this release"
+        if self.caa.has_art:
+            return "the Cover Art Archive"
+        return files if tracks_have_art else None
+
+    @property
     def writes(self) -> bool:
         """Whether a re-tag would write anything at all.
 

--- a/templates/partials/_artwork.html
+++ b/templates/partials/_artwork.html
@@ -44,6 +44,29 @@
 </p>
 {% endif %}
 
+{# There is no cover.jpg, and re-tagging writes one (#457). Said BEFORE the fact
+   rather than discovered afterwards in the folder: the file is mandatory for
+   Navidrome (design §"Cover art"), so a tagging creates it whether or not
+   anyone pressed anything about artwork, and an unannounced 3 MB image
+   appearing in a music folder reads as Harmonist having done something it was
+   not asked to.
+
+   Attributed to RE-TAGGING specifically, not to "Harmonist": the Update artwork
+   button below cannot create this file, only replace one that exists, and a
+   sentence that blurred the two would send the reader to the wrong control.
+
+   Stated, not drawn as a row. A row would count toward `artwork.writes`, which
+   is what puts that button on the page — see `ArtworkView.creates_cover_from`.
+
+   Neutral, not amber: nothing is wrong here. The album is missing a file that
+   is about to arrive, which is the same register as the rest of the section. #}
+{% if artwork.creates_cover_from %}
+<p class="text-sm text-muted">
+    This album has no <code class="text-2xs">cover.jpg</code> beside its tracks.
+    Re-tagging creates one from {{ artwork.creates_cover_from }}.
+</p>
+{% endif %}
+
 {% macro image_cell(image, album_id, who) %}
     {# The image itself, or a frame where one is missing. The empty frame is the
        finding on an album whose tracks have lost their art, so it is drawn as

--- a/test/test_artwork.py
+++ b/test/test_artwork.py
@@ -643,3 +643,68 @@ class TestSummaryWording:
         view = artwork.summarise(album(same, None, None), cover_of(same))
 
         assert view.summary == "2 tracks are missing artwork."
+
+
+class TestAnnouncingACoverThatWillBeCreated:
+    """#457: a re-tag writes a `cover.jpg` into an album that hasn't got one —
+    mandatory for Navidrome, and so not gated on anything the user pressed. The
+    section had no way to say so, because the folder cover is modelled as a
+    carrier of an image and a carrier that doesn't exist yet carries nothing."""
+
+    Answer = TestCoverArtArchiveNote._Answer
+
+    def test_an_album_with_a_cover_is_told_nothing(self) -> None:
+        """`ensure_cover` returns an existing cover untouched — no rung runs, no
+        file is written, and there is no event to announce."""
+        one = art_of(1)
+        assert artwork.summarise(album(one), cover_of(one)).creates_cover_from is None
+
+    def test_the_archive_is_named_when_it_has_this_release(self) -> None:
+        view = artwork.summarise(album(art_of(1)), None, self.Answer(art=True))
+        assert view.creates_cover_from == "the Cover Art Archive"
+
+    def test_it_falls_to_your_own_files_when_the_archive_has_nothing(self) -> None:
+        """The second rung, and the one that needs no network. Naming the
+        archive here would promise an image that has been established not to
+        exist."""
+        view = artwork.summarise(album(art_of(1)), None, self.Answer(art=False))
+        assert view.creates_cover_from == "the artwork already in your files"
+
+    def test_nothing_is_promised_when_nothing_could_make_a_cover(self) -> None:
+        """No archive art and no embedded art: `ensure_cover` writes nothing, so
+        the section says nothing rather than announcing a file that isn't
+        coming."""
+        view = artwork.summarise(album(None, None), None, self.Answer(art=False))
+        assert view.creates_cover_from is None
+
+    def test_an_unasked_archive_names_both_rungs_rather_than_guessing(self) -> None:
+        """`caa is None` is "nobody has asked", not "there is nothing". Either
+        rung may serve, and the wording carries that."""
+        view = artwork.summarise(album(art_of(1)), None)
+        assert view.creates_cover_from == (
+            "the Cover Art Archive, or the artwork already in your files"
+        )
+
+    def test_an_unasked_archive_with_no_embedded_art_stays_conditional(self) -> None:
+        view = artwork.summarise(album(None), None)
+        assert view.creates_cover_from == "the Cover Art Archive, if it has this release"
+
+    def test_an_unreadable_cover_is_not_a_missing_one(self) -> None:
+        """The file IS there — `cached_cover` only checks that it exists, so
+        `ensure_cover` hands it back without reading it and writes nothing. The
+        view is built with `cover=None` and `cover_unreadable` set afterwards by
+        `replace()`, so this case reaches the same code as a genuinely absent
+        cover and has to be told apart from it (#112)."""
+        from dataclasses import replace
+
+        view = replace(artwork.summarise(album(art_of(1)), None), cover_unreadable=True)
+        assert view.creates_cover_from is None
+
+    def test_it_does_not_put_the_update_artwork_button_on_the_page(self) -> None:
+        """The load-bearing one. `writes` is what draws that button, and
+        `tagger.update_artwork` cannot create a folder cover — it only promotes
+        over one that exists. Counting this as a write would offer a control
+        that does not do what the sentence beside it just said."""
+        view = artwork.summarise(album(art_of(1)), None, self.Answer(art=True))
+        assert view.creates_cover_from  # there IS something to announce...
+        assert view.writes is False  # ...and still no button

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -9000,6 +9000,38 @@ def test_artwork_section_names_the_tracks_missing_art(client, cfg):
     assert "the album&#39;s own artwork" in rendered
 
 
+def test_artwork_section_says_a_folder_cover_is_about_to_be_created(client, cfg):
+    """#457: a re-tag writes a cover.jpg into an album that hasn't got one —
+    mandatory for Navidrome, so it happens whether or not anyone pressed
+    anything about artwork. The section said nothing, and a 3 MB image appearing
+    in a music folder read as Harmonist acting unasked."""
+    art = _png(1)
+    d = _album_with_art(cfg, "NoFolderCover", covers=[art, art])  # no `folder=`
+
+    rendered = " ".join(client.get(f"/album/{_id_for(cfg, d)}/artwork").text.split())
+
+    # Attributed to RE-TAGGING, not to the artwork button beside it, which
+    # cannot create this file at all.
+    assert "This album has no" in rendered
+    assert "Re-tagging creates one from" in rendered
+    # ...and that button stays off: nothing about the album's existing images
+    # changes, so offering the control would promise the sentence's outcome from
+    # a button that does not produce it.
+    assert "Update artwork" not in rendered
+
+
+def test_artwork_section_does_not_announce_a_cover_the_album_already_has(client, cfg):
+    """The control for the test above, and the reason it can fail: the same
+    album WITH a folder cover must say nothing, or the sentence is unconditional
+    text rather than a finding."""
+    art = _png(1)
+    d = _album_with_art(cfg, "HasFolderCover", covers=[art, art], folder=art)
+
+    rendered = " ".join(client.get(f"/album/{_id_for(cfg, d)}/artwork").text.split())
+
+    assert "Re-tagging creates one from" not in rendered
+
+
 def test_artwork_section_promises_no_overwrite_where_art_is_preserved(client, cfg):
     """A compilation's covers are kept, so no row may offer a replacement."""
     d = _album_with_art(cfg, "Compilation", covers=[_png(1), _png(2)], folder=_png(3))


### PR DESCRIPTION
The Artwork section could say "better artwork is available for `cover.jpg`". It could not say "there is no `cover.jpg`, and a re-tag will create one" — so that is what happened, unannounced. A 3 MB image appearing in a music folder reads as Harmonist having acted unasked, which is what prompted this.

The section models the folder cover as a **carrier of an image**, and a carrier that does not exist yet carries nothing: `ArtworkView.cover` is None and the summary's cover clause is gated on it being present.

## What it says

`ArtworkView.creates_cover_from` names where the image would come from, mirroring `cover_art.ensure_cover`'s own ladder — the archive first, then art already embedded in the files:

| Album | Sentence |
|---|---|
| Archive has this release | …creates one from **the Cover Art Archive** |
| Archive asked, has nothing; tracks have art | …from **the artwork already in your files** |
| Archive never asked; tracks have art | …from **the Cover Art Archive, or the artwork already in your files** |
| Archive never asked; no embedded art | …from **the Cover Art Archive, if it has this release** |
| Nothing could make a cover | *(nothing said — `ensure_cover` writes nothing)* |

`caa is None` means *nobody has asked*, not *there is nothing*, so the wording carries that rather than resolving it in either direction.

## Stated, not drawn as a row

This is the part worth reviewing. The issue suggested a row, like the artless-track gap row. That would be wrong: a row counts toward `writes`, and `writes` is what puts the **Update artwork** button on the page — a button that *cannot* do this. `tagger.update_artwork` only ever promotes over an existing cover (it needs a `cover_path`); creating one is `ensure_cover`, which only a tagging calls.

A row would have offered a control promising exactly the file the sentence beside it had just described. The sentence names **re-tagging** for the same reason. There is a test asserting the button stays off.

## A property, not a field

`_artwork_view` builds the view with `cover=None` and then applies `cover_unreadable=True` via `replace()`. So an album whose cover exists but cannot be *read* reaches the same code as one with no cover at all — and `ensure_cover` hands that file back unread and writes nothing, so announcing a new cover there would be flatly wrong. Computed from the finished view, that case cannot arise; as a field it depended on the caller setting two things in the right order.

## Proof

Three mutations, each red, each restored:

| Mutation | Result |
|---|---|
| Drop the `cover_unreadable` guard | unreadable test red |
| Let the announcement feed `writes` | button-stays-off test red |
| Disable the template block | announcement red, control green |

And demo mode, since pytest cannot tell whether it reads right: the one seeded album without a folder cover renders *"This album has no `cover.jpg` beside its tracks. Re-tagging creates one from the Cover Art Archive, if it has this release."* — the conditional wording confirmed correct, as its tracks genuinely carry no embedded art. Both albums with covers render nothing.

No `hx-*`, no JS, no behaviour change, so no e2e run: this is wording, which `web-ui` §6 puts below that bar. `make css` produced no drift.

`make check`: exit 0, 1869 passed.

Fixes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
