### PR TITLE
Keep a Cover Art Archive outage out of the Activity feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ versions follow [semantic versioning](https://semver.org).
   is something you were told about rather than something you find afterwards
   (#457).
 
+- A Cover Art Archive outage no longer fills the Activity feed. The optional
+  check that asks the archive what it holds now reports a failure to the log
+  only — the "CAA checked" date simply stops moving, which is the signal that
+  the check didn't happen — and pressing **load** for the archive's cover
+  reports a failure once instead of twice (#464).
+
 ## [1.16.0] - 2026-09-09
 
 ### Added

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -5099,7 +5099,28 @@ def _register_routes(app: FastAPI) -> None:
                 max_age=max_age,
             )
         except cover_art.CoverArtError:
-            log.exception("could not ask the Cover Art Archive about release %s", mbid)
+            # `_LOG_ONLY`, because the docstring above is the design and the feed
+            # is part of the UI (#464). At ERROR this was mirrored into the
+            # Activity tab by `_ActivityLogHandler` — so the banner this function
+            # is careful not to raise arrived there instead, once per album page
+            # opened while the archive was down, naming an MBID and attributed
+            # to no album. The stale "CAA checked" date is the signal, as below.
+            #
+            # WARNING, not ERROR: nothing was lost and nothing stopped working.
+            # The stored answer is intact and the check will be re-asked.
+            #
+            # The wording says what happened rather than what Harmonist didn't
+            # do. "Could not ask" is this module's term of art for keeping "I
+            # could not ask" apart from "the archive has nothing" — a
+            # distinction the CODE needs when deciding whether to overwrite a
+            # stored answer, and one no reader shares. `exc_info` carries the
+            # status and URL, which is the detail that message dropped.
+            log.warning(
+                "Cover Art Archive check failed for release %s — the stored answer is unchanged",
+                mbid,
+                exc_info=True,
+                extra=_LOG_ONLY,
+            )
 
     @app.post("/album/{album_id}/artwork/update", response_class=HTMLResponse)
     def album_artwork_update(request: Request, album_id: str) -> Response:
@@ -5187,7 +5208,14 @@ def _register_routes(app: FastAPI) -> None:
         try:
             cover_art.fetch_image(mbid, answer.image_url)
         except cover_art.CoverArtError as e:
-            log.exception("could not load the Cover Art Archive image for %s", mbid)
+            # `_LOG_ONLY` for the opposite reason to the check above: here a feed
+            # entry IS wanted, because someone pressed a button — but
+            # `_flash_response` is the authoritative writer of it, and at ERROR
+            # this line was mirrored in beside it as a second copy naming an
+            # MBID and attributed to nothing (#464). One press, one entry.
+            log.exception(
+                "could not load the Cover Art Archive image for %s", mbid, extra=_LOG_ONLY
+            )
             return _flash_response(
                 "Couldn't load the archive's cover", str(e), level=Level.ERROR, tasks_changed=False
             )

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -9353,6 +9353,12 @@ def test_a_check_that_failed_does_not_ask_the_page_to_try_again(client, cfg, mon
     assert r.status_code == 200
     assert "not yet" in rendered
     assert f"/album/{album_id}/artwork?check=1" not in rendered
+    # ...and the FEED is part of the UI (#464). This assertion is what the
+    # comment above always claimed and never checked: the report went out at
+    # ERROR, so `_ActivityLogHandler` mirrored it into the feed and the banner
+    # this function is careful not to raise arrived in the Activity tab instead —
+    # once per album page opened, naming an MBID, attributed to nothing.
+    assert not [e for e in activity.recent(20) if "Cover Art Archive" in e.message]
 
 
 def test_the_page_open_check_is_served_from_the_store_when_it_is_fresh(client, cfg, monkeypatch):
@@ -9534,6 +9540,12 @@ def test_a_failed_load_of_the_archives_cover_says_so(client, cfg, monkeypatch):
     # renders as is Jinja's business, not this feature's.
     assert "load the archive" in r.text
     assert "the archive is down" in r.text  # …and what actually went wrong
+    # ONE feed entry, not two (#464). The user pressed a button, so an entry is
+    # wanted — but `_flash_response` is the authoritative writer, and the ERROR
+    # log beside it was mirrored in as a second, unattributed copy naming an
+    # MBID. Same shape as #461, one route along.
+    archive_lines = [e for e in activity.recent(20) if "archive" in e.message.lower()]
+    assert len(archive_lines) == 1, [e.message for e in archive_lines]
 
 
 def test_loading_is_refused_when_the_archive_has_nothing_to_load(client, cfg):


### PR DESCRIPTION
Browsing albums while the Cover Art Archive was down filled the Activity feed:

```
could not ask the Cover Art Archive about release 3386aade-5462-4934-ac67-d7577e429d21
could not ask the Cover Art Archive about release 2916c6d5-1b3e-42a0-858d-17e34c9b41d1
```

One per album page opened, naming a raw MBID, attributed to no album, saying neither what went wrong nor that nothing was lost.

## The check

`_check_cover_art` reported its swallowed `CoverArtError` with `log.exception` — ERROR — and `_ActivityLogHandler` mirrors WARNING+ into the feed. Its own docstring is explicit that this is meant to be log-only:

> Loud in the log, per the unattended rule, and the panel's timestamp simply does not move — which is the honest signal that the check did not happen. […] a page that opened a red banner because the Internet Archive was slow this morning would be reporting a failure the user did not ask for and cannot act on.

The banner it avoids raising arrived in the Activity tab instead. `extra=_LOG_ONLY` restores the stated design, and WARNING replaces ERROR because nothing was lost or stopped working — the stored answer is intact and the check is re-asked.

**The wording** now says what happened rather than what Harmonist didn't do. "Could not ask" is this module's term of art for keeping *"I could not ask"* apart from *"the archive has nothing"* — a distinction the **code** needs when deciding whether to overwrite a stored answer, and one no reader shares. `exc_info` carries the status and URL that message dropped.

## The sibling, same fault and opposite remedy

Loading the archive's cover is a button press, so a feed entry **is** wanted there — but `_flash_response` already writes the readable, attributed one, and the ERROR log beside it was mirrored in as a second copy:

```
"Couldn't load the archive's cover — the archive is down"     ← the flash (wanted)
"could not load the Cover Art Archive image for rel-down"     ← the mirror (duplicate)
```

One press, one entry.

## Not doing

Giving the album page its own indication of a failed check. A stale "CAA checked" date is signal enough, and the panel already shows it.

## Proof

Red first, both. The check case was caught by `test_a_failed_check_does_not_ask_the_page_to_try_again`, whose comment already claimed *"loud in the log, silent in the UI"* and only ever checked the rendered HTML — the feed is part of the UI, so that is where the assertion went. Its failure output confirmed all three complaints at once: `Level.ERROR`, `album_id=None`, `Source.ACTIVITY`.

`make check`: exit 0, 1869 passed.

## One more instance, deliberately left out

A sweep of every mirrored `log.*` call in `web/main.py` (26 of them; most legitimately belong in the feed, which is what the mirror is for) turned up one further genuine duplicate at `web/main.py:4613` — the retag route's "MusicBrainz no longer has release" warning, logged at WARNING and then flashed. Same shape, fourth instance.

Left out because it is the MusicBrainz release-gone path with no existing test, and bundling a different feature's fix under a CAA-titled issue would make the history harder to read. Worth its own issue.

Fixes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6yao67HLdFxuEr4QdiAtH
