### PR TITLE
Draw the Artwork section from the plan its actions write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ versions follow [semantic versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- **A missing `cover.jpg` is now a row in the Artwork section**, showing the
+  image it will be created from, and **Apply artwork** (was *Update artwork*)
+  creates it (#467, #469).
+- **A folder cover Harmonist creates is the largest image on offer** — your
+  album's own artwork now beats a smaller Cover Art Archive image (#469).
+- **Artwork changes are labelled Addition or Replacement**, and only a
+  replacement asks you to confirm (#468).
+- **Re-tag and Apply artwork write only the artwork the page showed**; if it has
+  changed since, no artwork is written and the album page says so (#469).
+
+### Removed
+
+- **The Cover art size setting** — Harmonist always uses the Cover Art Archive's
+  original image (#469).
+
+### Fixed
+
+- **History names `cover.jpg` instead of counting it as a track** (#469).
+
 ## [1.16.1] - 2026-09-10
 
 ### Changed

--- a/docs/design.md
+++ b/docs/design.md
@@ -104,7 +104,7 @@ the whole reason the `NEEDS_SYNC` state exists.
 
 1. User edits a release in MB (track titles, dates, etc.) — or just wants to refresh tags.
 2. User clicks **Re-tag from MB** on a Library album's page.
-3. Harmonist re-fetches the MB release and rewrites the file tags. Artwork the album already carries is left alone — a re-tag only fills a track that has none. Replacing artwork is **Update artwork**, its own action in the Artwork section (#418).
+3. Harmonist re-fetches the MB release and rewrites the file tags. Artwork the album already carries is left alone — a re-tag only fills a track that has none. Replacing artwork is **Apply artwork**, its own action in the Artwork section (#418).
 4. If the release now lists **more** tracks than the album has files, the tagger's
    count guard refuses (§15.3) and the refusal is presented as a decision rather
    than an error: both counts, plus a **Re-tag as incomplete** control that
@@ -1052,9 +1052,9 @@ The levels, ordered by how much of the album they call into question:
 - **Enrichment** — MusicBrainz filling in or correcting a detail: `album_artist_sort`, `artist_sort`, `mb_album_status`, `mb_album_country`, `date`, `original_date`, `script`, `label`, `catalog_number`, `barcode`, `asin`, `disc_subtitle`, `media`, `isrcs`.
 - **Structure** — the same album, laid out differently: `track_num`, `track_total`, `disc_num`, `disc_total`.
 - **Identity** — what the album or one of its tracks *is*: `album`, `album_artist`, `album_artists`, `artist`, `artists`, `title`, `mb_album_type`, and every MusicBrainz id.
-- **Artwork** — the cover image. Its own level rather than a rank among the others, because "let it update my cover art" is a trust decision people make separately from anything about tags.
+**Artwork is not on this scale** (#469). The scale says how far a *metadata* change reaches, which says nothing about a picture. An image write is described by its **operation** instead (`artwork.Operation`): an **Addition** where the target held no image, a **Replacement** where it did — which is also whether there is anything for an Undo to put back. A plan doing both summarises as a Replacement. `significance_of` refuses the `artwork` key rather than rank it, so no trust setting over tag levels can come to authorise an image, and the gardener's diff never carries one (`plan_for` passes `artwork=False`).
 
-`SIGNIFICANCE` lives beside `SCOPE` in `owned.py` and is keyed exactly as a tagging diff is keyed — the `Owned` values plus `ARTWORK` — so a classifier iterating a plan's changes needs no special case for the one key that isn't an owned field. A totality test over that vocabulary is the point of the placement: **a field added to `Owned` later cannot slip through unclassified**, because the test fails until someone places it. The cost of forgetting `SCOPE` is a mis-rendered history row; the cost of forgetting this is a change whose significance nothing can state, in the table a trust setting is read through.
+`SIGNIFICANCE` lives beside `SCOPE` in `owned.py` and is keyed exactly as a tagging diff keys its owned fields. A totality test over that vocabulary is the point of the placement: **a field added to `Owned` later cannot slip through unclassified**, because the test fails until someone places it. The cost of forgetting `SCOPE` is a mis-rendered history row; the cost of forgetting this is a change whose significance nothing can state, in the table a trust setting is read through.
 
 **Every level currently goes to review.** `AUTO_APPLY` is empty and `needs_review` is true for everything. That is deliberate rather than unfinished: nothing has watched this classification run against a real library, and the way to find out whether `mb_album_type` really belongs under Identity is to see it arrive in the Inbox, not to argue it out in advance. Starting closed also means the first cut of the runner cannot write anything unattended, whatever else is wrong with it. `AUTO_APPLY` is the seam #273 turns into a setting: a user who trusts Enrichment gets that level in the set, and everything else keeps going to review.
 
@@ -1096,7 +1096,7 @@ Embedding a cover overwrites whatever image the track already carried, and that 
 
 **Content-addressed files, not database rows.** Cover art runs 200 KB–5 MB per track and is mostly identical between tracks of one album, so the natural handling is dedup by digest: an eight-track album usually costs one file, not eight. Keeping the bytes out of `activity.db` also keeps that store cheap to poll, since it is read on every feed refresh. The digest recorded by the tagging audit *is* the lookup key, so the store needs no index of its own.
 
-**Only what is about to be destroyed.** The copy is taken *after* the per-track-art decision, not during the digest pass — `_has_per_track_art` can still cancel the embed, and an image that survives has no business being backed up. So `_keep_doomed_art` re-reads only the files whose art differs from the incoming cover, and an album already carrying that cover reads nothing at all.
+**Only what is about to be destroyed.** The copy is taken from the plan's *targets* — the files an action will really write — not from every file whose art differs from the winner: a tagging makes additions only, so an image it leaves in place is not being destroyed and has no business being backed up. `_keep_doomed_art` re-reads only those files, and an album already carrying the winner reads nothing at all.
 
 **Bounded, and honest about it.** The store has a size cap (default 500 MB) and evicts oldest-first, which makes restore best-effort by design: an old enough change becomes unrevertable. The album page checks availability *before* rendering, so no Undo button is offered for a change whose image has gone — a button that would fail is worse than none. Usage is shown in Settings, because "how much disk is this costing me" is the question the cap exists to answer.
 
@@ -1136,19 +1136,17 @@ Artwork is not in the plan: it is not an owned tag, and it has its own store, it
 
 Plex with the MusicBrainz agent can fetch its own artwork from external sources, but **Navidrome does not** — it reads from embedded tags and `cover.jpg` only. Navidrome is the strict consumer; we design for it.
 
-**The tagger always:**
+**One plan decides every image an album carries** (`artwork.plan`, #469). It is built from descriptions — each track's embedded image, the folder cover, and the Cover Art Archive's candidate — and names every write that would put the winning image in place: the target, what it holds now (or that it holds nothing), and what it will hold. The album page draws its Artwork section from the plan; a tagging and the Apply artwork action execute it (`tagger.apply_artwork`, and the tag loop for gap fills). Nothing decides twice — the page used to carry its own copy of the size rule, and it drifted from the writer's.
 
-1. Fetches the front cover from the [Cover Art Archive](https://coverartarchive.org) using the MB release ID:
-   - `GET https://coverartarchive.org/release/{mbid}/front` (follows redirects to the actual image)
-   - If unavailable, falls back to `release-group/{mbgid}/front` (release-group-level art).
-   - If CAA has nothing (common for a fresh / private Bandcamp release not yet in CAA), falls back to art **already embedded** in one of the album's audio files — Bandcamp downloads ship with cover art baked in, so this guarantees a folder `cover.*` even off-CAA.
-   - If still nothing (no CAA match, no embedded art), the album is tagged but with no cover; logged, surfaced in the inbox.
-2. Embeds the image in every track's `covr` atom (`mutagen.mp4.MP4Cover` with `FORMAT_JPEG` or `FORMAT_PNG`).
-3. Writes the same image to `<album_dir>/cover.jpg` (or `.png`, matching format) for tools that prefer the sidecar (Navidrome, MPD, foobar2000, etc.).
+1. **Candidates.** The archive's front cover for the release (`GET https://coverartarchive.org/release/{mbid}/front`), falling back to the release group's — always the original. A tagging asks for it only when the album has no folder cover, the one request a tagging has always spent (`cover_art.front_image`); otherwise it weighs whatever the album page's check has cached (`cached_front`). The candidate lives in a cache outside the library, and fetching it writes nothing into the album. An archive that cannot be reached is not a reason to abandon the tagging (#458).
+2. **The largest image wins** (`artwork.beats`): strictly larger on both axes, ties to what is already there, and an unmeasurable image never displaces anything — though any image beats none. Per-track artwork (tracks carrying *different* images) is never overwritten.
+3. **Operations.** Each write is an **Addition** — an artless track, or a folder cover the album lacks — or a **Replacement**. A tagging may make additions only (#418); the Apply artwork action makes both. A missing folder cover is created from the winner, as `cover.jpg` or `cover.png` to match it, so an album whose tracks carry a 3000px image is not given a 1200px archive cover. A compilation's folder cover comes only from the archive: its first sleeve is not the album's cover.
+4. **Revalidation.** The page carries a fingerprint of what it showed — the additions for Re-tag from MB, the whole plan for Apply artwork. The action rebuilds the plan from disk and proceeds only if it matches: Apply artwork otherwise writes nothing and redraws the section, and a re-tag writes its tags and no artwork, with a warning in the album's History. Each target is also re-read immediately before it is written, and one that no longer holds what the plan saw is left alone and reported. A tagging nobody previewed (exact-match auto-tagging, confirmation, recheck) carries no fingerprint and writes its plan's additions.
+5. **Records.** Every image written is recorded as an `artwork` before/after pair on a `tag.track` line — `[None, digest]` for an addition, including a created folder cover — and a folder cover also gets a `cover.write` audit line.
 
-**Resolution policy:** `original` (full CAA resolution). Lossless audio is the dominant cost in this library; an extra 10 MB of cover art per album is negligible by comparison. Configurable via `size` under `[cover_art]` in `harmonist.toml` (`250 | 500 | 1200 | original`) so a constrained deployment can downsize, but this is not the primary use case. Library-wide cover-art optimisation (clipping / recompressing) is a separate, future enhancement — not in scope here.
+If nothing is available — no archive image and no embedded art — the album is tagged without a cover.
 
-**Caching:** the downloaded image goes to `<album_dir>/cover.<ext>` first, and the embed step reads it from there. This means re-tagging an album doesn't refetch CAA, and the user can manually replace `cover.jpg` to override the embedded art on next retag.
+**Resolution policy:** always the archive's `original`. The largest available image is the one Harmonist prefers, and it is the one the album page measures, so a preview and the tagging that follows compare the same picture. (The former `[cover_art] size` setting is no longer read; an old `harmonist.toml` naming it still loads.) Library-wide cover-art optimisation (clipping / recompressing) is a separate, future enhancement.
 
 ---
 
@@ -1172,8 +1170,9 @@ src/harmonist/
   mb_search.py          MB free-text search (manual-ingest path)
   match.py              Disk-vs-MB comparison (assess_match): confidence + per-track deltas
   compare.py            Field-by-field tag-vs-MB comparison primitives (Tags section + tracklist)
-  tagger.py             Picard-compatible tag writer (+ embedded cover), and the undo of one (#157)
-  cover_art.py          Cover Art Archive fetch + cover.* writing
+  tagger.py             Picard-compatible tag writer, the artwork plan's reader and executor, and undo (#157)
+  artwork.py            The artwork plan — which image wins, and every write it takes (#469) — and the Artwork section's view of it
+  cover_art.py          Cover Art Archive fetch + the candidate cache (writes nothing into an album)
   caa_cache.py          TTL cache over cover_art's front-cover check, in activity.db (#436)
   formats/              Per-format tag I/O (m4a, mp3, flac, ogg, opus; _vorbis shared; types)
                         owned.py names the tags Harmonist writes, per-album vs per-track

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -86,7 +86,6 @@ user_agent = "Harmonist/1.0 ( you@example.com )"
 cache_ttl_seconds = 3600          # re-serve a fetched release for this long
 
 [cover_art]
-size = "original"                 # what to fetch from the Cover Art Archive
 cache_ttl_seconds = 604800        # re-serve a stored archive answer for a week
 
 [library]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -366,7 +366,7 @@ reaches — *Enrichment* for a catalogue number MusicBrainz has filled in,
 *Identity* for a release that has been merged into another. **Re-tag from MB**
 sits on that line, at the end of it, because it is the answer to that sentence.
 Artwork that could be better is a second finding in the same section, with
-**Update artwork** on its own line in the same way. At the foot of the section,
+**Apply artwork** on its own line in the same way. At the foot of the section,
 quieter than either button, are the two other answers: a checkbox that waits for
 an edit to land — *Ignore until MusicBrainz changes* — and a link to MusicBrainz
 to make one. An album where everything matches gets no section — the **Checked**
@@ -446,26 +446,44 @@ Some things it shows that are worth recognising:
 
 ### What would change, and the button that changes it
 
-Where a re-tag or an artwork update would alter a row, the section shows what it
-would become on the right, under **After a re-tag** — the picture itself, not a
-description of it.
+Where applying the artwork would alter a row, the section shows what it would
+become on the right, under **After Apply** — the picture itself, not a
+description of it. An album with no `cover.jpg` gets a row for the file it
+hasn't got: an empty frame, and beside it the image it would be created from.
 
 **The largest image wins.** Between what your tracks carry, what `cover.jpg`
 holds, and what the Cover Art Archive has, the one with the most pixels is the
-one Harmonist writes. A same-sized different picture is not an improvement and
-is left alone.
+one Harmonist writes — including into a `cover.jpg` it creates. A same-sized
+different picture is not an improvement and is left alone. When an album has no
+artwork at all, the archive's image is downloaded as soon as the page asks about
+it, so the preview can show the picture it would add.
 
-Two separate actions, deliberately:
+Each artwork change is labelled by what it does:
 
-- **A re-tag fills gaps and never replaces an image you already have.** A track
-  carrying nothing gets the album's cover; a track that has one keeps it. An
-  album with no `cover.jpg` at all gets one written beside its tracks, and the
-  section says so beforehand, naming where that image would come from.
-- **Update artwork**, in this section, is what replaces. It writes the winning
-  image to every track and to the folder cover, and touches no tags at all.
+- **Addition** — the image lands where there was none: a track without
+  artwork, or a folder cover the album hasn't got.
+- **Replacement** — it overwrites an image you already have. What is replaced
+  is kept first, so it can be undone from History. A change that does both is
+  labelled a Replacement.
 
-They are separate because replacing artwork is the change you are most likely to
-want to undo on its own — and it has always had its own Undo in History.
+Two actions write artwork, deliberately:
+
+- **A re-tag makes additions only.** A track carrying nothing gets the album's
+  best image and a missing `cover.jpg` is created beside the tracks; a track
+  that has an image keeps it.
+- **Apply artwork**, in this section, makes additions and replacements alike,
+  and touches no tags at all. It asks first only when it would replace
+  something.
+
+Both write only what the page showed. If the album's artwork changed after the
+page was drawn — an image edited elsewhere, or the archive's answer arriving
+late — **Apply artwork** writes nothing and redraws the section, and a re-tag
+writes its tags but no artwork, saying why in the album's History.
+
+Replacing artwork is the change you are most likely to want to undo on its own,
+which is why it has its own Undo in History. Undoing an addition — taking an
+image back off a track that had none, or removing a `cover.jpg` Harmonist
+created — is not offered yet.
 
 ### Asking the Cover Art Archive
 
@@ -504,7 +522,7 @@ It changes nothing about what a re-tag would write; it is there so you can see
 what you are turning down.
 
 When the archive's cover *is* larger, it is fetched without being asked, shown
-beside your own with the MusicBrainz hexagon, and **Update artwork** will write
+beside your own with the MusicBrainz hexagon, and **Apply artwork** will write
 it.
 
 ### Getting artwork back

--- a/src/harmonist/artwork.py
+++ b/src/harmonist/artwork.py
@@ -13,18 +13,27 @@ showing it only as an incoming value made a file already on disk read as
 something arriving from outside, and left the reader asking which of the two
 images was about to be replaced.
 
-Each row also says what a re-tag would do to it — the decision `tagger._prepare`
-already makes and used to keep to itself, reached here through the same
-predicate so the page and the button cannot disagree. Rows where nothing is
+Each row also says what applying the artwork would do to it — read off the
+`ArtworkPlan` below, which is the same object the writer executes (#469). The
+page used to reach that verdict with its own copy of the size rule, and the two
+copies drifted: an unmeasurable folder cover made the page promise to replace
+the tracks while the writer filled their gaps instead. Rows where nothing is
 written say nothing at all: agreement is silence everywhere else on this page,
 and a column of "left as is" on a 37-image box set is 37 boxes of noise.
+
+Display and actionability are separate facts (#467). A row exists because the
+album HAS something to show — an image, a gap, an absent folder cover that is
+about to be created — and its right-hand side exists because the plan names a
+write there. Neither is derived from the other.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+import hashlib
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pathlib import Path
 from typing import Protocol
 
 from .formats import TrackTags
@@ -98,8 +107,285 @@ def beats(mine: Size | None, theirs: Size | None) -> bool:
     return mine.width > theirs.width and mine.height > theirs.height
 
 
+# ---------------------------------------------------------------------------
+# The plan: what an album's images become, decided once (#418, #469)
+# ---------------------------------------------------------------------------
+
+
+class Operation(StrEnum):
+    """What one artwork write does to its target (#468).
+
+    Not a rank beside the tag levels. A tag change is described by how far it
+    reaches; an image is described by whether the place it lands already held
+    one — which is also what decides whether there is anything for an Undo to
+    put back.
+    """
+
+    #: The target carried no image: an artless track, or a folder cover that
+    #: does not exist yet.
+    ADDITION = "addition"
+    #: The target carried a different image, which this write overwrites.
+    REPLACEMENT = "replacement"
+
+
+class Source(StrEnum):
+    """Where the image a plan writes comes from — the three candidates an album
+    can offer (#276, #410)."""
+
+    #: The `cover.*` beside the tracks.
+    FOLDER = "folder"
+    #: The one image the tracks themselves carry.
+    ALBUM = "album"
+    #: The Cover Art Archive's front cover for the release, from the local cache.
+    ARCHIVE = "archive"
+
+
+class Scope(StrEnum):
+    """Which of a plan's changes an action may make.
+
+    The plan says everything the winning image implies; an action takes the
+    part of it that action is allowed to write. A tagging fills what is empty
+    and replaces nothing (#418); the artwork action does both.
+    """
+
+    ADDITIONS = "additions"
+    ALL = "all"
+
+
+@dataclass(frozen=True)
+class Change:
+    """One write the plan makes: a target, what it holds now, what it will hold.
+
+    `before` is None where the target holds no image at all — an artless track,
+    or a folder cover that does not exist. Digests on both sides, because that
+    is what the History records and the artwork store key on.
+    """
+
+    target: Path
+    before: str | None
+    after: str
+    folder_cover: bool = False
+
+    @property
+    def operation(self) -> Operation:
+        return Operation.ADDITION if self.before is None else Operation.REPLACEMENT
+
+
+@dataclass(frozen=True)
+class ArtworkPlan:
+    """What should happen to an album's images, as the writes that do it.
+
+    The single answer, consumed by the album page, the tagging, and the artwork
+    action alike (#469). Each of those used to reach its own verdict — the page
+    through a copy of the size rule, the tagging and the button through
+    `tagger.decide_artwork`, and the folder cover's creation through
+    `cover_art.ensure_cover` before any of them had looked — and a page
+    describing one decision while the writer made another is the bug class
+    this replaces.
+
+    `changes` is everything the winner implies. An action narrows it with
+    `scoped`; nothing narrows it by deciding again.
+    """
+
+    album_dir: Path
+    #: Every readable track's current image as a digest, or None where it has
+    #: none. Unreadable tracks are absent: a file nobody could open carries no
+    #: evidence, and is never a target.
+    before: Mapping[Path, str | None] = field(default_factory=dict)
+    #: The image being written, and where it comes from. None when nothing is.
+    winner: EmbeddedArt | None = None
+    source: Source | None = None
+    changes: tuple[Change, ...] = ()
+    #: The tracks carry differing images and are being left alone — a decision
+    #: worth reporting rather than a silent no-op (#260).
+    preserves_per_track_art: bool = False
+
+    def scoped(self, scope: Scope) -> tuple[Change, ...]:
+        """The changes `scope` permits."""
+        if scope is Scope.ALL:
+            return self.changes
+        return tuple(c for c in self.changes if c.operation is Operation.ADDITION)
+
+    def track_targets(self, scope: Scope) -> frozenset[Path]:
+        """The tracks `scope` writes to."""
+        return frozenset(c.target for c in self.scoped(scope) if not c.folder_cover)
+
+    def cover_change(self, scope: Scope) -> Change | None:
+        """The folder cover's write under `scope`, if it has one."""
+        return next((c for c in self.scoped(scope) if c.folder_cover), None)
+
+    def operation(self, scope: Scope) -> Operation | None:
+        """The summary of what `scope` would do: Replacement if anything is
+        overwritten, Addition if everything written lands where nothing was,
+        None if nothing is written. A mixed plan summarises as Replacement —
+        that is the half a reader deciding whether they mind needs to hear."""
+        changes = self.scoped(scope)
+        if not changes:
+            return None
+        if any(c.operation is Operation.REPLACEMENT for c in changes):
+            return Operation.REPLACEMENT
+        return Operation.ADDITION
+
+    def fingerprint(self, scope: Scope) -> str:
+        """A digest of exactly what `scope` would write, target by target.
+
+        What a reviewed page carries back to the server: the action rebuilds
+        its plan from disk and proceeds only if this matches, so an image edited
+        since the page was drawn, or a candidate that changed, cannot be written
+        under a preview that described something else.
+
+        Names are relative to the album, so the page — which reads through the
+        album — and the tagger — which reads through its file list — spell the
+        same target the same way.
+        """
+        lines = sorted(
+            f"{self._name(c.target)}\t{c.before or ''}\t{c.after}" for c in self.scoped(scope)
+        )
+        return hashlib.sha256("\n".join(lines).encode()).hexdigest()
+
+    def _name(self, path: Path) -> str:
+        try:
+            return path.relative_to(self.album_dir).as_posix()
+        except ValueError:
+            return path.name
+
+
+def cover_name_for(mime: str) -> str:
+    """The name a created folder cover takes: `cover.png` for a PNG, else
+    `cover.jpg` — the two names `cover_art.cached_cover` looks for."""
+    return "cover.png" if "png" in mime.lower() else "cover.jpg"
+
+
+def plan(
+    album_dir: Path,
+    tracks: Sequence[tuple[Path, EmbeddedArt | None]],
+    cover: FolderCover | None,
+    archive: EmbeddedArt | None = None,
+    *,
+    overwrite_art: bool = False,
+    cover_unreadable: bool = False,
+) -> ArtworkPlan:
+    """Which image wins, and every write it takes for it to be everywhere.
+
+    Pure: descriptions in, a plan out. The caller reads — the album page from
+    the tags it already has, the tagger from the files — and both reach the same
+    plan because both come through here.
+
+    THE LARGEST IMAGE WINS among the three an album can offer: what its tracks
+    carry, what its folder holds, and what the Cover Art Archive has cached
+    (#276, #410). Strictly larger on both axes (`beats`), so a tie goes to what
+    is already there and an unmeasurable challenger never displaces anything.
+    An image does beat NOTHING, though: an album with no artwork anywhere takes
+    whatever candidate exists.
+
+    `overwrite_art` opts out of the comparison: the user asked for the folder
+    cover to be embedded, not judged.
+
+    A missing folder cover is a target like any other, created from the winner
+    (#457). What it is created FROM is the size rule's answer rather than a
+    ladder of its own, so an album with a 3000px image in its tracks is no longer
+    given a 1200px `cover.jpg` it then offers to replace.
+
+    Per-track artwork is user data and nothing overwrites it. The one write
+    such an album can still receive is a folder cover it lacks, and only from
+    the archive — a compilation's first sleeve is not the album's cover.
+
+    `cover_unreadable` is a folder cover that exists and could not be read. The
+    plan is then empty: nothing can be decided about a file nobody saw, and a
+    plan that treated it as absent would create a second cover beside it.
+    """
+    before = {path: (art.digest if art is not None else None) for path, art in tracks}
+    if cover_unreadable:
+        return ArtworkPlan(album_dir=album_dir, before=before)
+
+    if overwrite_art:
+        if cover is None:
+            return ArtworkPlan(album_dir=album_dir, before=before)
+        return _plan_for(album_dir, before, cover, cover.image, Source.FOLDER)
+
+    if has_per_track_art(before.values()):
+        if cover is None and archive is not None:
+            return _plan_for(
+                album_dir, {}, None, archive, Source.ARCHIVE, before=before, preserves=True
+            )
+        return ArtworkPlan(album_dir=album_dir, before=before, preserves_per_track_art=True)
+
+    own = next((art for _, art in tracks if art is not None), None)
+    winner: EmbeddedArt | None = None
+    source: Source | None = None
+    if cover is not None:
+        winner, source = cover.image, Source.FOLDER
+    # With no folder cover the tracks' image is the incumbent, measurable or not
+    # — there is nothing for it to beat. Against a folder cover it wins unless
+    # the cover is strictly larger, which is where ties to the tracks come from
+    # (#397): `tagger` has always resolved it that way.
+    if own is not None and (
+        cover is None
+        or (
+            own.digest != cover.image.digest
+            and own.size is not None
+            and (cover.image.size is None or not beats(cover.image.size, own.size))
+        )
+    ):
+        winner, source = own, Source.ALBUM
+    if archive is not None and (winner is None or beats(archive.size, winner.size)):
+        winner, source = archive, Source.ARCHIVE
+    if winner is None or source is None:
+        return ArtworkPlan(album_dir=album_dir, before=before)
+    return _plan_for(album_dir, before, cover, winner, source)
+
+
+def _plan_for(
+    album_dir: Path,
+    targets: Mapping[Path, str | None],
+    cover: FolderCover | None,
+    winner: EmbeddedArt,
+    source: Source,
+    *,
+    before: Mapping[Path, str | None] | None = None,
+    preserves: bool = False,
+) -> ArtworkPlan:
+    """Every write that puts `winner` on `targets` and on the folder cover.
+
+    The folder file catches up only on a strict improvement: it is the one
+    write here the tracks cannot be used to undo, so a same-sized different
+    picture stays where it is.
+    """
+    changes = [
+        Change(target=path, before=digest, after=winner.digest)
+        for path, digest in targets.items()
+        if digest != winner.digest
+    ]
+    if cover is None:
+        changes.append(
+            Change(
+                target=album_dir / cover_name_for(winner.mime),
+                before=None,
+                after=winner.digest,
+                folder_cover=True,
+            )
+        )
+    elif cover.image.digest != winner.digest and beats(winner.size, cover.image.size):
+        changes.append(
+            Change(
+                target=cover.path or album_dir / cover.name,
+                before=cover.image.digest,
+                after=winner.digest,
+                folder_cover=True,
+            )
+        )
+    return ArtworkPlan(
+        album_dir=album_dir,
+        before=before if before is not None else targets,
+        winner=winner,
+        source=source,
+        changes=tuple(changes),
+        preserves_per_track_art=preserves,
+    )
+
+
 class Outcome(StrEnum):
-    """What a re-tag would do to one row's image.
+    """What applying the artwork would do to one row's image.
 
     Only the first two reach the page. The other two are the two ways of writing
     nothing, kept apart because they are different facts — one is a protection,
@@ -107,11 +393,14 @@ class Outcome(StrEnum):
     deserves the real answer.
     """
 
-    #: This image is replaced by the folder cover.
+    #: This image is replaced by the winner.
     REPLACED = "replaced"
-    #: These tracks have no image; the folder cover fills the gap.
+    #: These tracks have no image, or the folder cover does not exist; the
+    #: winner fills the gap.
     FILLED = "filled"
-    #: Per-track artwork Harmonist preserves.
+    #: Left as it is though it is not the folder cover's image — per-track
+    #: artwork Harmonist preserves, an album image that won or tied against the
+    #: folder cover, or a gap with nothing to fill it.
     KEPT = "kept"
     #: Already the folder cover, or the folder cover itself. Nothing changes.
     SAME = "same"
@@ -138,6 +427,9 @@ class FolderCover:
 
     name: str
     image: EmbeddedArt
+    #: Where it is, when that is not simply `name` in the album's directory — a
+    #: caller holding the real path hands it over rather than have it rebuilt.
+    path: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -215,6 +507,11 @@ class ArtRow:
     #: no tense — a reader cannot tell whether it already happened — and the
     #: picture on the right under a dated heading is what settles that.
     written_image: EmbeddedArt | None = None
+    #: The name of a folder cover that does not exist and that the plan will
+    #: create (#457). A row rather than a sentence, because an absent carrier
+    #: about to gain an image is a gap like an artless track, and a gap is the
+    #: finding.
+    creates: str | None = None
 
     @property
     def is_gap(self) -> bool:
@@ -222,7 +519,7 @@ class ArtRow:
 
     @property
     def writes(self) -> bool:
-        """Whether a re-tag would put something here. The rows that answer False
+        """Whether the plan puts something here. The rows that answer False
         render nothing on the right at all (#400)."""
         return self.outcome in (Outcome.REPLACED, Outcome.FILLED)
 
@@ -257,6 +554,8 @@ class ArtRow:
         A track with no number at all falls back to a count: an unnumbered file
         cannot be pointed at by position.
         """
+        if self.creates:
+            return self.creates
         n = len(self.tracks)
         carriers = []
         if n:
@@ -324,61 +623,48 @@ class ArtworkView:
     archive: EmbeddedArt | None = None
     #: A folder cover exists but could not be read. NOT the same as having none,
     #: and the difference is the whole right-hand column: with the cover unread
-    #: there is no saying what a re-tag would write, so the section states that
+    #: there is no saying what applying would write, so the section states that
     #: rather than showing outcomes derived from a file it never saw.
     cover_unreadable: bool = False
+    #: The plan the rows were read off — and the one the section's action
+    #: executes, checked by `fingerprint` (#469).
+    plan: ArtworkPlan | None = None
 
     @property
     def images(self) -> tuple[ArtRow, ...]:
-        """The rows that actually have an image — the gap row excluded."""
+        """The rows that actually have an image — the gap rows excluded."""
         return tuple(r for r in self.rows if r.image is not None)
 
     @property
-    def creates_cover_from(self) -> str | None:
-        """Where a RE-TAG would get the folder cover this album hasn't got,
-        named — or None when it has one, or when nothing could make one (#457).
+    def writes(self) -> bool:
+        """Whether applying the artwork would write anything at all.
 
-        Mirrors `cover_art.ensure_cover`'s ladder, which is the code that
-        actually writes the file: the archive first, then art already embedded
-        in the album's audio files.
-
-        Deliberately NOT a row, and deliberately not counted by `writes`. Rows
-        say what the album's images become and `writes` draws the Update artwork
-        button — and that button cannot do this. `tagger.update_artwork` only
-        ever promotes OVER an existing cover (it needs a `cover_path`); creating
-        one is `ensure_cover`, which only a tagging calls. A row would put a
-        button on the page promising a file it would not write, which is the one
-        thing this module exists to prevent.
-
-        A property rather than a field because `cover_unreadable` is applied by
-        `replace()` AFTER `summarise` returns. Computed here, the unreadable case
-        can never claim a cover is coming: there is a file on disk, `ensure_cover`
-        returns it without reading it, and nothing is written. As a field that
-        distinction depended on the caller setting two things in the right order.
+        Read off the plan, not off the rows: the rows are what the album HAS,
+        and a row existing says nothing about whether anything happens to it
+        (#467). The column headings and the action hang off this — with nothing
+        to write there is no second column to name, and "After Apply" over an
+        empty half promises a change that is not coming.
         """
-        if self.cover is not None or self.cover_unreadable:
-            return None
-        files = "the artwork already in your files"
-        tracks_have_art = bool(self.images)
-        if self.caa is None:
-            # Nobody has asked the archive. Both rungs are live, and the wording
-            # carries that rather than resolving it in either direction.
-            if tracks_have_art:
-                return f"the Cover Art Archive, or {files}"
-            return "the Cover Art Archive, if it has this release"
-        if self.caa.has_art:
-            return "the Cover Art Archive"
-        return files if tracks_have_art else None
+        return bool(self.plan and self.plan.changes)
 
     @property
-    def writes(self) -> bool:
-        """Whether a re-tag would write anything at all.
+    def operation(self) -> Operation | None:
+        """Addition or Replacement, for the action's own scope — what the
+        finding at the top of the page is labelled with (#468)."""
+        return self.plan.operation(Scope.ALL) if self.plan else None
 
-        The column headings hang off this: with nothing to write there is no
-        second column to name, and "After a re-tag" over an empty half promises a
-        change that is not coming.
-        """
-        return any(r.writes for r in self.rows)
+    @property
+    def fingerprint(self) -> str:
+        """What the section's action carries back, so it writes what was shown."""
+        return (self.plan or ArtworkPlan(album_dir=Path())).fingerprint(Scope.ALL)
+
+    @property
+    def tagging_fingerprint(self) -> str:
+        """The same, for the part of the plan a re-tag writes — the additions.
+
+        Carried by Re-tag from MB, so a folder cover created or a gap filled by
+        a tagging is one this page showed (#469)."""
+        return (self.plan or ArtworkPlan(album_dir=Path())).fingerprint(Scope.ADDITIONS)
 
     @property
     def distinct(self) -> tuple[tuple[EmbeddedArt, str], ...]:
@@ -403,6 +689,17 @@ class ArtworkView:
         # they wanted it for.
         if (archive_row := self.archive_row) is not None and archive_row.image is not None:
             out.setdefault(archive_row.image.digest, (archive_row.image, "Cover Art Archive"))
+        # …and the winner, wherever it came from. The incoming side of every
+        # written row points at it, and when it is the archive's it is on no
+        # row and no carrier, so nothing else above would emit its view.
+        if self.plan is not None and self.plan.winner is not None:
+            out.setdefault(
+                self.plan.winner.digest,
+                (
+                    self.plan.winner,
+                    _source_label(self.plan.source, self.cover) or "the incoming image",
+                ),
+            )
         return tuple(out.values())
 
     @property
@@ -432,6 +729,7 @@ class ArtworkView:
         # whether or not any track shares that image.
         improved = sum(len(r.tracks) for r in self.images if r.writes)
         cover_improved = any(r.writes and r.on_cover for r in self.images)
+        creates = next((r.creates for r in self.rows if r.creates and r.writes), None)
 
         carriers = []
         if improved:
@@ -444,6 +742,10 @@ class ArtworkView:
             parts.append(f"{filled} track{' is' if filled == 1 else 's are'} missing artwork")
         if carriers:
             parts.append(f"better artwork is available for {' and '.join(carriers)}")
+        if creates:
+            # Named, because it is a file that will appear in the user's folder
+            # and the one thing on this line they could not see coming (#457).
+            parts.append(f"there is no {creates}")
         if not parts:
             return "This album's artwork can be updated."
         # Capitalised from whichever clause leads, since either can.
@@ -549,51 +851,80 @@ def describe(image: EmbeddedArt) -> str:
     return describe_parts(image.size, image.mime, image.length)
 
 
+def _source_label(source: Source | None, cover: FolderCover | None) -> str | None:
+    """The winner, named the way a row names what it becomes.
+
+    By what it IS rather than by a filename, except where it is a file in this
+    album: the album's own image and the archive's are neither.
+    """
+    if source is Source.FOLDER:
+        return cover.name if cover is not None else "the folder cover"
+    if source is Source.ALBUM:
+        return "the album's own artwork"
+    if source is Source.ARCHIVE:
+        return "the Cover Art Archive"
+    return None
+
+
+def _name_in(path: Path, album_dir: Path) -> str:
+    """A track's name as the section shows it: relative to the album, or its
+    bare name when it sits outside the album's primary directory."""
+    try:
+        return path.relative_to(album_dir).as_posix()
+    except ValueError:
+        return path.name
+
+
 def summarise(
-    tracks: Sequence[tuple[str, TrackTags]],
+    album_dir: Path,
+    tracks: Sequence[tuple[Path, TrackTags]],
     cover: FolderCover | None,
     caa: CoverArtAnswer | None = None,
     archive: EmbeddedArt | None = None,
+    *,
+    cover_unreadable: bool = False,
 ) -> ArtworkView:
     """Everything the section shows, from tags already read and a folder cover.
 
-    `tracks` is `(file_name, tags)` in track order — the same shape the album
-    comparison takes, and taken in order for the same reason: the rows come out
-    in the order the album plays.
+    `tracks` is `(path, tags)` in track order — taken in order because the rows
+    come out in the order the album plays.
 
-    The outcomes mirror `tagger._prepare` exactly:
-
-    - no folder cover, or per-track artwork present → nothing is written, every
-      row is KEPT;
-    - otherwise the folder cover goes onto every track, so a row already carrying
-      it is SAME, a row carrying something else is REPLACED, and the row carrying
-      nothing is FILLED.
-
-    That third case is #397: an album that is uniform except for a hole in it has
-    one distinct image, so the preservation guard does not fire and the correct
-    images are rewritten to fill the gaps. The section states it plainly rather
-    than hiding it — see the issue for what the fix costs.
+    The rows are what the album HAS: one per distinct image, one for the tracks
+    carrying none, one for a folder cover that differs from them all, and one
+    for a folder cover that does not exist yet but is about to (#457). Which of
+    them change, and into what, is read off the `plan` built here from the same
+    descriptions — the plan the section's action then executes (#469). Nothing
+    below decides what wins; it only looks up what the plan decided.
     """
-    readable = [(name, t) for name, t in tracks if not t.unreadable]
-    by_digest: dict[str, list[TrackRef]] = {}
-    art_of: dict[str, EmbeddedArt] = {}
-    gap: list[TrackRef] = []
+    readable = [(path, t) for path, t in tracks if not t.unreadable]
+    the_plan = plan(
+        album_dir,
+        [(path, t.art) for path, t in readable],
+        cover,
+        archive,
+        cover_unreadable=cover_unreadable,
+    )
+    written = {c.target for c in the_plan.changes}
+    cover_change = the_plan.cover_change(Scope.ALL)
+    written_from = _source_label(the_plan.source, cover)
+    from_archive = the_plan.source is Source.ARCHIVE
 
-    for name, tags in readable:
+    by_digest: dict[str, list[tuple[Path, TrackRef]]] = {}
+    art_of: dict[str, EmbeddedArt] = {}
+    gap: list[tuple[Path, TrackRef]] = []
+    for path, tags in readable:
         ref = TrackRef(
-            name=name, track_num=tags.track_num, disc_num=tags.disc_num, title=tags.title
+            name=_name_in(path, album_dir),
+            track_num=tags.track_num,
+            disc_num=tags.disc_num,
+            title=tags.title,
         )
         if tags.art is None:
-            gap.append(ref)
+            gap.append((path, ref))
             continue
-        by_digest.setdefault(tags.art.digest, []).append(ref)
+        by_digest.setdefault(tags.art.digest, []).append((path, ref))
         art_of.setdefault(tags.art.digest, tags.art)
 
-    # Per-track artwork is user data, and nothing overwrites it — not the folder
-    # cover, not the archive, however large. Its own name because it is its own
-    # rule: `preserved` below adds "and there is nothing to write anyway", which
-    # is a different fact and used to be conflated with this one (#442).
-    per_track = has_per_track_art(by_digest)
     # More than one disc is a property of the ALBUM, not of a row: a box set
     # whose images each sit on one disc still needs every label to name its disc,
     # or two discs' track 1 read as one repeated row (#400).
@@ -601,149 +932,58 @@ def summarise(
 
     def row(
         image: EmbeddedArt | None,
-        refs: tuple[TrackRef, ...],
-        outcome: Outcome,
+        carriers: Sequence[tuple[Path, TrackRef]],
+        writes: bool,
+        *,
         on_cover: str | None = None,
-        written_from: str | None = None,
-        written_image: EmbeddedArt | None = None,
+        creates: str | None = None,
     ) -> ArtRow:
+        if writes:
+            outcome = Outcome.FILLED if image is None else Outcome.REPLACED
+        else:
+            outcome = Outcome.SAME if on_cover is not None else Outcome.KEPT
         return ArtRow(
             image=image,
-            tracks=refs,
+            tracks=tuple(ref for _, ref in carriers),
             outcome=outcome,
             total_tracks=len(tracks),
             multi_disc=multi_disc,
             on_cover=on_cover,
-            written_from=written_from,
-            written_image=written_image,
-            from_archive=written_image is not None and archive_wins,
+            written_from=written_from if writes else None,
+            written_image=the_plan.winner if writes else None,
+            from_archive=writes and from_archive,
+            creates=creates,
         )
 
-    def carried_by_cover(digest: str) -> str | None:
-        return cover.name if cover is not None and cover.image.digest == digest else None
+    def cover_written(digest: str) -> bool:
+        return cover_change is not None and cover_change.before == digest
 
-    def _unchanged(digest: str) -> bool:
-        """Whether this row's tracks keep what they have — preserved per-track
-        art, an album image that already won, or art that already IS the
-        winner."""
-        if preserved or keep_ours:
-            return True
-        return bool(carried_by_cover(digest)) and not archive_wins
-
-    # The album's own image may be the better one, in which case the folder file
-    # is what changes and the tracks are left alone (#410). Asked through the
-    # same `beats` the tagger asks, so the page cannot promise a different
-    # outcome from the one the button produces.
-    album_image = next(iter(art_of.values())) if len(art_of) == 1 else None
-    ours = album_image.size if album_image else None
-    theirs = cover.image.size if cover else None
-
-    # The best image the album ALREADY has, from either carrier — what a
-    # candidate from outside has to beat. An image that cannot be measured
-    # loses, exactly as `beats` reads a None.
-    #
-    # A folder cover that cannot be measured is the exception, and makes the
-    # answer unknown rather than "the tracks' one": something is there, its size
-    # is not, and leaving it alone is the safe reading of that.
-    album_best = (
-        None
-        if cover is not None and theirs is None
-        else ours
-        if theirs is None or (ours is not None and beats(ours, theirs))
-        else theirs
-    )
-
-    # The archive is the third candidate, and it displaces both when it beats
-    # them (#276). It needs NO FOLDER COVER to be one: it is an image from
-    # outside the album, and the folder file is not what carries it — requiring
-    # one ruled the archive out on exactly the albums #276 said the wins were in,
-    # art embedded in the files and no cover.jpg beside them (#442).
-    #
-    # Asked in the same order and by the same `beats` as `tagger.decide_artwork`,
-    # because this is the page saying what that code will do.
-    archive_wins = not per_track and archive is not None and beats(archive.size, album_best)
-
-    # Nothing is written when the album's own artwork is protected, or when
-    # there is nothing to write from: the folder cover normally, and the archive
-    # when it has beaten everything.
-    preserved = per_track or (cover is None and not archive_wins)
-
-    # What goes on the tracks: the folder cover has to actually be better to be
-    # written over what the album already carries, and both sizes have to be
-    # readable for that to be established at all (#397, #410).
-    keep_ours = (
-        not preserved
-        and album_image is not None
-        and ours is not None
-        and theirs is not None
-        and not beats(theirs, ours)
-    )
-    # …and the folder file catches up only when ours is strictly better (#410).
-    promote = keep_ours and beats(ours, theirs)
-    #: What fills a track carrying nothing — the winner, whichever that is.
-    fills_gaps = "the album's own artwork" if keep_ours else (cover.name if cover else None)
-    #: …and the image those words name.
-    gap_image = album_image if keep_ours else (cover.image if cover else None)
-
-    if archive_wins:
-        assert archive is not None  # narrowed by `archive_wins`
-        keep_ours = False
-        promote = archive.digest != cover.image.digest if cover else False
-        fills_gaps = "the Cover Art Archive"
-        gap_image = archive
-
-    rows = [
-        row(
-            art_of[digest],
-            tuple(refs),
-            Outcome.KEPT
-            if preserved or keep_ours
-            else Outcome.SAME
-            if carried_by_cover(digest) and not archive_wins
-            else Outcome.REPLACED,
-            on_cover=carried_by_cover(digest),
-            # What this row would become, named and shown. `fills_gaps` is the
-            # winner whatever it turned out to be — the folder cover, or the
-            # archive when it beat everything — so the row cannot name one and
-            # be written the other.
-            written_from=None if _unchanged(digest) else fills_gaps,
-            written_image=None if _unchanged(digest) else gap_image,
+    rows = []
+    for digest, carriers in by_digest.items():
+        on_cover = cover.name if cover is not None and cover.image.digest == digest else None
+        rows.append(
+            row(
+                art_of[digest],
+                carriers,
+                any(path in written for path, _ in carriers)
+                or (on_cover is not None and cover_written(digest)),
+                on_cover=on_cover,
+            )
         )
-        for digest, refs in by_digest.items()
-    ]
     # The folder cover is a carrier too, and gets a row of its own when no track
     # already accounts for it (#400) — the album HAS this image, whatever the
-    # tracks carry, and a reader deciding what a re-tag would do needs to see it
+    # tracks carry, and a reader deciding what applying would do needs to see it
     # beside the rest rather than only as something arriving from outside.
     if cover is not None and cover.image.digest not in by_digest:
-        rows.append(
-            row(
-                cover.image,
-                (),
-                Outcome.REPLACED if promote else Outcome.SAME,
-                on_cover=cover.name,
-                # Named as the thing it is rather than by a filename: what
-                # replaces the folder cover is the album's own image or the
-                # archive's, neither of which is a file in this album.
-                written_from=fills_gaps if promote else None,
-                written_image=gap_image if promote else None,
-            )
-        )
-    # A gap is filled whenever there is anything to fill it with — including
-    # when the tracks' own image is the one being kept (#397). "Left alone" is
-    # the right answer for a track that has art; for one that has none it just
-    # means left empty.
+        rows.append(row(cover.image, (), cover_written(cover.image.digest), on_cover=cover.name))
+    # …and when there is no folder cover and the plan makes one, that is a row
+    # too: an empty frame on the left, the image it will hold on the right. It
+    # was a sentence while nothing but a tagging could create it, because a row
+    # counts toward the section's action and that action could not (#457).
+    if cover is None and cover_change is not None:
+        rows.append(row(None, (), True, creates=cover_change.target.name))
     if gap:
-        fillable = not preserved and fills_gaps is not None
-        rows.append(
-            row(
-                None,
-                tuple(gap),
-                Outcome.FILLED if fillable else Outcome.KEPT,
-                written_from=fills_gaps if fillable else None,
-                written_image=gap_image if fillable else None,
-            )
-        )
+        rows.append(row(None, gap, any(path in written for path, _ in gap)))
 
     return ArtworkView(
         rows=tuple(rows),
@@ -751,6 +991,8 @@ def summarise(
         total_tracks=len(tracks),
         unreadable=len(tracks) - len(readable),
         caa=caa,
-        archive_wins=archive_wins,
+        archive_wins=from_archive,
         archive=archive,
+        cover_unreadable=cover_unreadable,
+        plan=the_plan,
     )

--- a/src/harmonist/artwork_store.py
+++ b/src/harmonist/artwork_store.py
@@ -102,7 +102,7 @@ def keep(data: bytes, *, mime: str | None = None) -> str | None:
     copy was kept.
 
     **A digest means the image is still there** (#427). Callers treat one as
-    permission to destroy the original — `tagger._promote_album_image` overwrites
+    permission to destroy the original — `tagger._write_folder_cover` overwrites
     a folder cover on the strength of it — so a key for an image the sweep at the
     end of this call already deleted is not a weaker promise, it is a false one.
     """

--- a/src/harmonist/config.py
+++ b/src/harmonist/config.py
@@ -11,7 +11,6 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator
 
 TestMode = Literal["fixture", "cassette", "live"]
-CoverArtSize = Literal["250", "500", "1200", "original"]
 GardenerLevel = Literal["off", "review"]
 
 
@@ -65,7 +64,11 @@ class AuthConfig(BaseModel):
 
 
 class CoverArtConfig(BaseModel):
-    size: CoverArtSize = "original"
+    # No `size`: the archive's ORIGINAL is always what Harmonist fetches, since
+    # the largest image available is the one it prefers and the one the album
+    # page measures (#469). An older harmonist.toml still naming `size` loads
+    # fine — the key is ignored.
+    #
     # How long a stored Cover Art Archive answer may be re-served before an album
     # page asks again (#436). The same knob `musicbrainz.cache_ttl_seconds` is,
     # for the other service Harmonist asks about a release.
@@ -211,7 +214,6 @@ def _apply_env_overrides(data: dict[str, Any]) -> dict[str, Any]:
     bandcamp = data.setdefault("bandcamp", {})
     server = data.setdefault("server", {})
     auth = data.setdefault("auth", {})
-    cover_art = data.setdefault("cover_art", {})
     library = data.setdefault("library", {})
     gardener = data.setdefault("gardener", {})
     test = data.setdefault("test", {})
@@ -239,8 +241,6 @@ def _apply_env_overrides(data: dict[str, Any]) -> dict[str, Any]:
         test["mode"] = v
     if v := env.get("HARMONIST_LOG_LEVEL"):
         data["log_level"] = v
-    if v := env.get("HARMONIST_COVER_ART_SIZE"):
-        cover_art["size"] = v
     if v := env.get("HARMONIST_WATCH_SETTLE_SECONDS"):
         library["watch_settle_seconds"] = float(v)
     if v := env.get("HARMONIST_GARDENER_LEVEL"):

--- a/src/harmonist/cover_art.py
+++ b/src/harmonist/cover_art.py
@@ -1,10 +1,10 @@
-"""Cover Art Archive fetcher with album-dir caching.
+"""Cover Art Archive fetcher, and the candidate cache its images are kept in.
 
-Tries the release endpoint first, falls back to the release-group endpoint
-if no front cover is linked at the release level, and finally to art already
-embedded in the album's audio files. Caches the result as `cover.jpg` (or
-`.png`) inside the album directory so there is always a folder cover for
-tools (notably Plex) that read art from disk.
+Asks the release endpoint first and falls back to the release group, where the
+archive very often keeps an album's artwork. What comes back is a CANDIDATE,
+held in a cache outside the music library: whether it is written into the
+album, and where, is the artwork plan's decision (`artwork.plan`, #469), made
+after this module has answered. Nothing here writes into an album directory.
 """
 
 from __future__ import annotations
@@ -12,13 +12,13 @@ from __future__ import annotations
 import logging
 import os
 import re
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
 
-from . import activity_store, album_files, audit, formats, id_registry, images, sidecar
+from . import activity_store, images
 
 CAA_BASE = "https://coverartarchive.org"
 DEFAULT_TIMEOUT = 30.0
@@ -38,121 +38,62 @@ def cached_cover(album_dir: Path) -> Path | None:
     return None
 
 
-def ensure_cover(
-    album_dir: Path,
+@dataclass(frozen=True)
+class Front:
+    """The archive's front cover for one release, with its bytes in hand.
+
+    Bytes rather than a path because the candidate cache can be switched off:
+    a tagging that needs the archive's image must still be able to use the one
+    it just fetched, whether or not there was anywhere to keep it.
+    """
+
+    data: bytes
+    mime: str
+
+
+def cached_front(release_mbid: str) -> Front | None:
+    """The archive's image for this release from the local cache only, or None.
+
+    No network, so it is safe on every path — the gardener's included. An
+    unreadable cache file is logged and treated as absent: the copy is
+    disposable, and the archive still has the original.
+    """
+    path = cached_image(release_mbid)
+    if path is None:
+        return None
+    try:
+        return Front(data=path.read_bytes(), mime=_mime_of(path))
+    except OSError:
+        log.exception("could not read the cached archive image for %s", release_mbid)
+        return None
+
+
+def front_image(
     release_mbid: str,
     release_group_mbid: str | None = None,
-    size: str = "original",
     *,
     client: httpx.Client | None = None,
-) -> Path | None:
-    """Return the path to a cover for the album.
+) -> Front | None:
+    """The archive's front cover for this release: from the cache, or fetched
+    into it.
 
-    If `cover.{jpg,png}` already exists in album_dir, it's returned as-is
-    (treated as a manual override / cache hit). Otherwise, fetch from CAA:
-    release first, then release-group fallback. If CAA has nothing (common
-    for fresh / private Bandcamp releases not yet in CAA), fall back to art
-    already embedded in the album's audio files. Returns None only when no
-    cover is available from any source.
+    Asked by a tagging for an album with no folder cover, which is the one case
+    where the archive's image may be written without anyone having looked at the
+    album page first — the same single request a tagging has always spent there.
+    Always the ORIGINAL: the largest image available is the one Harmonist wants
+    (#469), and it is what the page's own check measures, so the tagging and the
+    preview compare the same picture.
 
-    Raises `CoverArtError` only when the archive could not be *asked* and no
-    other rung served an image (#458). "I could not ask" and "there is nothing
-    there" are different answers, and collapsing them into None would let a
-    caller — and later #269's probe backoff — record an outage as a fact about
-    the release. Every rung is tried before that error is raised, because the
-    one that needs no network is the last one and it is the one an outage makes
-    most useful.
+    Returns None when the archive has no front cover for the release or its
+    group. Raises `CoverArtError` when it could not be ASKED (#458): "I could not
+    ask" and "there is nothing there" are different answers, and collapsing them
+    would let a caller record an outage as a fact about the release.
+
+    Writes nothing into the album. The image goes to the candidate cache, and
+    whether it lands anywhere in the library is the artwork plan's decision.
     """
-    if cached := cached_cover(album_dir):
+    if (cached := cached_front(release_mbid)) is not None:
         return cached
-
-    album_id = _album_id_for_record(album_dir)
-
-    # Remembered rather than propagated: the rung below needs no network, so an
-    # archive that cannot answer must not skip it. Re-raised at the end only if
-    # nothing else served an image.
-    unreachable: CoverArtError | None = None
-    try:
-        fetched = _fetch_to_disk(
-            album_dir, release_mbid, release_group_mbid, size, client=client, album_id=album_id
-        )
-    except CoverArtError as e:
-        unreachable = e
-        fetched = None
-    if fetched is not None:
-        return fetched
-
-    if (embedded := _extract_embedded_cover(album_dir, album_id)) is not None:
-        return embedded
-    if unreachable is not None:
-        raise unreachable
-    return None
-
-
-def _album_id_for_record(album_dir: Path) -> str:
-    """The id this album answers to right now, for the `cover.write` records
-    below (#456).
-
-    Read ONCE by `ensure_cover` and handed to whichever rung ends up writing.
-    Both rungs put a file in the user's album directory and both record it as
-    `cover.write`; taking the id in one place is what stops them drifting into
-    recording it differently, or a third rung arriving that forgets it entirely.
-
-    Mirrors `scanner._album_id`: the sidecar's MBID, else its temp_uid, else the
-    path-derived id. That last fall-back is the load-bearing part. A cover is
-    fetched BEFORE the tagging that will write the album's first sidecar, so on a
-    first tag `album_id_for` has nothing to read — and a bare None there would
-    leave exactly the albums most likely to gain a cover with no record of having
-    gained one. `id_registry.peek` is not a guess: it is a pure hash of the path,
-    it is what `sidecar.write()` then persists as `temp_uid`, and it is what the
-    scanner already calls the album meanwhile. So the record lands on the id the
-    album has, and the alias chain carries it forward when tagging replaces that
-    id with the MBID.
-
-    Deliberately NOT folded into `sidecar.album_id_for`, whose None means "this
-    album has no sidecar" — a distinction its other callers rely on.
-    """
-    return sidecar.album_id_for(album_dir) or id_registry.peek(album_dir)
-
-
-def _extract_embedded_cover(album_dir: Path, album_id: str) -> Path | None:
-    """Write a folder cover from the first audio file that carries embedded
-    art. Ensures a `cover.*` exists on disk even when CAA has no match."""
-    for path in album_files.audio_files(album_dir):
-        result = formats.read_cover(path)
-        if result is None:
-            continue
-        data, mime = result
-        name = "cover.png" if "png" in mime.lower() else "cover.jpg"
-        target = album_dir / name
-        # Writing into the user's album dir, and possibly over an existing
-        # cover.* they put there themselves — audited like any other file
-        # overwrite (#88). `overwrote` distinguishes creating from replacing.
-        overwrote = target.exists()
-        target.write_bytes(data)
-        audit.record(
-            "cover.write",
-            album_id=album_id,
-            album=album_dir,
-            file=target.name,
-            source="embedded",
-            overwrote=overwrote,
-        )
-        log.debug("cover: extracted embedded art from %s -> %s", path.name, target.name)
-        return target
-    return None
-
-
-def _fetch_to_disk(
-    album_dir: Path,
-    release_mbid: str,
-    release_group_mbid: str | None,
-    size: str,
-    *,
-    client: httpx.Client | None,
-    album_id: str,
-) -> Path | None:
-    suffix = "" if size == "original" else f"-{size}"
     targets = [("release", release_mbid)]
     if release_group_mbid:
         targets.append(("release-group", release_group_mbid))
@@ -169,7 +110,7 @@ def _fetch_to_disk(
 
     try:
         for kind, mbid in targets:
-            url = f"{CAA_BASE}/{kind}/{mbid}/front{suffix}"
+            url = f"{CAA_BASE}/{kind}/{mbid}/front"
             try:
                 resp = http.get(url)
             except httpx.HTTPError as e:
@@ -184,21 +125,14 @@ def _fetch_to_disk(
                 log.debug("CAA: no cover for %s/%s (404)", kind, mbid)
                 continue
             if resp.is_success:
-                target = album_dir / _filename_for(resp)
-                overwrote = target.exists()
-                target.write_bytes(resp.content)
-                audit.record(
-                    "cover.write",
-                    album_id=album_id,
-                    album=album_dir,
-                    file=target.name,
-                    source="caa",
-                    mbid=mbid,
-                    bytes=len(resp.content),
-                    overwrote=overwrote,
-                )
-                log.debug("CAA: wrote %s (%d bytes)", target, len(resp.content))
-                return target
+                ct = resp.headers.get("content-type", "").lower()
+                front = Front(data=resp.content, mime="image/png" if "png" in ct else "image/jpeg")
+                # Kept under the RELEASE's id even when the group answered, as
+                # `check_front` keeps it: the cache holds this release's front
+                # cover, wherever the archive filed it.
+                cache_image(release_mbid, front.data, front.mime)
+                log.debug("CAA: fetched %s/%s (%d bytes)", kind, mbid, len(resp.content))
+                return front
             log.warning("CAA: %s/%s returned status %d", kind, mbid, resp.status_code)
             failure = failure or CoverArtError(f"CAA returned status {resp.status_code} for {url}")
         if failure is not None:
@@ -228,8 +162,8 @@ def check_front(
     """Ask the archive what front cover it has, and measure it.
 
     Asks the RELEASE first and falls back to its RELEASE GROUP, which is where
-    the archive very often keeps the artwork — exactly as `_fetch_to_disk` has
-    done since #131. Asking only the release made the album page report "no
+    the archive very often keeps the artwork — exactly as a tagging's fetch
+    (`front_image`) does. Asking only the release made the album page report "no
     front cover" for albums a tagging would happily have fetched one for (#434).
 
     Returns the answer whatever it is — including "nothing", which is a real
@@ -487,8 +421,5 @@ def _is_mbid(value: str) -> bool:
 _SAFE_ID = re.compile(r"(?!\.)[A-Za-z0-9._-]{1,64}")
 
 
-def _filename_for(resp: httpx.Response) -> str:
-    ct = resp.headers.get("content-type", "").lower()
-    if "png" in ct:
-        return "cover.png"
-    return "cover.jpg"
+def _mime_of(path: Path) -> str:
+    return "image/png" if path.suffix.lower() == ".png" else "image/jpeg"

--- a/src/harmonist/demo.py
+++ b/src/harmonist/demo.py
@@ -1239,25 +1239,28 @@ def search_releases(artist: str, title: str, limit: int = 10) -> list[dict[str, 
     return results
 
 
-def ensure_cover(
-    album_dir: Path,
-    release_mbid: str = "",
+def front_image(
+    release_mbid: str,
     release_group_mbid: str | None = None,
-    size: str = "original",
     *,
     client: Any = None,
-) -> Path | None:
-    """Demo cover fetcher — returns existing cover.jpg if present, else copies a placeholder."""
-    for name in ("cover.jpg", "cover.png"):
-        p = album_dir / name
-        if p.exists():
-            return p
+) -> Any:
+    """Demo answer from the archive for a tagging: a placeholder from the demo
+    assets, never a request.
+
+    Kept in the real candidate cache like the live answer, so the album page
+    afterwards shows the image a tagging would have weighed. Returns a
+    `cover_art.Front` (typed `Any` so this module need not import `cover_art`
+    outside `install`, as for every other patch here).
+    """
+    from . import cover_art
+
     placeholder = ASSETS_DIR / "cover-7.jpg"  # generic green default
-    if placeholder.exists():
-        target = album_dir / "cover.jpg"
-        shutil.copy(placeholder, target)
-        return target
-    return None
+    if not placeholder.exists():
+        return None
+    data = placeholder.read_bytes()
+    cover_art.cache_image(release_mbid, data, "image/jpeg")
+    return cover_art.Front(data=data, mime="image/jpeg")
 
 
 def check_front(
@@ -1337,7 +1340,7 @@ def install() -> None:
     mb_lookup.lookup_by_bandcamp_url = lookup_by_bandcamp_url
     mb_lookup.browse_release_group_releases = browse_release_group_releases
     mb_search.search_releases = search_releases
-    cover_art.ensure_cover = ensure_cover
+    cover_art.front_image = front_image
     cover_art.check_front = check_front
     cover_art.fetch_image = fetch_image
     log.info("demo mode: monkey-patched mb_lookup, mb_search, cover_art")

--- a/src/harmonist/formats/owned.py
+++ b/src/harmonist/formats/owned.py
@@ -186,30 +186,17 @@ class Significance(StrEnum):
     #: What the album or one of its tracks IS — its name, its artist, or any of
     #: the MusicBrainz ids that say which entity it points at.
     IDENTITY = "identity"
-    #: The cover image being REPLACED. Its own level rather than a rank among
-    #: the others, because "let it update my cover art" is a trust decision
-    #: people make separately from anything about tags — and, more sharply,
-    #: because this is the one level whose reversal may be unavailable:
-    #: `artwork_store` keeps embedded art only and evicts under a size cap, so
-    #: an undo can be gone for reasons that have nothing to do with the change
-    #: (the image was large; the cap has since been reached). On the merits it
-    #: is IDENTITY-equivalent — this is the image that IS the album to a player
-    #: — and a level whose reversibility is conditional cannot sit in a rank
-    #: where the ones above it are all reversible.
-    #:
-    #: So the level tracks reversibility, not subject matter, and the
-    #: consequence is worth stating because it reads as an inconsistency:
-    #: **not every artwork change is classified here.** Giving an album artwork
-    #: it does not have is additive with nothing to reverse, and is ENRICHMENT
-    #: (#269). Replacing one it has is this (#276).
-    COVER_ART = "artwork"
 
 
-#: What kind of change each key of a tagging diff represents, keyed exactly as
-#: `diff` keys its result — the `Owned` values plus `ARTWORK`. Keyed by string
-#: for that reason: a classifier iterates a plan's changes, and artwork arrives
-#: in them under a key that is deliberately not an owned field. One lookup table
-#: for the whole diff means no caller has to remember which key is the exception.
+#: What kind of change each owned field's entry in a tagging diff represents.
+#: Keyed by string, as `diff` keys its result.
+#:
+#: `ARTWORK` is deliberately absent (#469). An image is not a tag, and the scale
+#: here describes how far a metadata change reaches — which says nothing about
+#: a picture. Artwork has its own description, `artwork.Operation`: whether the
+#: target already held an image (a Replacement) or did not (an Addition). A key
+#: missing from this table raises in `tagger.significance_of`, so an artwork
+#: entry can never be ranked against a retitle by accident.
 #:
 #: Placed here, beside `SCOPE`, so the totality test can hold: a field added to
 #: `Owned` later **cannot** slip through unclassified, because
@@ -275,8 +262,6 @@ SIGNIFICANCE: dict[str, Significance] = {
     Owned.TRACK_TOTAL: Significance.STRUCTURE,
     Owned.DISC_NUM: Significance.STRUCTURE,
     Owned.DISC_TOTAL: Significance.STRUCTURE,
-    # --- Artwork ---
-    ARTWORK: Significance.COVER_ART,
 }
 
 #: The tag levels, least far-reaching first — the ordering `Significance`'s
@@ -289,13 +274,9 @@ SIGNIFICANCE: dict[str, Significance] = {
 #: album is in question — an ISRC arriving beside a retitle does not make the
 #: retitle an enrichment.
 #:
-#: COVER_ART IS ABSENT, and its absence is the enum's own position: cover art is
-#: "its own level rather than a rank among the others", so it has no place in a
-#: line the others sit on. `ranked` refuses it rather than guessing where it
-#: would go. Nothing is lost today — the gardener plans with `cover_path=None`,
-#: so artwork cannot appear in a diff it classifies (#269 owns art, on its own
-#: cadence) — and when something does classify artwork it will need a verdict of
-#: its own, not a rank pretending to compare with a retitle.
+#: Artwork has no place on this line (#469): it is described by
+#: `artwork.Operation`, and the gardener's diff never carries it (`plan_for`
+#: passes `artwork=False`).
 ORDER: tuple[Significance, ...] = (
     Significance.COSMETIC,
     Significance.ENRICHMENT,
@@ -307,10 +288,9 @@ ORDER: tuple[Significance, ...] = (
 def ranked(significance: Significance) -> int:
     """How far `significance` reaches, as a sortable number.
 
-    Raises `ValueError` for COVER_ART — see `ORDER`. A caller that can produce
-    one has to say what it means before it can be compared, and the failure to
-    do that must not be silently resolved to "least significant", which is where
-    a `.get(..., 0)` would put it.
+    `ORDER.index`, not a `.get(..., 0)`: a level added to the enum without a
+    place in the order must fail here rather than silently rank as the least
+    significant.
     """
     return ORDER.index(significance)
 

--- a/src/harmonist/images.py
+++ b/src/harmonist/images.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 def digest(data: bytes) -> str:
     """The content address of an image: sha256, hex.
 
-    Load-bearing across three readers that must agree — `tagger._art_digests`
+    Load-bearing across three readers that must agree — the artwork plan
     decides whether per-track art is preserved, `artwork_store` names its files
     by this, and the album page compares tracks to each other with it. They were
     the same expression written three times before this existed.

--- a/src/harmonist/tag_history.py
+++ b/src/harmonist/tag_history.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from . import album_files
+from . import album_files, formats
 from .compare import Run, diff_runs
 from .formats.owned import ARTWORK, LABELS, SCOPE, Owned, Scope
 
@@ -80,6 +80,10 @@ class FieldChange:
     #: pair above already says everything. When they differ, these are the only
     #: honest values there are: the row shows `varied_summary` instead.
     variants: tuple[TrackChange, ...] = ()
+    #: The folder cover's name, when this artwork change reached it too. It is
+    #: not a track, so it is named beside the track count rather than counted
+    #: in it (#469).
+    cover: str | None = None
 
     @property
     def uniform(self) -> bool:
@@ -124,12 +128,20 @@ class FieldChange:
         to check eighteen things. A field that moved on only some tracks always
         gets the count, whatever its scope, because that is the case where the
         album has no single answer.
+
+        The folder cover is named rather than counted: "cover.jpg" alone when
+        it was the only thing an artwork change reached, and after the tracks
+        when it was one of several.
         """
+        if self.cover is not None and not self.tracks:
+            return self.cover
         if self.tracks < self.total:
-            return f"{self.tracks} of {self.total} tracks"
-        if self.scope is Scope.ALBUM:
-            return "album"
-        return "all tracks" if self.total > 1 else "1 track"
+            reach = f"{self.tracks} of {self.total} tracks"
+        elif self.scope is Scope.ALBUM:
+            reach = "album"
+        else:
+            reach = "all tracks" if self.total > 1 else "1 track"
+        return f"{reach} and {self.cover}" if self.cover is not None else reach
 
 
 def group_by_action(
@@ -376,10 +388,14 @@ def summarise(records: Sequence[Any]) -> tuple[FieldChange, ...]:
     `records` is one tagging's `activity_store.TagChanges`, in the order they
     were written (which is file order). The result is ordered by `_ORDER`, so
     album-level fields come before per-track ones and artwork sits last.
+
+    `total` counts TRACKS. A tagging that also created or replaced the folder
+    cover records that as a file of its own, and counting it would report a
+    field that reached all thirteen tracks as "13 of 14" (#469).
     """
-    total = len(records)
-    if not total:
+    if not records:
         return ()
+    total = sum(1 for record in records if _is_track(record.file))
 
     # field -> [(file, position, before, after)], in file order.
     by_field: dict[str, list[tuple[str, str | None, Any, Any]]] = {}
@@ -392,6 +408,13 @@ def summarise(records: Sequence[Any]) -> tuple[FieldChange, ...]:
 
     rows = [_row(field, entries, total) for field, entries in by_field.items()]
     return tuple(sorted(rows, key=lambda r: (_ORDER.get(r.field, len(_ORDER)), r.label)))
+
+
+def _is_track(file: str) -> bool:
+    """Whether a record names a track rather than the folder cover. By the name's
+    extension alone — no file is opened — so it holds for a record whose file has
+    since gone."""
+    return formats.is_supported(Path(file))
 
 
 def _row(field: str, entries: list[tuple[str, str | None, Any, Any]], total: int) -> FieldChange:
@@ -425,8 +448,9 @@ def _row(field: str, entries: list[tuple[str, str | None, Any, Any]], total: int
         before=before,
         after=after,
         opaque=opaque,
-        tracks=len(entries),
+        tracks=sum(1 for f, _, _, _ in entries if _is_track(f)),
         total=total,
+        cover=next((f for f, _, _, _ in entries if not _is_track(f)), None),
         scope=SCOPE.get(Owned(field)) if field in _ORDER and field != ARTWORK else None,
         before_runs=before_runs,
         after_runs=after_runs,

--- a/src/harmonist/tagger.py
+++ b/src/harmonist/tagger.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import Any, NamedTuple, Protocol, runtime_checkable
 
@@ -26,6 +27,7 @@ from . import (
     compare,
     cover_art,
     formats,
+    id_registry,
     images,
     mb_lookup,
     tag_history,
@@ -122,6 +124,8 @@ class Tagger(Protocol):
         incomplete: bool = False,
         overwrite_art: bool = False,
         files: list[Path] | None = None,
+        archive: cover_art.Front | None = None,
+        expected_artwork: str | None = None,
     ) -> int: ...
 
 
@@ -138,6 +142,8 @@ class PicardCompatibleTagger:
         incomplete: bool = False,
         overwrite_art: bool = False,
         files: list[Path] | None = None,
+        archive: cover_art.Front | None = None,
+        expected_artwork: str | None = None,
     ) -> int:
         return tag_album(
             album_dir,
@@ -146,6 +152,8 @@ class PicardCompatibleTagger:
             incomplete=incomplete,
             overwrite_art=overwrite_art,
             files=files,
+            archive=archive,
+            expected_artwork=expected_artwork,
         )
 
 
@@ -157,6 +165,8 @@ def tag_album(
     incomplete: bool = False,
     overwrite_art: bool = False,
     files: list[Path] | None = None,
+    archive: cover_art.Front | None = None,
+    expected_artwork: str | None = None,
 ) -> int:
     """Tag every supported audio file in `album_dir`.
 
@@ -185,6 +195,17 @@ def tag_album(
     `overwrite_art=True` embeds the album cover even when the tracks carry
     differing per-track artwork (which is otherwise preserved) — the user's
     explicit "replace the artwork" override.
+
+    Artwork is the ADDITIONS of the album's artwork plan (#418, #469): gaps
+    filled and a missing folder cover created, from whichever image the plan
+    says wins. `archive` is the Cover Art Archive's image when the caller has
+    just fetched it; otherwise the local cache is read.
+
+    `expected_artwork` is the fingerprint of the additions a page showed the
+    user. When the plan built here no longer matches it — an image edited
+    since, a candidate that arrived after the page was drawn — the album is
+    tagged and NO artwork is written, and the album's History says so. Writing
+    an image the page never showed would be the confident surprise #457 was.
     """
     prep = _prepare(
         album_dir,
@@ -193,6 +214,8 @@ def tag_album(
         incomplete=incomplete,
         overwrite_art=overwrite_art,
         files=files,
+        archive=archive,
+        expected_artwork=expected_artwork,
     )
     # Read before the loop, and before anything can move it: tagging drops a
     # sidecar's `temp_uid` for the MBID afterwards, which is why `album_history`
@@ -217,25 +240,25 @@ def tag_album(
         art="embedded" if prep.cover is not None else "preserved",
         mode="incomplete" if incomplete else "full",
     )
-    if prep.art_after is not None:
-        _keep_doomed_art(prep.art_before, prep.art_after)
+    if prep.art_withheld:
+        # Attributed, so it reaches the album's History and the feed: the user
+        # pressed a button having looked at a preview, and is owed the reason
+        # the artwork half of it did not happen.
+        log.warning(
+            "the album's artwork changed after the page showed it — tagged without "
+            "writing any artwork. Review the Artwork section and apply it from there.",
+            extra={"album_id": album_id, "album_label": _album_label(release, album_dir)},
+        )
+    if prep.cover is not None and prep.art_after is not None:
+        # Only this tagging's own targets: an image the plan leaves alone is not
+        # being destroyed and has no business being backed up.
+        _keep_doomed_art({p: prep.art.before.get(p) for p in prep.art_targets}, prep.art_after)
 
-    # The album's own image is the better one, so the folder file catches up
-    # rather than the tracks being dragged down to it (#410). Recorded as a
-    # change to `cover.jpg` in the same shape a tagged file's artwork change
-    # takes, which is what puts an Undo on it: `tag_history.artwork_replaced`
-    # reads that pair, and `restore_artwork` writes it back.
-    if prep.promote_cover is not None and cover_path is not None:
-        promoted = _promote_album_image(album_dir, cover_path, prep.promote_cover, album_id)
-        if promoted is not None:
-            was, now = promoted
-            event_id = audit.record(
-                "tag.track", album_id=album_id, album=album_dir, file=cover_path.name
-            )
-            if event_id is not None:
-                activity_store.record_tag_changes(
-                    event_id, file=cover_path.name, changes={owned.ARTWORK: [was, now]}
-                )
+    # The folder cover this tagging creates, when the album has none (#457) —
+    # written from the plan like every other image here, where it used to be
+    # fetched into the folder before the tagging had decided anything.
+    if prep.cover is not None and prep.cover_change is not None:
+        _write_folder_cover(album_dir, prep.cover_change, prep.cover, prep.art.source, album_id)
 
     wrote_something = False
     # How this album's records name its files — built once from the files the
@@ -253,8 +276,8 @@ def tag_album(
             tagset,
             before,
             file_path,
-            prep.art_before,
-            images.digest(incoming) if incoming is not None else None,
+            prep.art.before,
+            prep.art_after if incoming is not None else None,
             prep.accepted_album_title,
             prep.accepted_countries,
         )
@@ -286,7 +309,7 @@ def tag_album(
         if event_id is not None:
             _record_changes(event_id, naming, file_path, tagset, changes)
 
-    if prep.preserves_per_track_art and wrote_something:
+    if prep.art.preserves_per_track_art and wrote_something:
         # Attributed to the album (#260). This is a decision Harmonist made on
         # the user's behalf about their files, so it has to reach that album's
         # own History — and the feed's log mirror drops any record that doesn't
@@ -363,13 +386,19 @@ def plan_album(
             tagset,
             formats.read_owned(file_path),
             file_path,
-            prep.art_before,
-            prep.art_after,
+            prep.art.before,
+            # Only where the tagging would really write it — the same targets
+            # `tag_album` hands `write_tags`. Every file differing from the
+            # winner used to be reported here, including the ones a tagging
+            # leaves alone since #418.
+            prep.art.winner.digest
+            if prep.art.winner is not None and file_path in prep.art_targets
+            else None,
             prep.accepted_album_title,
             prep.accepted_countries,
         ):
             changes[file_path] = file_changes
-    return AlbumPlan(changes=changes, preserves_per_track_art=prep.preserves_per_track_art)
+    return AlbumPlan(changes=changes, preserves_per_track_art=prep.art.preserves_per_track_art)
 
 
 @dataclass(frozen=True)
@@ -490,11 +519,14 @@ class _Prepared:
 
     files: list[Path]
     pairs: list[tuple[Path, _FlatTrack]]
-    #: The cover to embed, or None to leave each file's own art alone.
+    #: The album's artwork plan, whole. What this tagging writes of it is
+    #: `art_targets` and `cover_change`.
+    art: artwork.ArtworkPlan
+    #: The winning image's bytes, loaded only when this tagging writes it —
+    #: None to leave every file's own art alone.
     cover: bytes | None
-    art_before: dict[Path, str | None]
+    #: …and its digest, for the per-file records.
     art_after: str | None
-    preserves_per_track_art: bool
     media_total: int
     #: The one other album title that counts as already correct — Picard's
     #: disambiguated spelling (#283). Album-constant, since every file's TagSet
@@ -507,85 +539,40 @@ class _Prepared:
     #: not MusicBrainz's scalar `country` and is not stale either. Album-constant
     #: for the reason above.
     accepted_countries: frozenset[str]
-    #: The image the folder cover should become, when something beats it — the
-    #: album's own artwork (#410) or the Cover Art Archive's (#276). None when
-    #: the folder file already holds the winner, which is the common case.
-    #: Bytes rather than a source, because the winner may come from the archive
-    #: cache rather than from a track.
-    promote_cover: bytes | None = None
     #: The files this TAGGING may write `cover` to — the ones carrying nothing,
     #: or every file under `overwrite_art` (#418). Everything else keeps the
     #: image it has; improving those is the artwork action's job.
     art_targets: frozenset[Path] = frozenset()
-
-
-@dataclass(frozen=True)
-class ArtworkPlan:
-    """What should happen to an album's images, decided once (#418).
-
-    Shared by the two paths that act on artwork so they cannot reach different
-    verdicts: a tagging, which fills gaps and touches nothing else, and the
-    artwork action, which replaces. Splitting the decision out is what lets the
-    second exist — `_prepare` also pairs files to tracks and enforces the count
-    guard, neither of which an artwork change has any business requiring.
-    """
-
-    #: Every file's current embedded image as a digest, or None where it has
-    #: none. The gaps are the None entries.
-    before: dict[Path, str | None]
-    #: The image that ought to be on every track, or None when nothing should be
-    #: written at all — per-track artwork worth preserving, or an album with
-    #: nothing outside its tracks to consider (no folder cover and no cached
-    #: archive image). An album with no folder cover DOES still have a winner
-    #: when it has one image of its own: it is the incumbent the archive has to
-    #: beat, and what a tagging fills that album's gaps from (#442).
-    winner: bytes | None
-    #: The image the folder cover should become, when something beats it.
-    promote_cover: bytes | None = None
-    #: Whether per-track artwork is being preserved, which is a decision worth
-    #: reporting rather than a silent no-op.
-    preserves_per_track_art: bool = False
-
-    @property
-    def digest(self) -> str | None:
-        """The winner's content address, or None when nothing would be written."""
-        return images.digest(self.winner) if self.winner is not None else None
-
-    def gaps(self) -> list[Path]:
-        """The files carrying no image at all — what a TAGGING may fill."""
-        return [path for path, digest in self.before.items() if digest is None]
-
-    def replacements(self) -> list[Path]:
-        """The files carrying a DIFFERENT image from the winner — what only the
-        artwork action may overwrite (#418)."""
-        winner = self.digest
-        if winner is None:
-            return []
-        return [
-            path for path, digest in self.before.items() if digest is not None and digest != winner
-        ]
+    #: The folder cover this tagging creates, when the album has none (#457).
+    cover_change: artwork.Change | None = None
+    #: The page's preview no longer matches the plan, so this tagging writes no
+    #: artwork at all (#469).
+    art_withheld: bool = False
 
 
 def decide_artwork(
-    files: list[Path],
-    release: Release,
+    album_dir: Path,
+    files: Sequence[Path],
     cover_path: Path | None,
     *,
+    archive: cover_art.Front | None = None,
     overwrite_art: bool = False,
     consider: bool = True,
-) -> ArtworkPlan:
-    """Which image wins, and what would have to change for it to be everywhere.
+) -> artwork.ArtworkPlan:
+    """The album's artwork plan, read from its files (#418, #469).
 
-    THE LARGEST IMAGE WINS, among the three an album can offer: what its tracks
-    carry, what its folder holds, and what the Cover Art Archive has if anyone
-    has asked (#276, #410). A re-tag used to embed the folder cover regardless,
-    which on a real library shrank one album in twelve — 3000px replaced by
-    2000px, in one case 5700px by 2000px.
+    The reading half of `artwork.plan`, which decides. Every track's image and
+    the folder cover are described through the same `EmbeddedArt.of` the album
+    page's tag read uses, so the page and this reach the same plan from the
+    same disk — the property a reviewed page's fingerprint relies on.
 
-    `overwrite_art` opts out of the comparison entirely: a user asking for the
-    folder cover to be embedded is not asking for it to be judged.
+    THE LARGEST IMAGE WINS — see `artwork.plan`. A re-tag used to embed the
+    folder cover regardless, which on a real library shrank one album in twelve:
+    3000px replaced by 2000px, in one case 5700px by 2000px.
 
-    Reads files and the local caches, and nothing else. No network: `plan_album`
+    Reads files and nothing else. `archive` is the Cover Art Archive's image,
+    handed in by a caller that has it — from the cache, or fetched by the
+    tagging entry point before any of this starts. No network here: `plan_album`
     reaches this on the gardener's path, where a request per album is exactly
     what must not happen.
 
@@ -593,63 +580,24 @@ def decide_artwork(
     The gardener's flag is about TAGS, and it used to say so by passing
     `cover_path=None` — which was a proxy, not a statement, and stopped being
     true the moment the archive became a second source that needs no folder
-    cover (#442). A plan that was artwork-free by construction started carrying
-    an ARTWORK change, which `owned.ranked` raises on by design, and the album
-    page's own comparison became a 500 for any album whose archive cover
-    happened to be cached. Say the thing rather than implying it (#448).
+    cover (#442). Say the thing rather than implying it (#448).
     """
     if not consider:
-        return ArtworkPlan(before={}, winner=None)
-    cover = cover_path.read_bytes() if cover_path else None
-    # The archive's image, from the LOCAL CACHE only.
-    archive = _archive_candidate(release)
-    # Read what the tracks carry whenever ANYTHING could overwrite it. The read
-    # used to be skipped when there was no folder cover, which was safe only
-    # while the cover was the sole candidate: `before` is what the per-track-art
-    # guard below consults, so an album with no cover and an archive candidate
-    # would have been judged on an empty dict and its sleeves flattened (#442).
-    before = _art_digests(files) if (cover is not None or archive is not None) else {}
-
-    # DATA SAFETY: if the tracks carry DIFFERENT embedded art (a per-track-art
-    # album, e.g. a compilation), embedding one album cover would destroy those
-    # images. Preserve them — the folder cover.* is still written separately.
-    preserves = not overwrite_art and artwork.has_per_track_art(before.values())
-    if preserves:
-        return ArtworkPlan(before=before, winner=None, preserves_per_track_art=True)
-    if overwrite_art:
-        # Asking for the folder cover to be embedded is not asking for it to be
-        # judged — and with no cover to embed there is nothing to do.
-        return ArtworkPlan(before=before, winner=cover)
-    if cover is None and archive is None:
-        # Nothing from outside the tracks, so nothing can change.
-        return ArtworkPlan(before=before, winner=None)
-
-    folder_size = images.dimensions(cover) if cover is not None else None
-    own = _album_image(before)
-
-    # Ordered worst-first so each candidate has to genuinely beat the one before
-    # it to displace it — ties go to what is already there, because a same-sized
-    # different picture is not an improvement and is not worth overwriting a
-    # user's file for.
-    winner, winner_size = cover, folder_size
-    if own is not None:
-        _, mine = own
-        ours = images.dimensions(mine)
-        # With no folder cover the tracks' own image is the incumbent rather
-        # than a challenger — there is nothing for it to beat, and it is what
-        # the archive then has to beat.
-        if ours is not None and (folder_size is None or not artwork.beats(folder_size, ours)):
-            winner, winner_size = mine, ours
-    if archive is not None:
-        theirs = images.dimensions(archive)
-        if artwork.beats(theirs, winner_size):
-            winner, winner_size = archive, theirs
-
-    # The folder file catches up when the winner is not what it holds. That
-    # write is the one here that could not be undone from the tracks themselves,
-    # so it happens only on a strict improvement.
-    promote = winner if winner is not cover and artwork.beats(winner_size, folder_size) else None
-    return ArtworkPlan(before=before, winner=winner, promote_cover=promote)
+        return artwork.ArtworkPlan(album_dir=album_dir)
+    cover = None
+    if cover_path is not None:
+        cover = artwork.FolderCover(
+            name=cover_path.name,
+            image=formats.EmbeddedArt.of(cover_path.read_bytes(), _mime_for(cover_path)),
+            path=cover_path,
+        )
+    return artwork.plan(
+        album_dir,
+        [(f, _embedded_art(f)) for f in files],
+        cover,
+        formats.EmbeddedArt.of(archive.data, archive.mime) if archive is not None else None,
+        overwrite_art=overwrite_art,
+    )
 
 
 def _prepare(
@@ -661,6 +609,8 @@ def _prepare(
     overwrite_art: bool,
     files: list[Path] | None,
     artwork_in_scope: bool = True,
+    archive: cover_art.Front | None = None,
+    expected_artwork: str | None = None,
 ) -> _Prepared:
     """Decide what a tagging of this album would consist of, reading no tags.
 
@@ -704,46 +654,63 @@ def _prepare(
     # exists to avoid.
     pairs = _assign_files_to_tracks(files, flat_tracks)
 
-    cover = cover_path.read_bytes() if cover_path else None
-    # Only when there IS a cover to embed. With `cover=None` write_tags leaves
-    # the existing art alone, so nothing changes and there is nothing to record
-    # — reading every file's cover would be a wasted pass over the album, on the
-    # path where scanning is already the slow part (#44, #74). Guarding here
-    # rather than relying on the `and` below, which used to short-circuit this
-    # read and stopped doing so when the digests were hoisted out.
+    if archive is None and artwork_in_scope:
+        archive = _archive_candidate(release)
     art = decide_artwork(
-        files, release, cover_path, overwrite_art=overwrite_art, consider=artwork_in_scope
+        album_dir,
+        files,
+        cover_path,
+        archive=archive,
+        overwrite_art=overwrite_art,
+        consider=artwork_in_scope,
     )
-    art_before = art.before
-    preserves_per_track_art = art.preserves_per_track_art
     # A TAGGING FILLS GAPS AND REPLACES NOTHING (#418). Improving an image the
-    # album already has is its own action now, because it is the change a user
-    # is most likely to want to undo on its own — and because the severity
-    # levels have said so all along: adding artwork where there is none is
-    # ENRICHMENT, replacing it is COVER_ART.
+    # album already has is the artwork action's, because it is the change a user
+    # is most likely to want to undo on its own — an Addition and a Replacement
+    # are different operations (#468), and a tagging is permitted only the first.
     #
     # Per FILE, not per album, which is why this is a set of targets rather than
     # a flag: an album with ten good images and two gaps gets the two filled and
     # the ten left exactly as they are. That album is #397, and it is the shape
-    # this rule exists for.
+    # this rule exists for. A folder cover the album lacks is an addition too.
     #
     # `overwrite_art` remains what it always was — an explicit "embed the folder
     # cover over everything" — and is the one way a tagging still replaces.
-    cover = art.winner
-    art_targets = frozenset(files if overwrite_art else art.gaps())
-    promote_cover = art.promote_cover if overwrite_art else None
+    scope = artwork.Scope.ALL if overwrite_art else artwork.Scope.ADDITIONS
+    withheld = expected_artwork is not None and art.fingerprint(scope) != expected_artwork
+    art_targets = frozenset() if withheld else art.track_targets(scope)
+    cover_change = None if withheld else art.cover_change(scope)
+    # The bytes only when something is really written. With `cover=None`
+    # write_tags leaves the existing art alone, so an album that needs nothing
+    # costs no second read of its winner (#44, #74).
+    cover: bytes | None = None
+    if art_targets or cover_change is not None:
+        try:
+            cover = _winner_bytes(art, cover_path, archive)
+        except ArtworkChangedError:
+            # Between reading the album and loading the image, the image moved.
+            # Tag without it rather than write something the plan never named.
+            log.warning(
+                "the winning artwork for %s changed while it was being tagged — "
+                "tagging without writing any",
+                album_dir.name,
+                exc_info=True,
+                extra={"album_id": sidecar_mod.album_id_for(album_dir)},
+            )
+            art_targets, cover_change = frozenset(), None
 
     return _Prepared(
         files=files,
         pairs=pairs,
+        art=art,
         cover=cover,
-        art_before=art_before,
         # Only now is it settled that the embed is really happening — the
-        # per-track-art guard above may have cancelled it.
-        art_after=images.digest(cover) if cover is not None else None,
-        preserves_per_track_art=preserves_per_track_art,
-        promote_cover=promote_cover,
+        # per-track-art guard may have cancelled it, and the preview check may
+        # have withheld it.
+        art_after=art.winner.digest if cover is not None and art.winner is not None else None,
         art_targets=art_targets,
+        cover_change=cover_change,
+        art_withheld=withheld,
         media_total=len(release.get("medium-list", [])) or 1,
         accepted_album_title=title_with_disambiguation(
             release.get("title"), release.get("disambiguation")
@@ -756,7 +723,7 @@ def _changes_for(
     tagset: TagSet,
     before: dict[str, Any],
     file_path: Path,
-    art_before: dict[Path, str | None],
+    art_before: Mapping[Path, str | None],
     art_after: str | None,
     accepted_album_title: str | None = None,
     accepted_countries: frozenset[str] = frozenset(),
@@ -847,18 +814,21 @@ def _record_changes(
     )
 
 
-def _art_digests(files: list[Path]) -> dict[Path, str | None]:
-    """Each file's embedded cover as a sha256, or None where it has none.
+def _embedded_art(path: Path) -> formats.EmbeddedArt | None:
+    """One file's embedded image, described — or None where it carries none.
 
     One read per file, at tag time, when the files are being opened anyway. The
-    same pass answers two questions that used to need separate machinery: whether
-    the album carries per-track artwork worth preserving, and what each track's
-    art WAS, so a tagging can record that it replaced it (#86).
+    same pass answers the questions that used to need separate machinery:
+    whether the album carries per-track artwork worth preserving, how large each
+    image is, and what each track's art WAS, so a tagging can record that it
+    replaced it (#86).
 
-    sha256 rather than the sha1 this used before #86: the digest is recorded, and
-    #131 stores the images content-addressed under it, so the two must agree.
+    Described by `EmbeddedArt.of`, exactly as `formats.read_tags` describes it
+    for the album page — so the digest this records is the one the artwork store
+    keys on (#131), and the page and the tagger plan from identical facts.
     """
-    return {f: images.digest(art[0]) if (art := formats.read_cover(f)) else None for f in files}
+    art = formats.read_cover(path)
+    return formats.EmbeddedArt.of(art[0], art[1]) if art is not None else None
 
 
 def _mime_for(path: Path) -> str:
@@ -867,96 +837,148 @@ def _mime_for(path: Path) -> str:
     return "image/png" if path.suffix.lower() == ".png" else "image/jpeg"
 
 
-def _archive_candidate(release: Release) -> bytes | None:
-    """The archive's image for this release, when it is cached AND larger than
-    the folder cover — or None.
+def _archive_candidate(release: Release) -> cover_art.Front | None:
+    """The archive's image for this release from the LOCAL CACHE, or None.
 
-    Cache-only, deliberately. The fetch happens when the user asks for a check
-    (#276); by the time a tagging runs, the answer either is on disk or is not,
-    and a tagging that reached the network would put a request behind every
-    album the gardener touches.
+    Cache-only, deliberately. A tagging entry point that needs the archive asks
+    it before tagging starts (`cover_art.front_image`) and hands the answer in;
+    everything else — the gardener's `plan_album` above all — must not put a
+    request behind every album it touches.
     """
     mbid = release.get("id")
-    if not isinstance(mbid, str):
-        return None
-    path = cover_art.cached_image(mbid)
-    if path is None:
-        return None
-    try:
-        return path.read_bytes()
-    except OSError:
-        log.exception("could not read the cached archive image for %s", mbid)
-        return None
+    return cover_art.cached_front(mbid) if isinstance(mbid, str) else None
 
 
-def _album_image(digests: dict[Path, str | None]) -> tuple[Path, bytes] | None:
-    """The album's own artwork and the file to read it from, when it has exactly
-    one — or None.
+class ArtworkChangedError(Exception):
+    """The image a plan names is not the image found when it came to be written.
 
-    "Exactly one distinct embedded image, carried by at least one track" is what
-    makes the album speak with one voice. In practice this guards the album with
-    NO embedded art at all, since per-track artwork has already set `cover` to
-    None upstream and this is never reached for it. Stated as the positive
-    condition anyway: what makes the decisions below safe is that the album has
-    one image, and a reader should not have to trace an outer guard to see it.
-    (A compilation's first sleeve is not the album's cover, however large it is.)
+    Raised before anything is written. The plan was reviewed, or at least
+    decided, against one picture; writing a different one under it would be the
+    preview saying one thing and the write doing another (#469).
     """
-    distinct = {d for d in digests.values() if d is not None}
-    if len(distinct) != 1:
-        return None
-    source = next((path for path, d in digests.items() if d is not None), None)
-    if source is None:
-        return None
-    art = formats.read_cover(source)
-    return (source, art[0]) if art is not None else None
 
 
-def _promote_album_image(
-    album_dir: Path, cover_path: Path, incoming: bytes, album_id: str | None
-) -> tuple[str, str] | None:
-    """Write the album's own image over the folder cover, keeping what was there.
+def _winner_bytes(
+    plan: artwork.ArtworkPlan, cover_path: Path | None, archive: cover_art.Front | None
+) -> bytes:
+    """The image the plan writes, read from where the plan found it — and
+    checked to BE that image, by digest.
 
-    Returns `(was, now)` as digests so the caller can record the change the way a
-    tagged file's artwork change is recorded — which is what puts an Undo on it,
-    since `tag_history.artwork_replaced` reads exactly that pair.
+    The plan carries descriptions, not bytes: an album page holds every track's
+    tags at once, and carrying the images too would be hundreds of megabytes on
+    a box set (`EmbeddedArt`). So the bytes are fetched here, once, at the last
+    moment — and anything that has moved since the plan was made is refused
+    rather than written.
+    """
+    winner = plan.winner
+    if winner is None:
+        raise ArtworkChangedError("the plan writes no image")
+    data: bytes | None = None
+    try:
+        if plan.source is artwork.Source.FOLDER and cover_path is not None:
+            data = cover_path.read_bytes()
+        elif plan.source is artwork.Source.ALBUM:
+            carrier = next((p for p, d in plan.before.items() if d == winner.digest), None)
+            art = formats.read_cover(carrier) if carrier is not None else None
+            data = art[0] if art is not None else None
+        elif plan.source is artwork.Source.ARCHIVE and archive is not None:
+            data = archive.data
+    except OSError as e:
+        raise ArtworkChangedError(f"could not read the winning image again: {e}") from e
+    if data is None or images.digest(data) != winner.digest:
+        raise ArtworkChangedError("the winning image is no longer where the plan found it")
+    return data
 
-    Best-effort, like every other artwork operation: a promotion that cannot be
+
+class _Wrote(StrEnum):
+    """How one folder-cover write went."""
+
+    WRITTEN = "written"
+    #: The folder no longer holds what the plan saw — an edit made since.
+    STALE = "stale"
+    #: It could not be done safely: unreadable, unkeepable, or unwritable.
+    FAILED = "failed"
+
+
+def _write_folder_cover(
+    album_dir: Path,
+    change: artwork.Change,
+    image: bytes,
+    source: artwork.Source | None,
+    album_id: str | None,
+) -> _Wrote:
+    """Create or replace the folder cover as `change` says, and record it.
+
+    Checked against the plan first. A creation finds no `cover.*` there now; a
+    replacement finds the very image it was planned against. Either one failing
+    means somebody changed the folder since, and their change stands.
+
+    A replacement keeps what it overwrites BEFORE writing, and is abandoned if
+    it can't: this is the one image the tracks cannot be used to put back, so
+    it is the one a failed backup would destroy irrecoverably (#408).
+
+    Best-effort, like every other artwork operation: a cover that cannot be
     written is a reason to warn, not to abandon the re-tag the user asked for.
+
+    Recorded twice, as a promotion always was: `cover.write` for forensics, and
+    a `tag.track` line carrying the `artwork` pair — the shape History renders
+    and the artwork Undo reads. A creation's pair is `[None, digest]`: the image
+    it added and the absence it added it to (#471 builds the Undo on that).
     """
+    target = change.target
+    if change.before is None:
+        if cover_art.cached_cover(target.parent) is not None:
+            log.info("%s gained a folder cover since it was planned; leaving it", album_dir.name)
+            return _Wrote.STALE
+    else:
+        try:
+            was = target.read_bytes()
+        except OSError:
+            log.exception("could not read %s to keep it before replacing it", target)
+            return _Wrote.FAILED
+        if images.digest(was) != change.before:
+            log.info("%s changed since it was planned; leaving it", target.name)
+            return _Wrote.STALE
+        if artwork_store.keep(was, mime=_mime_for(target)) is None:
+            log.warning(
+                "not replacing %s: its current image could not be kept, and the "
+                "change would not be undoable",
+                target.name,
+            )
+            return _Wrote.FAILED
     try:
-        was = cover_path.read_bytes()
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_bytes(image)
+        os.replace(tmp, target)
     except OSError:
-        log.exception("could not read %s to keep it before replacing it", cover_path)
-        return None
-    # Kept BEFORE the write, and the write is abandoned if it can't be: this is
-    # the first thing in Harmonist that overwrites a folder cover, so it is the
-    # first that could destroy one irrecoverably (#408).
-    if artwork_store.keep(was, mime=_mime_for(cover_path)) is None:
-        log.warning(
-            "not replacing %s with the album's larger image: its current cover "
-            "could not be kept, and the change would not be undoable",
-            cover_path.name,
-        )
-        return None
-    try:
-        tmp = cover_path.with_suffix(cover_path.suffix + ".tmp")
-        tmp.write_bytes(incoming)
-        os.replace(tmp, cover_path)
-    except OSError:
-        log.exception("could not write the album's larger image to %s", cover_path)
-        return None
+        log.exception("could not write the album's artwork to %s", target)
+        return _Wrote.FAILED
+
+    # The id the album answers to right now (#456). A cover is often created by
+    # an album's FIRST tagging, before any sidecar names it — and a bare None
+    # would leave exactly the albums most likely to gain a cover with no record
+    # of having gained one. `id_registry.peek` is a pure hash of the path, what
+    # `sidecar.write()` then persists as `temp_uid`, and what the scanner already
+    # calls the album meanwhile; the alias chain carries it forward from there.
+    album_id = album_id or id_registry.peek(album_dir)
+    details = {"was": change.before} if change.before is not None else {}
     audit.record(
         "cover.write",
         album_id=album_id,
         album=album_dir,
-        file=cover_path.name,
-        source="album",
-        bytes=len(incoming),
-        overwrote=True,
-        was=images.digest(was),
-        digest=images.digest(incoming),
+        file=target.name,
+        source=source.value if source is not None else "-",
+        bytes=len(image),
+        overwrote=change.before is not None,
+        digest=change.after,
+        **details,
     )
-    return images.digest(was), images.digest(incoming)
+    event_id = audit.record("tag.track", album_id=album_id, album=album_dir, file=target.name)
+    if event_id is not None:
+        activity_store.record_tag_changes(
+            event_id, file=target.name, changes={owned.ARTWORK: [change.before, change.after]}
+        )
+    return _Wrote.WRITTEN
 
 
 def _keep_doomed_art(digests: dict[Path, str | None], incoming: str) -> None:
@@ -1265,46 +1287,50 @@ class ArtworkUnavailableError(Exception):
     restoring anything is the confident lie the design forbids."""
 
 
-def update_artwork(
+@dataclass(frozen=True)
+class ArtworkOutcome:
+    """What an artwork action actually wrote — not what it was asked to."""
+
+    changed: int = 0
+    #: Targets left alone because they no longer held what the plan saw: an
+    #: edit made since, which stands. Named, so the user knows where to look.
+    stale: tuple[str, ...] = ()
+    #: Targets that could not be written safely, already logged.
+    failed: tuple[str, ...] = ()
+
+
+def apply_artwork(
     album_dir: Path,
-    release: Release,
-    cover_path: Path | None,
+    plan: artwork.ArtworkPlan,
     *,
-    files: list[Path] | None = None,
-    overwrite_art: bool = False,
-) -> int:
-    """Put the winning image on every track and on the folder cover (#418).
+    files: Sequence[Path],
+    cover_path: Path | None,
+    archive: cover_art.Front | None = None,
+    scope: artwork.Scope = artwork.Scope.ALL,
+) -> ArtworkOutcome:
+    """Carry out the part of `plan` that `scope` permits, and nothing else.
 
-    The other half of the split: a tagging fills gaps and replaces nothing, and
-    this replaces. It exists as its own action because replacing artwork is the
-    change a user is most likely to want to undo on its own — History has
-    offered a separate Undo for it since #131, and having one way to reverse
-    them separately and no way to do them separately was the asymmetry.
+    The executor half of #469. It decides nothing: which image, and where, came
+    from the plan — the one the album page drew its rows from, when the page is
+    who asked. A plan whose winner can no longer be found raises
+    `ArtworkChangedError` before anything is written.
 
-    Writes ARTWORK ONLY. Tags are not touched, not even the ones that happen to
-    be stale: pressing a button about images must not quietly re-tag an album,
-    which is the whole point of separating them.
+    Each target is re-read before it is written and left alone if it no longer
+    holds what the plan saw, so an image changed by anyone in between survives
+    and is reported rather than overwritten.
 
-    No count guard and no file-to-track pairing, unlike `_prepare` — an album
-    missing half its tracks still has artwork worth fixing, and which file is
-    which track has no bearing on what image it should carry.
-
-    Returns how many files changed. Zero is an ordinary answer: it means the
-    winner is already everywhere, which is what a second press should find.
+    Writes ARTWORK ONLY, through `formats.write_cover`. Tags are not touched.
     """
-    paths = files if files is not None else album_files.audio_files(album_dir)
+    changes = plan.scoped(scope)
+    if not changes:
+        return ArtworkOutcome()
+    image = _winner_bytes(plan, cover_path, archive)
+    digest = images.digest(image)
+    album_id = sidecar_mod.album_id_for(album_dir)
     # Named the same way a tagging names them, or the Undo this records would
     # address the wrong disc of a split album (#423).
-    naming = album_files.Naming(album_dir, paths)
-    art = decide_artwork(paths, release, cover_path, overwrite_art=overwrite_art)
-    winner, digest = art.winner, art.digest
-    if winner is None or digest is None:
-        return 0
-
-    album_id = sidecar_mod.album_id_for(album_dir)
-    targets = [p for p in paths if art.before.get(p) != digest]
-    if not targets and art.promote_cover is None:
-        return 0
+    naming = album_files.Naming(album_dir, files)
+    tracks = [c for c in changes if not c.folder_cover]
 
     # Before anything is written, and for the same reason `tag_album` records
     # its `tag.album` line first: a crash part-way through leaves evidence of
@@ -1313,48 +1339,50 @@ def update_artwork(
         "artwork.update",
         album_id=album_id,
         album=album_dir,
-        files=len(targets),
+        files=len(tracks),
         digest=digest,
-        mode="replace" if overwrite_art else "best",
+        scope=scope.value,
     )
     # Keep whatever is about to be destroyed, so this is undoable — the same
     # pass a tagging makes, and the reason the artwork store exists (#131).
-    _keep_doomed_art(art.before, digest)
+    _keep_doomed_art({c.target: c.before for c in tracks}, digest)
 
     changed = 0
-    for path in targets:
-        was = art.before.get(path)
-        formats.write_cover(path, winner)
+    stale: list[str] = []
+    failed: list[str] = []
+    for change in tracks:
+        name = naming.name_of(change.target)
+        current = formats.read_cover(change.target)
+        if (images.digest(current[0]) if current is not None else None) != change.before:
+            stale.append(name)
+            continue
+        formats.write_cover(change.target, image)
         changed += 1
         # Recorded in the shape a tagged file's artwork change takes, which is
         # what puts an Undo on it: `tag_history.artwork_replaced` reads that
         # pair and `restore_artwork` writes it back.
-        event_id = audit.record(
-            "tag.track",
-            album_id=album_id,
-            album=album_dir,
-            file=naming.name_of(path),
-        )
+        event_id = audit.record("tag.track", album_id=album_id, album=album_dir, file=name)
         if event_id is not None:
             activity_store.record_tag_changes(
-                event_id,
-                file=naming.name_of(path),
-                changes={owned.ARTWORK: [was, digest]},
+                event_id, file=name, changes={owned.ARTWORK: [change.before, change.after]}
             )
 
-    if art.promote_cover is not None and cover_path is not None:
-        promoted = _promote_album_image(album_dir, cover_path, art.promote_cover, album_id)
-        if promoted is not None:
-            was, now = promoted
-            event_id = audit.record(
-                "tag.track", album_id=album_id, album=album_dir, file=cover_path.name
-            )
-            if event_id is not None:
-                activity_store.record_tag_changes(
-                    event_id, file=cover_path.name, changes={owned.ARTWORK: [was, now]}
-                )
+    if (cover := plan.cover_change(scope)) is not None:
+        wrote = _write_folder_cover(album_dir, cover, image, plan.source, album_id)
+        if wrote is _Wrote.WRITTEN:
             changed += 1
-    return changed
+        elif wrote is _Wrote.STALE:
+            stale.append(cover.target.name)
+        else:
+            failed.append(cover.target.name)
+    return ArtworkOutcome(changed=changed, stale=tuple(stale), failed=tuple(failed))
+
+
+# No `update_artwork(album_dir, release, ...)` that decides and applies in one
+# call. It was the artwork action's entry point until #469, and would now have
+# no production caller: the action applies the plan its page was DRAWN from,
+# checked by fingerprint, and a convenience that re-decides behind the page's
+# back is exactly the parallel decision that change removed.
 
 
 def restore_artwork(

--- a/src/harmonist/web/main.py
+++ b/src/harmonist/web/main.py
@@ -2284,24 +2284,36 @@ def _artwork_view(
     pulled these bytes off disk and `TrackTags.art` is what it noticed about them.
     The one genuinely new read is the folder cover, once.
     """
-    audio, _ = _album_tracks(album.path, album.folders)
+    # Paths as well as tags: the view's plan names its targets by path, exactly
+    # as the tagger's does, so the fingerprint a re-tag carries back means the
+    # same files on both sides (#469). The same listing `_album_tracks` makes.
+    files = (
+        album_files.for_paths(album.folders)
+        if album.folders
+        else album_files.audio_files(album.path)
+    )
+    with timing.warn_if_slow(
+        "album artwork read", _SLOW_ALBUM_READ, album=album.path, files=len(files)
+    ):
+        tracks = [(f, formats.read_tags(f)) for f in files]
     if album.cover_path is None or not album.cover_path.exists():
-        return artwork.summarise(audio, None, caa, archive)
+        return artwork.summarise(album.path, tracks, None, caa, archive)
     try:
         data = album.cover_path.read_bytes()
     except OSError:
         # Loud, per the unattended rule — and NOT reported as "this album has no
         # folder cover". There is one; Harmonist couldn't read it, and the two
-        # lead to opposite conclusions about what a re-tag would do (#112). The
-        # view says so and shows no outcomes at all rather than guessing.
+        # lead to opposite conclusions about what applying would do (#112). The
+        # view says so and its plan writes nothing rather than guessing.
         log.exception("could not read the folder cover for %s", album.path)
-        return replace(artwork.summarise(audio, None, caa, archive), cover_unreadable=True)
+        return artwork.summarise(album.path, tracks, None, caa, archive, cover_unreadable=True)
     mime = "image/png" if album.cover_path.suffix.lower() == ".png" else "image/jpeg"
     cover = artwork.FolderCover(
         name=album.cover_path.name,
         image=formats.EmbeddedArt.of(data, mime),
+        path=album.cover_path,
     )
-    return artwork.summarise(audio, cover, caa, archive)
+    return artwork.summarise(album.path, tracks, cover, caa, archive)
 
 
 def _albums(request: Request) -> list[Album]:
@@ -3128,8 +3140,13 @@ def _tag_with_release(
     store_url_override: str | None = None,
     overwrite_art: bool = False,
     paths: Sequence[Path] | None = None,
+    expected_artwork: str | None = None,
 ) -> None:
     """Fetch MB release, fetch cover, write tags, update sidecar.
+
+    `expected_artwork` is the fingerprint of the artwork additions the album
+    page showed, when a page is who asked (#469). A tagging whose plan no
+    longer matches it writes the tags and no artwork.
 
     `mbid` is what to ask MusicBrainz for, not necessarily what the album ends
     up tagged as: a merged release redirects, and this follows the release it
@@ -3174,13 +3191,17 @@ def _tag_with_release(
     # fact arriving beside them.
     requested_mbid, mbid = mbid, release["id"]
     rg = release.get("release-group") or {}
+    cover_path = cover_art.cached_cover(album_path)
+    archive: cover_art.Front | None = None
     try:
-        cover_path = cover_art.ensure_cover(
-            album_path,
-            release_mbid=release["id"],
-            release_group_mbid=rg.get("id"),
-            size=cfg.cover_art.size,
-        )
+        # Asked only when the album has no folder cover — the one case a
+        # tagging has always spent a request on, and the one where the archive
+        # may be what the cover is created from. The answer is a CANDIDATE: the
+        # tagger's plan decides whether it wins (#469). An album whose folder
+        # cover already exists weighs the archive only from the cache, which
+        # the album page's own check fills.
+        if cover_path is None:
+            archive = cover_art.front_image(release["id"], rg.get("id"))
     except cover_art.CoverArtError:
         # Tagging is the work; the cover is a side effect of it (#458). Design
         # §"Cover art (mandatory)" already rules that an album with no cover
@@ -3188,9 +3209,9 @@ def _tag_with_release(
         # not produce a worse outcome than one that answered "there is none".
         # Losing a whole re-tag to a transient 503 is exactly that inversion.
         #
-        # `cover_path=None` is a value the tagger already handles: `_prepare`
-        # reads no bytes, `write_tags` leaves every file's existing art alone,
-        # and no artwork change is recorded because none happens.
+        # `archive=None` is a value the tagger already handles: the plan weighs
+        # what the album has, and a folder cover may still be created from the
+        # album's own artwork.
         #
         # Loud in both channels, because the two readers are different: the log
         # is all there is at 3am, and the activity line is how someone who
@@ -3205,13 +3226,14 @@ def _tag_with_release(
         # path under Docker, which is why audit records are relativised — and no
         # album id, so it floats attributed to nothing.
         log.exception(
-            "cover art unavailable for %s — tagging without it", album_path, extra=_LOG_ONLY
+            "Cover Art Archive unavailable for %s — tagging without it",
+            album_path,
+            extra=_LOG_ONLY,
         )
         activity.warning(
-            "Cover art unavailable — tagged without it",
+            "Cover Art Archive unavailable — tagged without its artwork",
             album_id=sidecar_mod.album_id_for(album_path),
         )
-        cover_path = None
     tagger.tag_album(
         album_path,
         release,
@@ -3222,6 +3244,8 @@ def _tag_with_release(
         # primary one, so tagging what is under that alone would leave the rest
         # of the album on its old tags.
         files=album_files.for_paths(paths) if paths else None,
+        archive=archive,
+        expected_artwork=expected_artwork,
     )
 
     sc = sidecar_mod.read(album_path)
@@ -3749,13 +3773,12 @@ def _register_routes(app: FastAPI) -> None:
         download_format: str = Form(...),
         max_downloads_per_sync: int = Form(...),
         user_agent: str = Form(...),
-        cover_art_size: str = Form(...),
         gardener_level: str = Form(...),
         log_level: str = Form(...),
     ) -> Response:
         cfg: config_mod.Config = request.app.state.cfg
         # Re-validate by constructing fresh sub-models (model_copy does NOT
-        # validate). Bad values (e.g. an invalid cover-art size) raise here.
+        # validate). Bad values (e.g. an unknown gardener level) raise here.
         try:
             new_bandcamp = config_mod.BandcampConfig(
                 download_format=download_format.strip(),
@@ -3766,7 +3789,6 @@ def _register_routes(app: FastAPI) -> None:
             new_mb = config_mod.MusicBrainzConfig(user_agent=user_agent.strip())
             # model_validate (vs the constructor) keeps mypy happy about the
             # str→Literal narrowing while still validating the value at runtime.
-            new_cover = config_mod.CoverArtConfig.model_validate({"size": cover_art_size})
             new_gardener = config_mod.GardenerConfig.model_validate(
                 {"level": gardener_level.strip()}
             )
@@ -3774,7 +3796,6 @@ def _register_routes(app: FastAPI) -> None:
                 update={
                     "bandcamp": new_bandcamp,
                     "musicbrainz": new_mb,
-                    "cover_art": new_cover,
                     "gardener": new_gardener,
                     "log_level": log_level.strip().lower(),
                 }
@@ -3790,7 +3811,6 @@ def _register_routes(app: FastAPI) -> None:
                 "bandcamp.download_format": new_bandcamp.download_format,
                 "bandcamp.max_downloads_per_sync": new_bandcamp.max_downloads_per_sync,
                 "musicbrainz.user_agent": new_mb.user_agent,
-                "cover_art.size": new_cover.size,
                 "gardener.level": new_gardener.level,
                 "log_level": new_cfg.log_level,
             },
@@ -4559,6 +4579,7 @@ def _register_routes(app: FastAPI) -> None:
         album_id: str,
         overwrite_art: bool = Form(False),
         accept_short: bool = Form(False),
+        art_plan: str = Form(""),
     ) -> Response:
         """Re-tag a Library album from the MusicBrainz release it names.
 
@@ -4566,6 +4587,11 @@ def _register_routes(app: FastAPI) -> None:
         when the guard refuses (#252) — tag the files against a release that lists
         more tracks than are on disk. It is a decision, so it arrives from a
         control the user pressed; the endpoint never infers it from the counts.
+
+        `art_plan` is the fingerprint of the artwork this re-tag would add, as
+        the Artwork section drew it (#469). Absent when the section has not
+        loaded — the re-tag then writes what its own plan says, as every
+        tagging without a page does.
         """
         album = _find_album(request, album_id)
         sc = album.sidecar
@@ -4603,6 +4629,7 @@ def _register_routes(app: FastAPI) -> None:
                 incomplete=accept_short or album.state == AlbumState.INCOMPLETE,
                 overwrite_art=overwrite_art,
                 paths=album.folders,
+                expected_artwork=art_plan or None,
             )
         except mb_lookup.ReleaseGoneError:
             # Not a failure to report as one: MusicBrainz has deleted the release
@@ -5081,9 +5108,13 @@ def _register_routes(app: FastAPI) -> None:
         # What the archive has to beat to be worth downloading: the widest image
         # the album already has. A candidate that loses is measured and
         # forgotten; only a winner costs the full 200 KB–5 MB.
+        #
+        # Zero when the album has no image at all, so ANY cover the archive has
+        # is downloaded: it would be written into that album, and a preview of an
+        # addition has to show the picture it adds (#469).
         best = max(
             (r.image.size.width for r in current.images if r.image and r.image.size),
-            default=None,
+            default=0,
         )
         try:
             # The release group, from the STORED release payload — a local read
@@ -5123,8 +5154,9 @@ def _register_routes(app: FastAPI) -> None:
             )
 
     @app.post("/album/{album_id}/artwork/update", response_class=HTMLResponse)
-    def album_artwork_update(request: Request, album_id: str) -> Response:
-        """Put the winning image on every track and on the folder cover (#418).
+    def album_artwork_update(request: Request, album_id: str, plan: str = Form("")) -> Response:
+        """Apply the artwork the section shows: the plan its rows were read off
+        (#418, #469).
 
         Artwork only — no tags are written, not even stale ones. A button about
         images that quietly re-tagged an album would defeat the separation this
@@ -5132,48 +5164,71 @@ def _register_routes(app: FastAPI) -> None:
         want to undo on its own, and History has offered a separate Undo for it
         since #131.
 
+        `plan` is the fingerprint of what the page showed. The section is
+        rebuilt from disk here, and nothing is written unless it still says the
+        same thing — an image edited in another tab, or an archive candidate that
+        arrived after the page was drawn, sends the section back to be looked at
+        again rather than being written under a preview that described something
+        else. No MusicBrainz request either way: the archive's image comes from
+        the same local cache the page read.
+
         Re-renders the section, so what the page shows afterwards is what is now
         on disk rather than what was proposed a moment ago.
         """
         album = _refreshed_from_disk(request, _find_album(request, album_id))
         mbid = album.sidecar.mb_release_id if album.sidecar else None
-        if mbid is None:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, "album has no MusicBrainz release")
-        try:
-            release = mb_cache.fetch_release(mbid)
-        except mb_lookup.MBError as e:
-            return _flash_response(
-                "Couldn't update artwork", str(e), level=Level.ERROR, tasks_changed=False
+        caa = caa_cache.stored(mbid) if mbid else None
+        view = _artwork_view(album, caa, _archive_image(mbid))
+
+        def section(*, changed_since: bool = False) -> Response:
+            # Re-read from disk: the files may just have changed, and the
+            # section describes what they carry.
+            fresh = _refreshed_from_disk(request, _find_album(request, album_id))
+            return _templates(request).TemplateResponse(
+                request,
+                "partials/_artwork.html",
+                _ctx(
+                    request,
+                    album=fresh,
+                    artwork=_artwork_view(fresh, caa, _archive_image(mbid)),
+                    artwork_changed_since=changed_since,
+                    # Stated rather than left undefined: writing artwork changes
+                    # what the album carries, not what the archive holds, so this
+                    # response has no reason to send anyone back to ask (#436).
+                    caa_check_due=False,
+                ),
             )
-        changed = tagger_mod.update_artwork(
-            album.path,
-            release,
-            album.cover_path,
-            files=album_files.for_paths(album.folders) if album.folders else None,
-        )
-        activity.info(
+
+        if view.plan is None or plan != view.fingerprint:
+            log.info("artwork for %s changed since the page was drawn; not applying", album.path)
+            return section(changed_since=True)
+        try:
+            outcome = tagger_mod.apply_artwork(
+                album.path,
+                view.plan,
+                files=album_files.for_paths(album.folders)
+                if album.folders
+                else album_files.audio_files(album.path),
+                cover_path=album.cover_path,
+                archive=cover_art.cached_front(mbid) if mbid else None,
+            )
+        except tagger_mod.ArtworkChangedError:
+            log.info("the winning image for %s moved before it was written", album.path)
+            return section(changed_since=True)
+        changed = outcome.changed
+        message = (
             f"Updated artwork on {changed} file{'s' if changed != 1 else ''}"
             if changed
-            else "Artwork was already up to date",
-            album_id=album.id,
+            else "Artwork was already up to date"
         )
-        # Re-read from disk: the files just changed, and the section describes
-        # what they carry.
-        album = _refreshed_from_disk(request, _find_album(request, album_id))
-        caa = caa_cache.stored(mbid)
-        return _templates(request).TemplateResponse(
-            request,
-            "partials/_artwork.html",
-            _ctx(
-                request,
-                album=album,
-                artwork=_artwork_view(album, caa, _archive_image(mbid)),
-                # Stated rather than left undefined: writing artwork changes
-                # what the album carries, not what the archive holds, so this
-                # response has no reason to send anyone back to ask (#436).
-                caa_check_due=False,
-            ),
-        )
+        if outcome.stale or outcome.failed:
+            # Named, because the remedy is to go and look at those files — and a
+            # count alone reads as Harmonist having done less than it said.
+            left = ", ".join((*outcome.stale, *outcome.failed))
+            activity.warning(f"{message} — left alone: {left}", album_id=album.id)
+        else:
+            activity.info(message, album_id=album.id)
+        return section()
 
     @app.post("/album/{album_id}/artwork/load-archive", response_class=HTMLResponse)
     def album_load_archive_image(request: Request, album_id: str) -> Response:

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -42,8 +42,8 @@
 {# How far an update reaches, as one chip (#366).
 
    `owned.Significance` ranks four levels by how much of the album they call into
-   question — cosmetic, enrichment, structure, identity — with artwork a fifth on
-   its own axis rather than a rank among them.
+   question — cosmetic, enrichment, structure, identity. Artwork is not among
+   them: it has its own chip below (#468).
 
    TWO CHANNELS, and neither does the other's job. The glyph says what KIND of
    change it is; the fill weight says HOW FAR it reaches, so the ordering is
@@ -69,7 +69,6 @@
     'enrichment': ('Enrichment', 'sev--enrichment', 'plus'),
     'structure':  ('Structure',  'sev--structure',  'order'),
     'identity':   ('Identity',   'sev--identity',   'tag'),
-    'artwork':    ('Artwork',    'sev--artwork',    'art'),
 } %}
 {% if _s in _spec %}
 {% set label, cls, glyph = _spec[_s] %}
@@ -77,9 +76,31 @@
     {% if glyph == 'aa' %}<span class="sev__aa" aria-hidden="true">Aa</span>
     {% elif glyph == 'plus' %}<svg class="sev__g" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
     {% elif glyph == 'order' %}<svg class="sev__g" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 20V4M7 4L3.5 7.5M7 4l3.5 3.5M17 4v16M17 20l-3.5-3.5M17 20l3.5-3.5"/></svg>
-    {% elif glyph == 'tag' %}<svg class="sev__g" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12.5V5a2 2 0 012-2h7.5L21 11.5 12.5 20z"/><circle cx="7.6" cy="7.6" r="1.5" fill="currentColor" stroke="none"/></svg>
-    {% else %}<svg class="sev__g" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4.5" width="18" height="15" rx="2"/><path d="M3 15.5l4.5-4.5 3.5 3.5 3-3 7 7"/></svg>
+    {% else %}<svg class="sev__g" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12.5V5a2 2 0 012-2h7.5L21 11.5 12.5 20z"/><circle cx="7.6" cy="7.6" r="1.5" fill="currentColor" stroke="none"/></svg>
     {% endif %}
+    {{ label }}
+</span>
+{% endif %}
+{%- endmacro %}
+
+{# What an artwork change DOES, as one chip (#468): an Addition fills a place
+   that held no image, a Replacement overwrites one. A plan doing both is a
+   Replacement — the half a reader deciding whether they mind needs to hear.
+
+   Deliberately not a severity level. The chips above say how far a TAG change
+   reaches; an image has no place on that scale, and ranking it there is what
+   made artwork a fifth level with no rank. It keeps the dashed edge that marked
+   it out then, and the album glyph. #}
+{% macro artwork_chip(operation) -%}
+{% set _o = operation | string %}
+{% set _spec = {
+    'addition':    ('Addition',    'Adds artwork where there is none — to a track without any, or as a folder cover the album lacks.'),
+    'replacement': ('Replacement', 'Replaces artwork the album already has. What is replaced is kept first, so it can be undone from History.'),
+} %}
+{% if _o in _spec %}
+{% set label, tip = _spec[_o] %}
+<span class="sev sev--artwork" title="{{ tip }}">
+    <svg class="sev__g" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4.5" width="18" height="15" rx="2"/><path d="M3 15.5l4.5-4.5 3.5 3.5 3-3 7 7"/></svg>
     {{ label }}
 </span>
 {% endif %}

--- a/templates/partials/_album_update.html
+++ b/templates/partials/_album_update.html
@@ -70,16 +70,18 @@
            cover that; not drawing it at all is better, and the endpoint's
            own refusal (#194) was always the real guard. #}
         {% if comparison.mb_available and album.sidecar and album.sidecar.mb_release_id %}
+        {# `hx-include` carries the Artwork section's fingerprint of what this
+           re-tag would add (#469), so it writes only artwork the page showed.
+           Nothing is carried until that section has loaded. #}
         <button id="retag-btn-{{ album.id }}"
                 hx-post="/retag/{{ album.id }}"
+                hx-include="#art-plan-{{ album.id }}"
                 hx-swap="none" hx-disabled-elt="this" hx-indicator="#tagging-{{ album.id }}"
                 class="album-finding__act"
-                {# What it does to artwork, kept true (#417). It read
-                   "Per-track embedded artwork is preserved", which was the
-                   whole story until a re-tag could also replace a folder
-                   cover and embed a larger image. Since #418 it is simpler
-                   than either: a re-tag never replaces an image you have. #}
-                title="Re-tag from MusicBrainz. Your artwork is left alone — a track with none is given the album's cover.">
+                {# What it does to artwork, kept true (#417). Since #418 a
+                   re-tag never replaces an image you have; it fills what is
+                   empty, and a missing folder cover is one of those (#457). #}
+                title="Re-tag from MusicBrainz. Your artwork is left alone — a track with none, or a missing folder cover, is given the album's best image.">
             Re-tag from MB
         </button>
         {% endif %}

--- a/templates/partials/_artwork.html
+++ b/templates/partials/_artwork.html
@@ -1,16 +1,23 @@
-{% from 'macros.html' import severity_chip %}
-{# What artwork this album carries, and what a re-tag would do to it (#155).
+{% from 'macros.html' import artwork_chip %}
+{# What artwork this album carries, and what applying it would do (#155).
 
    One row per distinct image, labelled by everything carrying it — tracks and
    the folder cover alike, so an album where they agree is a single row reading
-   "All 12 tracks and cover.jpg" rather than one picture drawn twice (#400).
+   "All 12 tracks and cover.jpg" rather than one picture drawn twice (#400). A
+   folder cover the album does not have yet is a row too, when the plan
+   creates one (#457).
 
    A row that would be written to SHOWS what it would become, on the right,
    under a heading that dates it. Words alone could not: "Replaced by the
    album's own artwork" reads equally as something that has already happened
    (#413), and no wording fixes that as directly as a second picture under
-   "After a re-tag" does. Rows that change nothing stay silent and keep the
+   "After Apply" does. Rows that change nothing stay silent and keep the
    column empty, as agreement does everywhere else on this page.
+
+   The right-hand column is the artwork PLAN — the one the Apply button
+   executes, checked against the fingerprint the form carries (#469). The rows
+   on the left are what the album has; nothing on the left implies a write. #}
+{#
 
    The incoming image is usually also a row of its own further down — the two
    halves of one album's artwork are both things it HAS (#406). That repetition
@@ -37,33 +44,23 @@
 
 {% if artwork.cover_unreadable %}
 {# "Couldn't read it" and "there isn't one" lead to opposite conclusions about
-   what a re-tag would write, so the section says which (#112). #}
+   what applying would write, so the section says which (#112). #}
 <p class="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
-    This album has a folder cover, but Harmonist couldn't read it — so what a
-    re-tag would embed can't be shown. The error is in the application log.
+    This album has a folder cover, but Harmonist couldn't read it — so what
+    applying the artwork would write can't be shown. The error is in the
+    application log.
 </p>
 {% endif %}
 
-{# There is no cover.jpg, and re-tagging writes one (#457). Said BEFORE the fact
-   rather than discovered afterwards in the folder: the file is mandatory for
-   Navidrome (design §"Cover art"), so a tagging creates it whether or not
-   anyone pressed anything about artwork, and an unannounced 3 MB image
-   appearing in a music folder reads as Harmonist having done something it was
-   not asked to.
-
-   Attributed to RE-TAGGING specifically, not to "Harmonist": the Update artwork
-   button below cannot create this file, only replace one that exists, and a
-   sentence that blurred the two would send the reader to the wrong control.
-
-   Stated, not drawn as a row. A row would count toward `artwork.writes`, which
-   is what puts that button on the page — see `ArtworkView.creates_cover_from`.
-
-   Neutral, not amber: nothing is wrong here. The album is missing a file that
-   is about to arrive, which is the same register as the rest of the section. #}
-{% if artwork.creates_cover_from %}
-<p class="text-sm text-muted">
-    This album has no <code class="text-2xs">cover.jpg</code> beside its tracks.
-    Re-tagging creates one from {{ artwork.creates_cover_from }}.
+{# The button was pressed on a page that no longer describes the album (#469):
+   an image edited since, or an archive cover that arrived after the page was
+   drawn. Nothing was written, and the section below is the fresh account —
+   which is the thing to look at before pressing again. Amber, because the user
+   asked for something and it did not happen. #}
+{% if artwork_changed_since %}
+<p class="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+    This album's artwork changed after the page showed it, so nothing was
+    written. This is what applying would do now.
 </p>
 {% endif %}
 
@@ -93,7 +90,7 @@
     {% if artwork.writes %}
     <div class="art-rows__head">
         <span>Now</span>
-        <span>After a re-tag</span>
+        <span>After Apply</span>
     </div>
     {% endif %}
 
@@ -109,6 +106,10 @@
             {% if r.title %}<span class="art-row__title">{{ r.title }}</span>{% endif %}
             {% if r.image %}
             <span class="art-row__meta">{{ describe_image(r.image) }}</span>
+            {% elif r.creates %}
+            {# A folder cover the album does not have yet (#457): the empty
+               frame is the finding, the picture beside it what will fill it. #}
+            <span class="art-row__meta-plain">not in the folder yet</span>
             {% else %}
             {# Named, not counted: the remedy is per file, so the user needs to
                know which files to look at. #}
@@ -169,7 +170,7 @@
    value MusicBrainz would write and leaves an agreeing one plain. Before this
    the column had to carry both meanings, and could only carry one.
 
-   Its own heading, because "After a re-tag" above is a promise and this is the
+   Its own heading, because "After Apply" above is a promise and this is the
    one image on the page that certainly is not coming. "Also considered" is past
    tense on purpose: it says the thing was weighed and lost, which is also why
    there is no picture to show. #}
@@ -239,19 +240,26 @@
 
    No button when nothing would change, the same way the rows say nothing then.
 
-   `hx-confirm` because this overwrites images the user has; the folder cover is
-   kept first, so it can be put back from History (#408). #}
+   `plan` is the fingerprint of the right-hand column. The server rebuilds the
+   plan and writes only if it still matches, so the button applies what the
+   reader is looking at — not whatever the album has become since (#469).
+
+   `hx-confirm` only for a Replacement, because that overwrites images the user
+   has (kept first, so it can be put back from History, #408). An Addition fills
+   an empty place and costs a few megabytes at most; asking about it would train
+   the reader to click through the one question that matters. #}
 {% if artwork.writes %}
 <form hx-post="/album/{{ album.id }}/artwork/update"
       hx-target="#album-artwork" hx-swap="innerHTML"
       hx-disabled-elt="find button"
-      hx-confirm="Update this album's artwork? What is replaced is kept, so this can be undone from History."
+      {% if artwork.operation == 'replacement' %}hx-confirm="Replace artwork this album already has? What is replaced is kept, so this can be undone from History."{% endif %}
       class="pt-1">
+    <input type="hidden" name="plan" value="{{ artwork.fingerprint }}">
     <button type="submit"
             class="text-2xs uppercase tracking-widest font-bold px-3 py-1.5 rounded
                    border border-mb-purple/40 text-mb-purple hover:bg-mb-purple/10 transition"
-            title="Write the winning image to every track and to the folder cover"
-            aria-label="Update this album's artwork">Update artwork</button>
+            title="Write what the After Apply column shows. No tags are touched."
+            aria-label="Apply this album's artwork">Apply artwork</button>
 </form>
 {% endif %}
 
@@ -324,8 +332,17 @@
    whole reason that section exists.
 
    The anchor is gone with it, and its stray purple with it — purple means
-   MusicBrainz, and navigating down a page is not that. #}
+   MusicBrainz, and navigating down a page is not that.
+
+   The hidden input is what Re-tag from MB carries (`hx-include`): the
+   fingerprint of the artwork a re-tag would ADD, as drawn here. A re-tag whose
+   own plan no longer matches it tags the album and writes no artwork (#469).
+   Here, in the element that is always swapped, so it is present whenever the
+   section has loaded and absent — the re-tag then carries nothing — until it
+   has. #}
 <div id="album-artwork-note-{{ album.id }}" hx-swap-oob="true">
+    <input type="hidden" id="art-plan-{{ album.id }}" name="art_plan"
+           value="{{ artwork.tagging_fingerprint }}">
     {% if artwork.writes %}
     <div class="album-finding">
         {# The album glyph the Artwork severity already uses, muted: this finding
@@ -339,18 +356,20 @@
             </svg>
         </span>
         <h2 class="album-update__legend">{{ artwork.summary }}</h2>
-        {# The dashed chip, which has existed for artwork since #366 and has
-           never had anywhere to appear: artwork is a fifth level on its own
-           axis rather than a rank among the other four. #}
-        {{ severity_chip('artwork') }}
+        {# What KIND of artwork change this is — Addition or Replacement (#468).
+           Not a rank beside the tag levels: whether the target already held an
+           image is the question a reader deciding whether they mind is asking,
+           and it is also whether there is anything for an Undo to put back. #}
+        {{ artwork_chip(artwork.operation) }}
         <form hx-post="/album/{{ album.id }}/artwork/update"
               hx-target="#album-artwork" hx-swap="innerHTML"
               hx-disabled-elt="find button"
-              hx-confirm="Update this album's artwork? What is replaced is kept, so this can be undone from History."
+              {% if artwork.operation == 'replacement' %}hx-confirm="Replace artwork this album already has? What is replaced is kept, so this can be undone from History."{% endif %}
               class="album-finding__act-form">
+            <input type="hidden" name="plan" value="{{ artwork.fingerprint }}">
             <button type="submit" class="album-finding__act"
-                    title="Write the winning image to every track and to the folder cover. No tags are touched.">
-                Update artwork
+                    title="Write the artwork the Artwork section shows under After Apply. No tags are touched.">
+                Apply artwork
             </button>
         </form>
     </div>

--- a/templates/partials/library_detail.html
+++ b/templates/partials/library_detail.html
@@ -172,6 +172,7 @@
                describes the mechanism; here what matters is the effect on the
                files this badge is counting. #}
             <button hx-post="/retag/{{ album.id }}"
+                    hx-include="#art-plan-{{ album.id }}"
                     hx-swap="none" hx-disabled-elt="this" hx-indicator="#tagging-{{ album.id }}"
                     class="mt-2 ml-1.5 px-2 py-1 rounded-md text-2xs font-bold uppercase tracking-widest
                            bg-white hover:bg-surface text-ink border border-line transition"

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -91,16 +91,6 @@
         </label>
 
         <label class="block">
-            <span class="block text-xs font-bold text-ink mb-1">Cover art size</span>
-            <select name="cover_art_size"
-                    class="w-full bg-white border border-line rounded px-3 py-1.5 text-sm text-ink focus:border-accent outline-none">
-                {% for s in ['250', '500', '1200', 'original'] %}
-                <option value="{{ s }}" {{ 'selected' if s == cfg.cover_art.size }}>{{ s }}</option>
-                {% endfor %}
-            </select>
-        </label>
-
-        <label class="block">
             <span class="block text-xs font-bold text-ink mb-1">MusicBrainz user agent</span>
             <input type="text" name="user_agent" required
                    value="{{ cfg.musicbrainz.user_agent }}"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,7 +21,7 @@ _PRISTINE_GLOBALS = {
     (mb_lookup, "fetch_release_urls"): mb_lookup.fetch_release_urls,
     (mb_lookup, "lookup_by_bandcamp_url"): mb_lookup.lookup_by_bandcamp_url,
     (mb_search, "search_releases"): mb_search.search_releases,
-    (cover_art, "ensure_cover"): cover_art.ensure_cover,
+    (cover_art, "front_image"): cover_art.front_image,
     (cover_art, "check_front"): cover_art.check_front,
     (cover_art, "fetch_image"): cover_art.fetch_image,
 }

--- a/test/e2e/test_artwork_apply.py
+++ b/test/e2e/test_artwork_apply.py
@@ -1,0 +1,91 @@
+"""The artwork a page shows is the artwork its buttons write (#469).
+
+`test_web.py` proves the server half: a fingerprint that matches writes, one
+that doesn't writes nothing. It cannot prove the browser half, and both halves
+of this are browser questions:
+
+- Re-tag from MB carries the fingerprint with `hx-include`, pointing at a hidden
+  input that arrives in ANOTHER fragment's out-of-band swap. Whether HTMX finds
+  it there when the button is pressed is exactly the kind of wiring a correct
+  string in a response says nothing about (#40).
+- Apply artwork posts the fingerprint from its own form. A form that lost the
+  input would still render, still post, and be refused every time — the section
+  redrawing itself with nothing written, which reads like a slow button.
+
+Its own module, so its own demo server: pressing Apply writes into the demo
+album, and `test_artwork_section.py` counts that album's images.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1", reason="e2e disabled (set RUN_E2E=1)"
+)
+playwright_sync = pytest.importorskip("playwright.sync_api")
+
+# The demo album seeded with `"art": "gaps"`: one track carries no image, so the
+# plan has an addition to make.
+ALBUM_ID = "demo-rel-dingoes"
+
+
+def test_re_tag_carries_the_fingerprint_the_artwork_section_drew(demo_server: str) -> None:
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+
+        page.goto(f"{demo_server}/album/{ALBUM_ID}")
+        page.wait_for_selector("#album-artwork .art-row")
+
+        # The out-of-band half has landed where the page reserved room for it.
+        drawn = page.locator(f"#art-plan-{ALBUM_ID}").get_attribute("value")
+        assert drawn and re.fullmatch(r"[0-9a-f]{64}", drawn), drawn
+
+        # What HTMX would submit for every control that re-tags this album. Asked
+        # of HTMX itself rather than by pressing one, which would re-tag the
+        # demo album under the next test.
+        carried = page.evaluate(
+            """() => [...document.querySelectorAll('[hx-post^="/retag/"]')]
+                    .map(el => htmx.values(el).art_plan)"""
+        )
+        assert carried, "no re-tag control on the page to carry anything"
+        assert set(carried) == {drawn}
+
+        browser.close()
+
+
+def test_apply_artwork_writes_what_the_section_showed(demo_server: str) -> None:
+    with playwright_sync.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        # A Replacement asks first; accept it, as the user pressing would.
+        page.on("dialog", lambda dialog: dialog.accept())
+
+        page.goto(f"{demo_server}/album/{ALBUM_ID}")
+        page.wait_for_selector("#album-artwork .art-row")
+        section = page.locator("#album-artwork")
+        # Lower-cased: the column headings are set in capitals by CSS, and
+        # `inner_text` reports what is rendered.
+        assert "after apply" in section.inner_text().lower()
+
+        button = section.get_by_role("button", name="Apply this album's artwork")
+        with page.expect_response(re.compile(r"/artwork/update$")) as answer:
+            button.click()
+        assert answer.value.ok
+        # The form's own fingerprint went with it…
+        assert re.search(r"plan=[0-9a-f]{64}", answer.value.request.post_data or "")
+
+        # …and it matched: the section redrew from the files it just wrote, with
+        # nothing left to apply, rather than coming back to say the album had
+        # changed under it.
+        page.wait_for_function(
+            "() => !document.querySelector('#album-artwork')"
+            ".innerText.toLowerCase().includes('after apply')"
+        )
+        assert "changed after the page showed it" not in section.inner_text().lower()
+
+        browser.close()

--- a/test/e2e/test_artwork_section.py
+++ b/test/e2e/test_artwork_section.py
@@ -80,15 +80,20 @@ def test_every_row_reaches_its_own_image(demo_server: str) -> None:
         page.goto(f"{demo_server}/album/{ALBUM_ID}")
         page.wait_for_selector("#album-artwork .art-row")
 
+        # Every button that SHOWS an image. The archive's "load" frame shares the
+        # class and opens nothing by design — it fetches — so it names no target.
         targets = [
-            b.get_attribute("popovertarget")
+            t
             for b in page.locator("#album-artwork button.art-row__art").all()
+            if (t := b.get_attribute("popovertarget"))
         ]
-        # The tracks' image and the folder cover — one button each. The folder
-        # cover is no longer drawn a second time per row it would replace (#406).
-        assert len(targets) == 2, "expected the tracks' image and the folder cover"
+        # Two images on this album — the tracks' and the folder cover's — however
+        # many places each is drawn: the tracks' image is also what fills the
+        # gap, on the After Apply side. Counting buttons rather than images went
+        # stale the moment an image could appear twice.
+        assert len(set(targets)) == 2, "expected the tracks' image and the folder cover"
 
-        for target in targets:
+        for target in set(targets):
             assert page.locator(f"#{target}").count() == 1, f"{target} is not a single element"
 
         browser.close()

--- a/test/test_artwork.py
+++ b/test/test_artwork.py
@@ -159,17 +159,34 @@ def art_of(seed: int, *, width: int = 1400, height: int = 1400) -> EmbeddedArt:
     return EmbeddedArt.of(data, "image/png")
 
 
+#: Where these albums live. Nothing is read from it — `summarise` is pure — but
+#: the plan names its targets by path, and a created folder cover lands here.
+ALBUM = Path("/music/Artist/Album")
+
+
 def cover_of(image: EmbeddedArt, name: str = "cover.jpg") -> artwork.FolderCover:
     return artwork.FolderCover(name=name, image=image)
 
 
+def summarise(
+    tracks: Sequence[tuple[Path, TrackTags]],
+    cover: artwork.FolderCover | None,
+    caa: artwork.CoverArtAnswer | None = None,
+    archive: EmbeddedArt | None = None,
+    *,
+    cover_unreadable: bool = False,
+) -> artwork.ArtworkView:
+    """`artwork.summarise` for an album at `ALBUM`."""
+    return artwork.summarise(ALBUM, tracks, cover, caa, archive, cover_unreadable=cover_unreadable)
+
+
 def album(
     *art: EmbeddedArt | None, disc: int | None = None, titles: Sequence[str] = ()
-) -> list[tuple[str, TrackTags]]:
-    """An album of `(file_name, tags)`, one entry per track, numbered from 1."""
+) -> list[tuple[Path, TrackTags]]:
+    """An album of `(path, tags)`, one entry per track, numbered from 1."""
     return [
         (
-            f"{i:02d} Track.m4a",
+            ALBUM / f"{i:02d} Track.m4a",
             TrackTags(
                 art=a,
                 track_num=i,
@@ -188,7 +205,7 @@ class TestOutcomes:
         """Tracks and folder cover carrying one picture is ONE thing to look at,
         not a row plus an incoming copy of itself (#400)."""
         one = art_of(1)
-        view = artwork.summarise(album(one, one, one), cover_of(one))
+        view = summarise(album(one, one, one), cover_of(one))
 
         assert len(view.rows) == 1
         assert view.rows[0].label == "All 3 tracks and cover.jpg"
@@ -202,7 +219,7 @@ class TestOutcomes:
 
         A larger cover, so it is the one that wins and the row really is
         replaced — an equal one is left alone since #397."""
-        view = artwork.summarise(
+        view = summarise(
             album(art_of(1, width=400, height=400), art_of(1, width=400, height=400)),
             cover_of(art_of(2, width=900, height=900)),
         )
@@ -214,7 +231,7 @@ class TestOutcomes:
     def test_per_track_art_is_kept_and_says_nothing(self) -> None:
         """A compilation's covers are preserved, so no row may offer a
         replacement — and none may spend a column saying it doesn't."""
-        view = artwork.summarise(album(art_of(1), art_of(2), art_of(3)), cover_of(art_of(9)))
+        view = summarise(album(art_of(1), art_of(2), art_of(3)), cover_of(art_of(9)))
 
         # The three track rows are preserved; the fourth is the folder cover,
         # which is a file the album has and which nothing writes to either.
@@ -227,7 +244,7 @@ class TestOutcomes:
         that already carry it are left alone. The folder cover here is no better
         — same size, different picture — so it wins nothing."""
         one = art_of(1)
-        view = artwork.summarise(album(one, None, one, None), cover_of(art_of(2)))
+        view = summarise(album(one, None, one, None), cover_of(art_of(2)))
 
         outcomes = {r.is_gap: r.outcome for r in view.rows if r.tracks}
         assert outcomes == {False: artwork.Outcome.KEPT, True: artwork.Outcome.FILLED}
@@ -238,16 +255,24 @@ class TestOutcomes:
         """The other direction, and the reason the rule is about size rather
         than about never touching what is there."""
         small = art_of(1, width=400, height=400)
-        view = artwork.summarise(album(small, None), cover_of(art_of(2, width=900, height=900)))
+        view = summarise(album(small, None), cover_of(art_of(2, width=900, height=900)))
 
         outcomes = {r.is_gap: r.outcome for r in view.rows if r.tracks}
         assert outcomes == {False: artwork.Outcome.REPLACED, True: artwork.Outcome.FILLED}
 
-    def test_no_folder_cover_means_nothing_is_written(self) -> None:
-        view = artwork.summarise(album(art_of(1), None), None)
+    def test_no_folder_cover_takes_the_albums_own_image_everywhere_empty(self) -> None:
+        """With no folder cover the tracks' image is the winner by default, and
+        what is empty gets it: the artless track, and the folder cover the album
+        lacks (#457, #469). The track that has it is left exactly alone."""
+        one = art_of(1)
+        view = summarise(album(one, None), None)
 
-        assert {r.outcome for r in view.rows} == {artwork.Outcome.KEPT}
-        assert view.writes is False
+        own, created, gap = view.rows
+        assert own.outcome is artwork.Outcome.KEPT
+        assert (created.creates, created.outcome) == ("cover.png", artwork.Outcome.FILLED)
+        assert (gap.is_gap, gap.outcome) == (True, artwork.Outcome.FILLED)
+        assert created.written_image == one and gap.written_image == one
+        assert view.operation is artwork.Operation.ADDITION
 
     def test_outcomes_follow_the_taggers_own_verdict(self) -> None:
         """`preserves_per_track_art` in `tagger._prepare` and the KEPT rows here
@@ -260,16 +285,16 @@ class TestOutcomes:
 class TestLabels:
     def test_every_track_reads_as_all_of_them(self) -> None:
         one = art_of(1)
-        assert artwork.summarise(album(one, one, one), None).rows[0].label == "All 3 tracks"
+        assert summarise(album(one, one, one), None).rows[0].label == "All 3 tracks"
 
     def test_some_tracks_are_named_by_number(self) -> None:
         one, two = art_of(1), art_of(2)
-        rows = artwork.summarise(album(one, two, one), None).rows
+        rows = summarise(album(one, two, one), None).rows
         assert [r.label for r in rows] == ["Tracks 1, 3", "Track 2"]
 
     def test_consecutive_tracks_collapse_to_a_range(self) -> None:
         one, two = art_of(1), art_of(2)
-        assert artwork.summarise(album(one, one, one, two), None).rows[0].label == "Tracks 1–3"
+        assert summarise(album(one, one, one, two), None).rows[0].label == "Tracks 1–3"
 
     def test_a_multi_disc_album_names_the_disc(self) -> None:
         """A bare track number is not a unique reference across discs, and
@@ -277,49 +302,49 @@ class TestLabels:
         one, two = art_of(1), art_of(2)
         tracks = album(one, two, disc=1) + album(one, disc=2)
 
-        rows = artwork.summarise(tracks, None).rows
+        rows = summarise(tracks, None).rows
 
         assert rows[0].label == "Disc 1, track 1 · Disc 2, track 1"
         assert rows[1].label == "Disc 1, track 2"
 
     def test_a_single_disc_album_does_not_mention_discs(self) -> None:
         one, two = art_of(1), art_of(2)
-        rows = artwork.summarise(album(one, two, disc=1), None).rows
+        rows = summarise(album(one, two, disc=1), None).rows
         assert [r.label for r in rows] == ["Track 1", "Track 2"]
 
     def test_a_row_of_one_track_carries_its_title(self) -> None:
         """A number is a poor thing to recognise an image by; on a box set of
         episodes the title is how you know which one this is."""
         one, two = art_of(1), art_of(2)
-        view = artwork.summarise(album(one, two, titles=["Dexter's Chalk", "Appleshine"]), None)
+        view = summarise(album(one, two, titles=["Dexter's Chalk", "Appleshine"]), None)
 
         assert view.rows[0].title == "Dexter's Chalk"
 
     def test_a_row_of_several_tracks_carries_no_title(self) -> None:
         one = art_of(1)
-        view = artwork.summarise(album(one, one, titles=["A", "B"]), None)
+        view = summarise(album(one, one, titles=["A", "B"]), None)
         assert view.rows[0].title is None
 
     def test_unnumbered_tracks_fall_back_to_a_count(self) -> None:
         one, two = art_of(1), art_of(2)
         tracks = [
-            ("a.m4a", TrackTags(art=one)),
-            ("b.m4a", TrackTags(art=one)),
-            ("c.m4a", TrackTags(art=two)),
+            (ALBUM / "a.m4a", TrackTags(art=one)),
+            (ALBUM / "b.m4a", TrackTags(art=one)),
+            (ALBUM / "c.m4a", TrackTags(art=two)),
         ]
-        assert artwork.summarise(tracks, None).rows[0].label == "2 tracks"
+        assert summarise(tracks, None).rows[0].label == "2 tracks"
 
 
 class TestRows:
     def test_the_gap_row_names_the_files(self) -> None:
         """The remedy is per file, so a count would not be enough to act on."""
         one = art_of(1)
-        view = artwork.summarise(album(one, None), cover_of(one))
+        view = summarise(album(one, None), cover_of(one))
         gap = next(r for r in view.rows if r.is_gap)
         assert [t.name for t in gap.tracks] == ["02 Track.m4a"]
 
     def test_a_cover_no_track_carries_is_a_row_with_no_tracks(self) -> None:
-        view = artwork.summarise(album(None, None), cover_of(art_of(1)))
+        view = summarise(album(None, None), cover_of(art_of(1)))
         cover_row = next(r for r in view.rows if r.on_cover)
         assert cover_row.tracks == ()
         assert cover_row.label == "cover.jpg"
@@ -328,9 +353,9 @@ class TestRows:
         """A file Harmonist cannot open is not a file without artwork (#112)."""
         one = art_of(1)
         tracks = album(one, one)
-        tracks.append(("03 Track.m4a", TrackTags(unreadable=True)))
+        tracks.append((ALBUM / "03 Track.m4a", TrackTags(unreadable=True)))
 
-        view = artwork.summarise(tracks, cover_of(one))
+        view = summarise(tracks, cover_of(one))
 
         assert view.unreadable == 1
         assert not any(r.is_gap for r in view.rows)
@@ -340,18 +365,18 @@ class TestRows:
 
 class TestHeadingCount:
     def test_counts_the_distinct_images(self) -> None:
-        view = artwork.summarise(album(art_of(1), art_of(2)), cover_of(art_of(3)))
+        view = summarise(album(art_of(1), art_of(2)), cover_of(art_of(3)))
         assert view.count == "3 images"
 
     def test_counts_gaps_alongside(self) -> None:
         """ "1 image" over an album a third of whose tracks have none is true and
         misses the point."""
         one = art_of(1)
-        view = artwork.summarise(album(one, None, one), cover_of(one))
+        view = summarise(album(one, None, one), cover_of(one))
         assert view.count == "1 image · 1 gap"
 
     def test_no_count_when_there_is_no_image_anywhere(self) -> None:
-        assert artwork.summarise(album(None, None), None).count is None
+        assert summarise(album(None, None), None).count is None
 
 
 class TestLargerLocalImageWins:
@@ -361,7 +386,7 @@ class TestLargerLocalImageWins:
         big = art_of(1, width=1000, height=1000)
         small = art_of(2, width=400, height=400)
 
-        view = artwork.summarise(album(big, big), cover_of(small))
+        view = summarise(album(big, big), cover_of(small))
 
         tracks_row, cover_row = view.rows
         assert tracks_row.outcome is artwork.Outcome.KEPT
@@ -372,7 +397,7 @@ class TestLargerLocalImageWins:
         small = art_of(1, width=400, height=400)
         big = art_of(2, width=1000, height=1000)
 
-        view = artwork.summarise(album(small, small), cover_of(big))
+        view = summarise(album(small, small), cover_of(big))
 
         assert view.rows[0].outcome is artwork.Outcome.REPLACED
         assert view.rows[0].written_from == "cover.jpg"
@@ -383,7 +408,7 @@ class TestLargerLocalImageWins:
         unknown = EmbeddedArt.of(b"not an image at all", "image/jpeg")
         assert unknown.size is None
 
-        view = artwork.summarise(album(unknown, unknown), cover_of(art_of(2, width=40, height=40)))
+        view = summarise(album(unknown, unknown), cover_of(art_of(2, width=40, height=40)))
 
         # Falls back to today's behaviour: the folder cover is embedded.
         assert view.rows[0].outcome is artwork.Outcome.REPLACED
@@ -394,13 +419,13 @@ class TestLargerLocalImageWins:
         mine = art_of(1, width=500, height=500)
         theirs = art_of(2, width=500, height=500)
 
-        view = artwork.summarise(album(mine, mine), cover_of(theirs))
+        view = summarise(album(mine, mine), cover_of(theirs))
 
         assert not any(r.writes for r in view.rows)
         assert view.rows[0].outcome is artwork.Outcome.KEPT
 
     def test_per_track_art_is_never_promoted(self) -> None:
-        view = artwork.summarise(
+        view = summarise(
             album(art_of(1, width=900, height=900), art_of(2, width=900, height=900)),
             cover_of(art_of(3, width=100, height=100)),
         )
@@ -425,7 +450,7 @@ class TestCoverArtArchiveNote:
             return False
 
     def test_nothing_said_until_it_has_been_asked(self) -> None:
-        assert artwork.summarise(album(art_of(1)), None).archive_row is None
+        assert summarise(album(art_of(1)), None).archive_row is None
 
     def test_a_winning_archive_cover_needs_no_sentence(self) -> None:
         """It is the incoming value, shown in that column with the hexagon —
@@ -433,7 +458,7 @@ class TestCoverArtArchiveNote:
         # The cached IMAGE as well as the answer: an archive cover that was
         # never downloaded cannot be written, so it cannot win — the tagger
         # reads the same cache.
-        view = artwork.summarise(
+        view = summarise(
             album(art_of(1, width=600, height=600)),
             cover_of(art_of(2, width=600, height=600)),
             self._Answer(1400, 1400),
@@ -447,7 +472,7 @@ class TestCoverArtArchiveNote:
         big = art_of(1, width=3000, height=3000)
         small = art_of(2, width=500, height=500)
 
-        view = artwork.summarise(album(big), cover_of(small), self._Answer(2000, 2000))
+        view = summarise(album(big), cover_of(small), self._Answer(2000, 2000))
 
         row = view.archive_row
         assert row is not None
@@ -456,13 +481,13 @@ class TestCoverArtArchiveNote:
     def test_the_archive_having_nothing_is_its_own_placeholder(self) -> None:
         """A different word from "not loaded": there is nothing to load, rather
         than something that was not loaded (#433)."""
-        view = artwork.summarise(album(art_of(1)), None, self._Answer(art=False))
+        view = summarise(album(art_of(1)), None, self._Answer(art=False))
         row = view.archive_row
         assert row is not None
         assert (row.placeholder, row.meta) == ("none", "no front cover for this release")
 
     def test_an_unmeasurable_archive_cover_says_so(self) -> None:
-        view = artwork.summarise(album(art_of(1)), None, self._Answer())
+        view = summarise(album(art_of(1)), None, self._Answer())
         row = view.archive_row
         assert row is not None
         assert row.meta == "size could not be read"
@@ -476,7 +501,7 @@ class TestArchiveWins:
         theirs = art_of(2, width=800, height=800)
         archive = art_of(3, width=1400, height=1400)
 
-        view = artwork.summarise(album(mine, mine), cover_of(theirs), archive=archive)
+        view = summarise(album(mine, mine), cover_of(theirs), archive=archive)
 
         # Both the tracks and the folder cover are replaced, by the same image.
         assert {r.outcome for r in view.rows} == {artwork.Outcome.REPLACED}
@@ -486,9 +511,7 @@ class TestArchiveWins:
     def test_an_archive_image_that_loses_changes_nothing(self) -> None:
         big = art_of(1, width=3000, height=3000)
 
-        view = artwork.summarise(
-            album(big, big), cover_of(big), archive=art_of(2, width=400, height=400)
-        )
+        view = summarise(album(big, big), cover_of(big), archive=art_of(2, width=400, height=400))
 
         assert not any(r.writes for r in view.rows)
 
@@ -498,7 +521,7 @@ class TestArchiveWins:
         tracks = art_of(1, width=3000, height=3000)
         folder = art_of(2, width=500, height=500)
 
-        view = artwork.summarise(
+        view = summarise(
             album(tracks), cover_of(folder), archive=art_of(3, width=2000, height=2000)
         )
 
@@ -506,7 +529,7 @@ class TestArchiveWins:
 
     def test_per_track_artwork_is_still_never_overwritten(self) -> None:
         """The archive does not get to flatten a compilation, however large."""
-        view = artwork.summarise(
+        view = summarise(
             album(art_of(1, width=500, height=500), art_of(2, width=500, height=500)),
             cover_of(art_of(3, width=500, height=500)),
             archive=art_of(4, width=3000, height=3000),
@@ -524,46 +547,49 @@ class TestArchiveWins:
         mine = art_of(1, width=600, height=600)
         archive = art_of(2, width=1400, height=1400)
 
-        view = artwork.summarise(album(mine, mine), None, archive=archive)
+        view = summarise(album(mine, mine), None, archive=archive)
 
-        assert [r.outcome for r in view.rows] == [artwork.Outcome.REPLACED]
-        assert view.rows[0].written_from == "the Cover Art Archive"
-        assert view.rows[0].written_image == archive
-        assert view.rows[0].from_archive is True
+        tracks, created = view.rows
+        assert tracks.outcome is artwork.Outcome.REPLACED
+        assert tracks.written_from == "the Cover Art Archive"
+        assert tracks.written_image == archive
+        assert tracks.from_archive is True
+        # …and the folder cover the album lacked is created from it too (#469).
+        assert created.creates == "cover.png"
+        assert created.written_image == archive
+        assert view.operation is artwork.Operation.REPLACEMENT
 
     def test_it_must_still_beat_the_tracks_when_there_is_no_folder_cover(self) -> None:
         """With no cover file there is nothing else to compare against, so the
         tracks' own image is the incumbent — and ties go to what is there."""
         mine = art_of(1, width=1400, height=1400)
 
-        same = artwork.summarise(
-            album(mine, mine), None, archive=art_of(2, width=1400, height=1400)
-        )
-        smaller = artwork.summarise(
-            album(mine, mine), None, archive=art_of(3, width=600, height=600)
-        )
+        same = summarise(album(mine, mine), None, archive=art_of(2, width=1400, height=1400))
+        smaller = summarise(album(mine, mine), None, archive=art_of(3, width=600, height=600))
 
-        assert not any(r.writes for r in same.rows)
-        assert not any(r.writes for r in smaller.rows)
+        for view in (same, smaller):
+            assert not any(r.writes for r in view.rows if r.tracks)
+            # The folder cover it lacks is created from its own image — the
+            # winner, and so the largest thing on offer.
+            created = next(r for r in view.rows if r.creates)
+            assert created.written_image == mine
 
     def test_per_track_artwork_survives_having_no_folder_cover(self) -> None:
-        """The promise, on the album shape #442 opened up.
+        """The promise, on the album shape #442 opened up: the sleeves are user
+        data and a 3000px archive cover writes over none of them.
 
-        Two things hold it, and the second is the one doing the work here: the
-        `not per_track` guard on `archive_wins` (which is what protects a
-        compilation that HAS a folder cover), and — with no cover — the fact
-        that an album with more than one image has no single `album_image`, so
-        `album_best` cannot be measured and there is nothing for the archive to
-        beat. Removing either leaves this passing; removing both does not, and
-        the promise is worth pinning by its outcome rather than its mechanism.
-        """
-        view = artwork.summarise(
+        The one write such an album can receive is the folder cover it lacks,
+        from the archive (#469) — a compilation's first sleeve is not the
+        album's cover, but the archive's front cover is."""
+        view = summarise(
             album(art_of(1, width=500, height=500), art_of(2, width=500, height=500)),
             None,
             archive=art_of(3, width=3000, height=3000),
         )
 
-        assert not any(r.writes for r in view.rows)
+        assert not any(r.writes for r in view.rows if r.tracks)
+        created = next(r for r in view.rows if r.creates)
+        assert created.from_archive is True
 
 
 def test_a_track_row_replaced_by_the_cover_shows_the_incoming_image() -> None:
@@ -573,7 +599,7 @@ def test_a_track_row_replaced_by_the_cover_shows_the_incoming_image() -> None:
     small = art_of(1, width=400, height=400)
     big = art_of(2, width=900, height=900)
 
-    view = artwork.summarise(album(small, small), cover_of(big))
+    view = summarise(album(small, small), cover_of(big))
 
     tracks_row = view.rows[0]
     assert tracks_row.outcome is artwork.Outcome.REPLACED
@@ -589,8 +615,8 @@ def test_only_the_archives_image_carries_the_musicbrainz_mark() -> None:
     folder = art_of(2, width=900, height=900)
     archive = art_of(3, width=1400, height=1400)
 
-    from_cover = artwork.summarise(album(small), cover_of(folder))
-    from_archive = artwork.summarise(album(small), cover_of(folder), archive=archive)
+    from_cover = summarise(album(small), cover_of(folder))
+    from_archive = summarise(album(small), cover_of(folder), archive=archive)
 
     assert from_cover.rows[0].written_image == folder
     assert from_cover.rows[0].from_archive is False
@@ -608,7 +634,7 @@ class TestSummaryWording:
 
     def test_it_counts_the_tracks_that_change_not_the_images(self) -> None:
         small = art_of(1, width=300, height=300)
-        view = artwork.summarise(album(small, small, small), cover_of(art_of(2)))
+        view = summarise(album(small, small, small), cover_of(art_of(2)))
 
         assert view.summary == "Better artwork is available for 3 tracks."
 
@@ -616,13 +642,13 @@ class TestSummaryWording:
         """The album's own art beats `cover.jpg`, so the FOLDER file catches up
         and no track moves (#410). A count of tracks would say zero here."""
         big = art_of(1, width=3000, height=3000)
-        view = artwork.summarise(album(big, big), cover_of(art_of(2, width=500, height=500)))
+        view = summarise(album(big, big), cover_of(art_of(2, width=500, height=500)))
 
         assert view.summary == "Better artwork is available for cover.jpg."
 
     def test_tracks_and_the_cover_together(self) -> None:
         """The archive beats both, so both change and both are named."""
-        view = artwork.summarise(
+        view = summarise(
             album(art_of(1, width=400, height=400), art_of(1, width=400, height=400)),
             cover_of(art_of(2, width=500, height=500)),
             archive=art_of(3, width=2000, height=2000),
@@ -632,7 +658,7 @@ class TestSummaryWording:
 
     def test_a_gap_and_an_improvement_are_two_clauses(self) -> None:
         small = art_of(1, width=300, height=300)
-        view = artwork.summarise(album(small, small, None), cover_of(art_of(2)))
+        view = summarise(album(small, small, None), cover_of(art_of(2)))
 
         assert view.summary == (
             "1 track is missing artwork, and better artwork is available for 2 tracks."
@@ -640,71 +666,144 @@ class TestSummaryWording:
 
     def test_a_gap_alone_says_only_that(self) -> None:
         same = art_of(1)
-        view = artwork.summarise(album(same, None, None), cover_of(same))
+        view = summarise(album(same, None, None), cover_of(same))
 
         assert view.summary == "2 tracks are missing artwork."
 
 
-class TestAnnouncingACoverThatWillBeCreated:
-    """#457: a re-tag writes a `cover.jpg` into an album that hasn't got one —
-    mandatory for Navidrome, and so not gated on anything the user pressed. The
-    section had no way to say so, because the folder cover is modelled as a
-    carrier of an image and a carrier that doesn't exist yet carries nothing."""
+class TestTheFolderCoverThatWillBeCreated:
+    """#457: a `cover.*` gets written into an album that hasn't got one, and the
+    section had no way to say so — the folder cover was modelled as a carrier of
+    an image, and a carrier that doesn't exist yet carries nothing.
+
+    It is a row now (#467): an empty frame, and beside it the image that will
+    fill it. What that image is comes from the plan, like every other row's."""
 
     Answer = TestCoverArtArchiveNote._Answer
 
-    def test_an_album_with_a_cover_is_told_nothing(self) -> None:
-        """`ensure_cover` returns an existing cover untouched — no rung runs, no
-        file is written, and there is no event to announce."""
+    @staticmethod
+    def created(view: artwork.ArtworkView) -> artwork.ArtRow | None:
+        return next((r for r in view.rows if r.creates), None)
+
+    def test_an_album_with_a_cover_has_no_such_row(self) -> None:
         one = art_of(1)
-        assert artwork.summarise(album(one), cover_of(one)).creates_cover_from is None
+        assert self.created(summarise(album(one), cover_of(one))) is None
 
-    def test_the_archive_is_named_when_it_has_this_release(self) -> None:
-        view = artwork.summarise(album(art_of(1)), None, self.Answer(art=True))
-        assert view.creates_cover_from == "the Cover Art Archive"
+    def test_the_archive_is_named_when_its_image_wins(self) -> None:
+        """Shown, not merely named: the archive's image is on disk because the
+        check downloads any cover an artless or coverless album would take."""
+        archive = art_of(2, width=3000, height=3000)
+        view = summarise(album(art_of(1)), None, self.Answer(art=True), archive=archive)
 
-    def test_it_falls_to_your_own_files_when_the_archive_has_nothing(self) -> None:
-        """The second rung, and the one that needs no network. Naming the
-        archive here would promise an image that has been established not to
-        exist."""
-        view = artwork.summarise(album(art_of(1)), None, self.Answer(art=False))
-        assert view.creates_cover_from == "the artwork already in your files"
+        row = self.created(view)
+        assert row is not None
+        assert (row.written_from, row.written_image) == ("the Cover Art Archive", archive)
+
+    def test_it_is_made_from_your_own_files_when_the_archive_has_nothing(self) -> None:
+        """Naming the archive here would promise an image that has been
+        established not to exist."""
+        mine = art_of(1)
+        row = self.created(summarise(album(mine), None, self.Answer(art=False)))
+        assert row is not None
+        assert (row.written_from, row.written_image) == ("the album's own artwork", mine)
+
+    def test_an_unasked_archive_promises_only_what_is_already_on_disk(self) -> None:
+        """`caa is None` is "nobody has asked". The row shows the image that
+        WOULD be written now — the album's own — rather than a picture nobody
+        has seen; the check that follows re-draws it if the archive wins."""
+        mine = art_of(1)
+        row = self.created(summarise(album(mine), None))
+        assert row is not None
+        assert row.written_image == mine
 
     def test_nothing_is_promised_when_nothing_could_make_a_cover(self) -> None:
-        """No archive art and no embedded art: `ensure_cover` writes nothing, so
-        the section says nothing rather than announcing a file that isn't
-        coming."""
-        view = artwork.summarise(album(None, None), None, self.Answer(art=False))
-        assert view.creates_cover_from is None
-
-    def test_an_unasked_archive_names_both_rungs_rather_than_guessing(self) -> None:
-        """`caa is None` is "nobody has asked", not "there is nothing". Either
-        rung may serve, and the wording carries that."""
-        view = artwork.summarise(album(art_of(1)), None)
-        assert view.creates_cover_from == (
-            "the Cover Art Archive, or the artwork already in your files"
-        )
-
-    def test_an_unasked_archive_with_no_embedded_art_stays_conditional(self) -> None:
-        view = artwork.summarise(album(None), None)
-        assert view.creates_cover_from == "the Cover Art Archive, if it has this release"
+        """No archive art and no embedded art: nothing would be written, so no
+        row announces a file that isn't coming."""
+        view = summarise(album(None, None), None, self.Answer(art=False))
+        assert self.created(view) is None
+        assert view.writes is False
 
     def test_an_unreadable_cover_is_not_a_missing_one(self) -> None:
-        """The file IS there — `cached_cover` only checks that it exists, so
-        `ensure_cover` hands it back without reading it and writes nothing. The
-        view is built with `cover=None` and `cover_unreadable` set afterwards by
-        `replace()`, so this case reaches the same code as a genuinely absent
-        cover and has to be told apart from it (#112)."""
-        from dataclasses import replace
+        """The file IS there, unread. A plan that treated it as absent would
+        create a second cover beside it (#112)."""
+        view = summarise(album(art_of(1)), None, cover_unreadable=True)
+        assert self.created(view) is None
+        assert view.writes is False
 
-        view = replace(artwork.summarise(album(art_of(1)), None), cover_unreadable=True)
-        assert view.creates_cover_from is None
+    def test_it_puts_the_apply_button_on_the_page(self) -> None:
+        """The section's own action creates it (#469) — so it counts as a write,
+        and the button that makes it is offered beside the row that shows it.
+        It used to be withheld, because the button could not do this."""
+        view = summarise(album(art_of(1)), None, self.Answer(art=True))
+        assert self.created(view) is not None
+        assert view.writes is True
+        assert view.operation is artwork.Operation.ADDITION
+        assert view.summary == "There is no cover.png."
 
-    def test_it_does_not_put_the_update_artwork_button_on_the_page(self) -> None:
-        """The load-bearing one. `writes` is what draws that button, and
-        `tagger.update_artwork` cannot create a folder cover — it only promotes
-        over one that exists. Counting this as a write would offer a control
-        that does not do what the sentence beside it just said."""
-        view = artwork.summarise(album(art_of(1)), None, self.Answer(art=True))
-        assert view.creates_cover_from  # there IS something to announce...
-        assert view.writes is False  # ...and still no button
+
+class TestPlan:
+    """The plan the section is drawn from and the writers execute (#469)."""
+
+    def test_an_unmeasurable_folder_cover_leaves_the_tracks_their_own_image(self) -> None:
+        """Where the page and the writer used to disagree. With the cover's size
+        unknown the tagger kept the tracks' measurable image and filled the gap
+        from it, while the page's own copy of the rule promised to replace the
+        tracks with the cover. One plan, one answer — the tagger's."""
+        mine = art_of(1, width=800, height=800)
+        unknown = EmbeddedArt.of(b"not an image at all", "image/jpeg")
+
+        view = summarise(album(mine, None), cover_of(unknown))
+
+        tracks, cover_row, gap = view.rows
+        assert tracks.outcome is artwork.Outcome.KEPT
+        assert cover_row.writes is False  # an unknown size is never written over
+        assert gap.written_image == mine
+
+    def test_the_fingerprint_moves_when_a_target_does(self) -> None:
+        """What a reviewed page carries back. It must be stable for an album that
+        has not changed, or every press is refused — and must move when any
+        target's image does, or an edit made since would be overwritten."""
+        cover = cover_of(art_of(9, width=2000, height=2000))
+
+        drawn = summarise(album(art_of(1), None), cover).fingerprint
+
+        assert summarise(album(art_of(1), None), cover).fingerprint == drawn
+        assert summarise(album(art_of(2), None), cover).fingerprint != drawn
+
+    def test_a_re_tag_answers_only_for_the_additions(self) -> None:
+        """A re-tag writes the additions and nothing else (#418), so a
+        replacement on offer is no part of what it checks — and a mixed plan
+        still reads as the Replacement it is to the section's own button."""
+        small = art_of(1, width=400, height=400)
+        view = summarise(album(small, None), cover_of(art_of(2, width=900, height=900)))
+        plan = view.plan
+        assert plan is not None
+
+        assert plan.operation(artwork.Scope.ALL) is artwork.Operation.REPLACEMENT
+        assert plan.operation(artwork.Scope.ADDITIONS) is artwork.Operation.ADDITION
+        assert {c.operation for c in plan.scoped(artwork.Scope.ADDITIONS)} == {
+            artwork.Operation.ADDITION
+        }
+        assert view.tagging_fingerprint != view.fingerprint
+
+    def test_overwrite_art_embeds_the_folder_cover_without_judging_it(self) -> None:
+        """The explicit override: every track gets the folder cover, however
+        small, and per-track artwork is no protection — the user asked."""
+        tracks = [
+            (ALBUM / "1.m4a", art_of(1, width=3000, height=3000)),
+            (ALBUM / "2.m4a", art_of(2)),
+        ]
+        cover = cover_of(art_of(3, width=10, height=10))
+
+        plan = artwork.plan(ALBUM, tracks, cover, overwrite_art=True)
+
+        assert [c.after for c in plan.changes] == [cover.image.digest] * 2
+        assert not any(c.folder_cover for c in plan.changes)
+
+    def test_a_created_cover_is_named_for_its_format(self) -> None:
+        jpeg = EmbeddedArt.of(jpeg_bytes(600, 600), "image/jpeg")
+        plan = artwork.plan(ALBUM, [(ALBUM / "1.m4a", jpeg)], None)
+
+        created = plan.cover_change(artwork.Scope.ADDITIONS)
+        assert created is not None
+        assert created.target == ALBUM / "cover.jpg"

--- a/test/test_artwork_store.py
+++ b/test/test_artwork_store.py
@@ -139,7 +139,7 @@ def test_a_zero_cap_keeps_nothing():
     """A legitimate choice on a volume with no room: artwork replacement stops
     being reversible, and nothing accumulates. The caller is told so rather
     than handed a digest for a file the cap evicted on its way out (#427) —
-    that digest is what `_promote_album_image` reads as permission to destroy
+    that digest is what `_write_folder_cover` reads as permission to destroy
     the original."""
     artwork_store.configure(artwork_store._root, max_bytes=0)
 
@@ -323,7 +323,7 @@ class TestEviction:
 
     def test_a_backup_that_could_not_be_retained_is_reported_as_not_kept(self):
         """A digest is the caller's licence to overwrite the original (see
-        `tagger._promote_album_image`). If the cap cannot hold the image even
+        `tagger._write_folder_cover`). If the cap cannot hold the image even
         after everything else has gone, saying so is the difference between a
         change that is merely unundoable and one whose original is destroyed."""
         artwork_store.configure(artwork_store._root, max_bytes=10)

--- a/test/test_cover_art.py
+++ b/test/test_cover_art.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
-import shutil
 from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
 import pytest
 
-from harmonist import id_registry
-from harmonist.cover_art import CoverArtError, cached_cover, ensure_cover
+from harmonist import cover_art
+from harmonist.cover_art import CoverArtError, Front, cached_cover, front_image
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
-_TINY_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00" + b"\x00" * 40
 
 
 def _client(handler) -> httpx.Client:
@@ -24,23 +22,17 @@ def _client(handler) -> httpx.Client:
     )
 
 
-def _flac_with_embedded_art(dirpath: Path, art: bytes) -> Path:
-    """Copy the FLAC fixture into dirpath and embed `art` as its front cover."""
-    from mutagen.flac import FLAC, Picture
-
-    dst = dirpath / "01 track.flac"
-    shutil.copy(FIXTURES_DIR / "sine.flac", dst)
-    audio = FLAC(dst)
-    pic = Picture()
-    pic.type = 3  # front cover
-    pic.mime = "image/jpeg"
-    pic.data = art
-    audio.add_picture(pic)
-    audio.save()
-    return dst
+@pytest.fixture
+def caa_cache(tmp_path, monkeypatch) -> Path:
+    """The candidate cache, configured for this test and put back afterwards —
+    `configure_cache` sets a module global, and a test that leaves it pointing
+    at its own tmp_path hands the next test a cache it did not ask for."""
+    root = tmp_path / "caa"
+    monkeypatch.setattr(cover_art, "_caa_root", root)
+    return root
 
 
-# ---------- cache hits ----------
+# ---------- folder covers already on disk ----------
 
 
 def test_cached_cover_finds_jpg(tmp_path):
@@ -57,138 +49,64 @@ def test_cached_cover_returns_none_when_absent(tmp_path):
     assert cached_cover(tmp_path) is None
 
 
-def test_caa_cover_write_is_audited(tmp_path):
-    """#88: fetching cover art writes into the user's album dir, and can land on
-    a cover.* they put there themselves — a file write like any other, so it's
-    audited. `overwrote` distinguishes creating from replacing."""
-    from harmonist import activity_store
-    from harmonist.activity_store import Source
-
-    activity_store.init(tmp_path / "audit.db")
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, content=b"imagebytes", headers={"content-type": "image/jpeg"})
-
-    album = tmp_path / "album"
-    album.mkdir()
-    assert ensure_cover(album, "rel-1", client=_client(handler)) == album / "cover.jpg"
-
-    rows = [e for e in activity_store.recent(10, source=Source.AUDIT)]
-    row = next(e for e in rows if e.message.startswith("cover.write"))
-    assert "source=caa" in row.message
-    assert "overwrote=False" in row.message  # created, not replaced
-    assert "bytes=10" in row.message
-    # The COLUMN, not the message (#456). Asserting the message alone is what let
-    # this ship: every field above was right while `album_id` was NULL, so the
-    # row was real, correct, and unreachable from the album whose directory it
-    # describes — `album_history` selects by id.
-    assert row.album_id == id_registry.peek(album)
+# ---------- the archive's image for a tagging: front_image (#469) ----------
+#
+# A CANDIDATE, not a folder cover. Whether it is written anywhere is the artwork
+# plan's decision — see test_tagger's creation tests — so nothing here can touch
+# an album directory: `front_image` is not given one.
 
 
-def test_embedded_cover_write_is_audited_against_the_album(tmp_path):
-    """The other rung that writes a file, and it needs the id just as much (#456)
-    — more, arguably, since it fires exactly when CAA had nothing to say and the
-    user is most likely to wonder where the image came from."""
-    from harmonist import activity_store
-    from harmonist.activity_store import Source
-
-    activity_store.init(tmp_path / "audit.db")
-    album = tmp_path / "album"
-    album.mkdir()
-    _flac_with_embedded_art(album, _TINY_JPEG)
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(404)
-
-    assert ensure_cover(album, "rel-1", client=_client(handler)) == album / "cover.jpg"
-
-    row = next(
-        e
-        for e in activity_store.recent(10, source=Source.AUDIT)
-        if e.message.startswith("cover.write")
-    )
-    assert "source=embedded" in row.message
-    assert row.album_id == id_registry.peek(album)
-
-
-def test_cover_write_is_recorded_against_the_sidecars_id_when_there_is_one(tmp_path):
-    """An album that already has an identity is recorded under THAT, not under
-    the path hash — otherwise the row lands on an id the album stopped answering
-    to the moment it was tagged, and `album_history` would need an alias that
-    was never recorded because the id never actually moved."""
-    from harmonist import activity_store, sidecar
-    from harmonist.activity_store import Source
-    from harmonist.models import Sidecar
-
-    activity_store.init(tmp_path / "audit.db")
-    album = tmp_path / "album"
-    album.mkdir()
-    sidecar.write(album, Sidecar(mb_release_id="rel-already-tagged"))
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, content=b"img", headers={"content-type": "image/jpeg"})
-
-    ensure_cover(album, "rel-already-tagged", client=_client(handler))
-
-    row = next(
-        e
-        for e in activity_store.recent(10, source=Source.AUDIT)
-        if e.message.startswith("cover.write")
-    )
-    assert row.album_id == "rel-already-tagged"
-
-
-def test_ensure_cover_uses_cache_without_network(tmp_path):
-    (tmp_path / "cover.jpg").write_bytes(b"existing")
-
-    def boom(req):
-        raise AssertionError(f"network should not be hit: {req.url}")
-
-    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(boom))
-    assert result == tmp_path / "cover.jpg"
-    assert result.read_bytes() == b"existing"
-
-
-# ---------- fetch from release endpoint ----------
-
-
-def test_ensure_cover_fetches_jpeg_from_release(tmp_path):
+def test_front_image_fetches_the_releases_original_and_keeps_it(caa_cache):
+    """The ORIGINAL, whatever size a deployment once configured: the largest
+    image available is the one Harmonist prefers, and it is the one the album
+    page's check measures — the preview and the tagging compare one picture."""
     seen_urls = []
 
     def handler(req):
         seen_urls.append(str(req.url))
         return httpx.Response(200, content=b"REAL_JPEG", headers={"content-type": "image/jpeg"})
 
-    result = ensure_cover(tmp_path, "rel-123", client=_client(handler))
-    assert result == tmp_path / "cover.jpg"
-    assert result.read_bytes() == b"REAL_JPEG"
+    assert front_image("rel-123", client=_client(handler)) == Front(b"REAL_JPEG", "image/jpeg")
     assert seen_urls == ["https://coverartarchive.org/release/rel-123/front"]
+    # Kept, so the album page afterwards shows the candidate a tagging weighed.
+    kept = cover_art.cached_image("rel-123")
+    assert kept is not None
+    assert kept.read_bytes() == b"REAL_JPEG"
 
 
-def test_ensure_cover_writes_png_when_content_type_says_png(tmp_path):
+def test_front_image_reports_a_png_as_one(caa_cache):
+    """The mime decides the name a created folder cover takes."""
+
     def handler(req):
         return httpx.Response(200, content=b"REAL_PNG", headers={"content-type": "image/png"})
 
-    result = ensure_cover(tmp_path, "rel-123", client=_client(handler))
-    assert result == tmp_path / "cover.png"
-    assert result.read_bytes() == b"REAL_PNG"
+    assert front_image("rel-123", client=_client(handler)) == Front(b"REAL_PNG", "image/png")
 
 
-def test_ensure_cover_with_explicit_size_hits_sized_url(tmp_path):
-    seen_urls = []
+def test_front_image_serves_the_cache_without_asking(caa_cache):
+    cover_art.cache_image("rel-123", b"CACHED", "image/jpeg")
+
+    def boom(req):
+        raise AssertionError(f"network should not be hit: {req.url}")
+
+    assert front_image("rel-123", "rg-456", client=_client(boom)) == Front(b"CACHED", "image/jpeg")
+
+
+def test_front_image_still_answers_with_the_cache_switched_off(monkeypatch):
+    """Bytes in hand rather than a path: a tagging needs the image it just
+    fetched whether or not there was anywhere to keep it."""
+    monkeypatch.setattr(cover_art, "_caa_root", None)
 
     def handler(req):
-        seen_urls.append(str(req.url))
-        return httpx.Response(200, content=b"x", headers={"content-type": "image/jpeg"})
+        return httpx.Response(200, content=b"REAL_JPEG", headers={"content-type": "image/jpeg"})
 
-    ensure_cover(tmp_path, "rel-123", size="500", client=_client(handler))
-    assert seen_urls == ["https://coverartarchive.org/release/rel-123/front-500"]
+    assert front_image("rel-123", client=_client(handler)) == Front(b"REAL_JPEG", "image/jpeg")
 
 
 # ---------- fallback to release-group ----------
 
 
-def test_ensure_cover_falls_back_to_release_group_on_404(tmp_path):
+def test_front_image_falls_back_to_release_group_on_404(caa_cache):
     seen_urls = []
 
     def handler(req):
@@ -197,37 +115,34 @@ def test_ensure_cover_falls_back_to_release_group_on_404(tmp_path):
             return httpx.Response(200, content=b"RG_JPEG", headers={"content-type": "image/jpeg"})
         return httpx.Response(404)
 
-    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
-    assert result == tmp_path / "cover.jpg"
-    assert result.read_bytes() == b"RG_JPEG"
+    assert front_image("rel-123", "rg-456", client=_client(handler)) == Front(
+        b"RG_JPEG", "image/jpeg"
+    )
     assert seen_urls == [
         "https://coverartarchive.org/release/rel-123/front",
         "https://coverartarchive.org/release-group/rg-456/front",
     ]
+    # Kept under the RELEASE, which is what the cache is keyed by.
+    assert cover_art.cached_image("rel-123") is not None
 
 
-def test_ensure_cover_returns_none_when_both_endpoints_404(tmp_path):
+def test_front_image_is_none_when_both_endpoints_404(caa_cache):
     def handler(req):
         return httpx.Response(404)
 
-    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
-    assert result is None
-    # No cover file written
-    assert not list(tmp_path.glob("cover.*"))
+    assert front_image("rel-123", "rg-456", client=_client(handler)) is None
 
 
-def test_ensure_cover_returns_none_when_release_404_and_no_release_group(tmp_path):
+def test_front_image_is_none_when_release_404_and_no_release_group(caa_cache):
     def handler(req):
         return httpx.Response(404)
 
-    result = ensure_cover(tmp_path, "rel-123", client=_client(handler))
-    assert result is None
+    assert front_image("rel-123", client=_client(handler)) is None
 
 
-def test_ensure_cover_falls_back_to_release_group_when_the_release_endpoint_is_down(tmp_path):
+def test_front_image_falls_back_to_release_group_when_the_release_endpoint_is_down(caa_cache):
     """#458: a 503 says nothing about whether this release has a cover, so it
-    must not end the ladder the way a 404's definitive "there is none" does.
-    The release-group rung is still worth asking."""
+    must not end the search the way a 404's definitive "there is none" does."""
     seen_urls = []
 
     def handler(req):
@@ -236,123 +151,64 @@ def test_ensure_cover_falls_back_to_release_group_when_the_release_endpoint_is_d
             return httpx.Response(200, content=b"RG_JPEG", headers={"content-type": "image/jpeg"})
         return httpx.Response(503)
 
-    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
-    assert result == tmp_path / "cover.jpg"
-    assert result.read_bytes() == b"RG_JPEG"
+    assert front_image("rel-123", "rg-456", client=_client(handler)) == Front(
+        b"RG_JPEG", "image/jpeg"
+    )
     assert seen_urls == [
         "https://coverartarchive.org/release/rel-123/front",
         "https://coverartarchive.org/release-group/rg-456/front",
     ]
 
 
-def test_ensure_cover_falls_back_to_release_group_after_a_transport_failure(tmp_path):
-    """#458, the other way the first rung fails. A refused connection reaches
-    `_fetch_to_disk` as an httpx error rather than a status, and used to raise
-    from a different line — so it needs its own proof that it now falls through."""
+def test_front_image_falls_back_to_release_group_after_a_transport_failure(caa_cache):
+    """#458, the other way the first endpoint fails: an httpx error rather than a
+    status."""
 
     def handler(req):
         if "release-group" in str(req.url):
             return httpx.Response(200, content=b"RG_JPEG", headers={"content-type": "image/jpeg"})
         raise httpx.ConnectError("connection refused")
 
-    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
-    assert result == tmp_path / "cover.jpg"
-    assert result.read_bytes() == b"RG_JPEG"
-
-
-# ---------- fallback to embedded art ----------
-
-
-def test_ensure_cover_extracts_embedded_art_when_caa_misses(tmp_path):
-    """When CAA has no cover (fresh/private release) but an audio file carries
-    embedded art, a folder cover.jpg is written from that art."""
-    _flac_with_embedded_art(tmp_path, _TINY_JPEG)
-
-    def handler(req):
-        return httpx.Response(404)
-
-    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
-    assert result == tmp_path / "cover.jpg"
-    assert result.read_bytes() == _TINY_JPEG
-
-
-def test_ensure_cover_extracts_embedded_art_when_caa_is_down(tmp_path):
-    """#458: the embedded-art rung is the one that needs no network at all, so an
-    archive that cannot answer is the case it is most useful in — and the case it
-    used to be skipped in, because the 503 propagated past it."""
-    _flac_with_embedded_art(tmp_path, _TINY_JPEG)
-
-    def handler(req):
-        return httpx.Response(503)
-
-    result = ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
-    assert result == tmp_path / "cover.jpg"
-    assert result.read_bytes() == _TINY_JPEG
-
-
-def test_ensure_cover_prefers_caa_over_embedded(tmp_path):
-    """CAA art wins over embedded — it's the authoritative match for the
-    tagged release and typically higher resolution."""
-    _flac_with_embedded_art(tmp_path, _TINY_JPEG)
-
-    def handler(req):
-        return httpx.Response(200, content=b"CAA_JPEG", headers={"content-type": "image/jpeg"})
-
-    result = ensure_cover(tmp_path, "rel-123", client=_client(handler))
-    assert result == tmp_path / "cover.jpg"
-    assert result.read_bytes() == b"CAA_JPEG"
-
-
-def test_ensure_cover_none_when_caa_misses_and_audio_has_no_art(tmp_path):
-    """An audio file with no embedded art and no CAA match → no cover written."""
-    shutil.copy(FIXTURES_DIR / "sine.flac", tmp_path / "01 track.flac")  # plain, no art
-
-    def handler(req):
-        return httpx.Response(404)
-
-    result = ensure_cover(tmp_path, "rel-123", client=_client(handler))
-    assert result is None
-    assert not list(tmp_path.glob("cover.*"))
+    assert front_image("rel-123", "rg-456", client=_client(handler)) == Front(
+        b"RG_JPEG", "image/jpeg"
+    )
 
 
 # ---------- error path ----------
 
 
-def test_ensure_cover_raises_on_non_404_failure(tmp_path):
-    """Once every rung has been tried and none of them served an image, the
-    archive's silence is reported rather than swallowed — "I could not ask" and
-    "there is nothing there" must not arrive as the same answer (#458). The
-    404 tests above are the other half of that pair: they return None, because a
-    404 IS an answer. `tmp_path` holds no audio, so the embedded rung has nothing
-    to offer and this really is the end of the ladder."""
+def test_front_image_raises_on_non_404_failure(caa_cache):
+    """Could-not-ask and there-is-nothing-there must not arrive as the same
+    answer (#458). The 404 tests above are the other half of that pair: they
+    return None, because a 404 IS an answer."""
 
     def handler(req):
         return httpx.Response(500, content=b"server explosion")
 
     with pytest.raises(CoverArtError):
-        ensure_cover(tmp_path, "rel-123", client=_client(handler))
+        front_image("rel-123", client=_client(handler))
 
 
-def test_ensure_cover_raises_on_network_error(tmp_path):
+def test_front_image_raises_on_network_error(caa_cache):
     def handler(req):
         raise httpx.ConnectError("connection refused")
 
     with pytest.raises(CoverArtError):
-        ensure_cover(tmp_path, "rel-123", client=_client(handler))
+        front_image("rel-123", client=_client(handler))
 
 
-def test_a_later_404_does_not_erase_an_earlier_could_not_ask(tmp_path):
-    """The release rung was unreachable and the release-group rung answered "no
-    art here". The album still has no cover AND the archive was never properly
-    asked about it, so this must raise rather than return None: returning None
-    would report a definitive "there is nothing for this release" that only one
-    of the two rungs is entitled to say (#458)."""
+def test_a_later_404_does_not_erase_an_earlier_could_not_ask(caa_cache):
+    """The release endpoint was unreachable and the release group answered "no
+    art here". The archive was never properly asked about this release, so this
+    must raise rather than return None: None would report a definitive "there is
+    nothing for this release" that only one of the two answers is entitled to
+    say (#458)."""
 
     def handler(req):
         return httpx.Response(404 if "release-group" in str(req.url) else 503)
 
     with pytest.raises(CoverArtError):
-        ensure_cover(tmp_path, "rel-123", release_group_mbid="rg-456", client=_client(handler))
+        front_image("rel-123", "rg-456", client=_client(handler))
 
 
 # ---------- the candidate cache (#276) ----------

--- a/test/test_demo.py
+++ b/test/test_demo.py
@@ -290,19 +290,17 @@ def test_search_releases_empty_inputs_returns_all():
     assert len(results) == len(demo.MB_RELEASES)
 
 
-def test_ensure_cover_returns_existing(music_dir):
-    album_dir = music_dir / "alb"
-    album_dir.mkdir(parents=True)
-    (album_dir / "cover.jpg").write_bytes(b"existing")
-    assert demo.ensure_cover(album_dir, release_mbid="demo-rel-x") == album_dir / "cover.jpg"
+def test_front_image_answers_with_a_placeholder_and_keeps_it(tmp_path, monkeypatch):
+    """Demo mode never asks the archive; a tagging still gets a candidate to
+    weigh, and it lands in the real cache like a live answer would."""
+    from harmonist import cover_art
 
+    monkeypatch.setattr(cover_art, "_caa_root", tmp_path / "caa")
+    front = demo.front_image("demo-rel-x")
 
-def test_ensure_cover_copies_placeholder(music_dir):
-    album_dir = music_dir / "alb"
-    album_dir.mkdir(parents=True)
-    result = demo.ensure_cover(album_dir, release_mbid="demo-rel-x")
-    assert result == album_dir / "cover.jpg"
-    assert result.exists()
+    assert front is not None
+    assert front.data == (demo.ASSETS_DIR / "cover-7.jpg").read_bytes()
+    assert cover_art.cached_image("demo-rel-x") is not None
 
 
 # ---------- web integration ----------

--- a/test/test_flagship.py
+++ b/test/test_flagship.py
@@ -46,7 +46,7 @@ def reset_demo_state():
         mb_lookup.fetch_release_urls,
         mb_lookup.lookup_by_bandcamp_url,
         mb_search.search_releases,
-        cover_art.ensure_cover,
+        cover_art.front_image,
     )
     demo.pending_downloads.reset()
     yield
@@ -56,7 +56,7 @@ def reset_demo_state():
         mb_lookup.fetch_release_urls,
         mb_lookup.lookup_by_bandcamp_url,
         mb_search.search_releases,
-        cover_art.ensure_cover,
+        cover_art.front_image,
     ) = saved
 
 

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -757,13 +757,13 @@ def test_every_owned_field_has_a_significance():
     forgetting `SCOPE` is a mis-rendered history row; the cost of forgetting this
     one is an unattended write nobody authorised (#267).
 
-    Keyed over the whole diff vocabulary, not just `Owned`: `ARTWORK` is a key a
-    plan really produces, so leaving it out would be a hole exactly where the map
-    is supposed to be total.
+    Exactly `Owned`, and deliberately not `ARTWORK` (#469): an image is not a
+    tag, and is described by `artwork.Operation` rather than ranked on this
+    scale. Its absence is what makes `significance_of` refuse it.
     """
-    from harmonist.formats.owned import ARTWORK, BY_VALUE, SIGNIFICANCE, Owned
+    from harmonist.formats.owned import BY_VALUE, SIGNIFICANCE, Owned
 
-    assert set(SIGNIFICANCE) == {f.value for f in Owned} | {ARTWORK}
+    assert set(SIGNIFICANCE) == {f.value for f in Owned}
     assert BY_VALUE.keys() <= {f.value for f in Owned}
 
 

--- a/test/test_foundations.py
+++ b/test/test_foundations.py
@@ -55,7 +55,6 @@ def test_config_defaults(monkeypatch, tmp_path):
     assert cfg.bandcamp.download_format == "flac"
     assert cfg.bandcamp.max_downloads_per_sync == 5
     assert cfg.musicbrainz.user_agent == "Harmonist/1.0 ( harmonist@girtby.net )"
-    assert cfg.cover_art.size == "original"
     assert cfg.test.mode == "fixture"
 
 

--- a/test/test_gardener.py
+++ b/test/test_gardener.py
@@ -1967,7 +1967,7 @@ def test_taking_the_update_clears_the_ignore(engaged, monkeypatch):
         mb_lookup, "fetch_release", lambda *a, **k: _release("Test Album (remastered)")
     )
     # The re-tag path asks the Cover Art Archive, which a test must not.
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     client, runner = engage()
     album_id = _flagged(runner).id
     client.get(f"/library/{album_id}/compare")

--- a/test/test_mb_cache_routes.py
+++ b/test/test_mb_cache_routes.py
@@ -44,7 +44,7 @@ def cfg(tmp_path):
 
 @pytest.fixture(autouse=True)
 def no_cover_fetch(monkeypatch):
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_mb_merge.py
+++ b/test/test_mb_merge.py
@@ -51,7 +51,7 @@ def cfg(tmp_path):
 @pytest.fixture(autouse=True)
 def no_cover_fetch(monkeypatch):
     """No cover-art requests: this module is about identity, and CAA is off-box."""
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
 
 @pytest.fixture

--- a/test/test_retag_sidecar.py
+++ b/test/test_retag_sidecar.py
@@ -51,7 +51,7 @@ def cfg(tmp_path):
 @pytest.fixture(autouse=True)
 def no_cover_fetch(monkeypatch):
     """No cover-art requests: this module is about the sidecar, and CAA is off-box."""
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
 
 @pytest.fixture

--- a/test/test_tag_history.py
+++ b/test/test_tag_history.py
@@ -64,6 +64,28 @@ def test_reach_distinguishes_album_wide_from_partial_and_per_track():
     assert _row(rows, "title").reach == "1 of 18 tracks"
 
 
+def test_a_folder_cover_in_a_tagging_is_named_not_counted():
+    """A tagging that creates the folder cover records it as a file of its own
+    (#469). It is not a track: counting it reported a field that reached every
+    one of thirteen tracks as "13 of 14"."""
+    records = _album(13, lambda i: {"artist": ["A", "B"], ARTWORK: [None, "sha-new"]}) + [
+        TagChanges(file="cover.jpg", changes={ARTWORK: [None, "sha-new"]})
+    ]
+
+    rows = summarise(records)
+
+    assert _row(rows, "artist").reach == "all tracks"
+    assert _row(rows, ARTWORK).reach == "all tracks and cover.jpg"
+
+
+def test_an_artwork_change_to_the_folder_cover_alone_names_it():
+    """The album's own image promoted over `cover.jpg`, and no track moved:
+    "1 track" named something that did not happen."""
+    records = [TagChanges(file="cover.jpg", changes={ARTWORK: ["sha-old", "sha-new"]})]
+
+    assert summarise(records)[0].reach == "cover.jpg"
+
+
 def test_album_fields_sort_before_track_fields_and_artwork_sits_last():
     records = _album(2, lambda i: {"title": ["a", "b"], "label": [None, "L"], ARTWORK: ["x", "y"]})
 

--- a/test/test_tagger.py
+++ b/test/test_tagger.py
@@ -49,6 +49,29 @@ from harmonist.tagger import (
 )
 
 
+def _update_artwork(
+    album_dir: Path,
+    release: dict,
+    cover_path: Path | None,
+    *,
+    files: list[Path] | None = None,
+    overwrite_art: bool = False,
+) -> int:
+    """What the Artwork section's button does, from files rather than a page:
+    decide the album's plan, then apply all of it (#418, #469). Returns how many
+    files changed — zero once the winner is everywhere."""
+    from harmonist import album_files, cover_art
+
+    paths = files if files is not None else album_files.audio_files(album_dir)
+    archive = cover_art.cached_front(release["id"])
+    plan = tagger.decide_artwork(
+        album_dir, paths, cover_path, archive=archive, overwrite_art=overwrite_art
+    )
+    return tagger.apply_artwork(
+        album_dir, plan, files=paths, cover_path=cover_path, archive=archive
+    ).changed
+
+
 def _release_2_tracks() -> dict:
     """Build a synthetic 2-track MB release dict with all the trimmings."""
     return {
@@ -260,24 +283,23 @@ def test_tagging_records_artwork_replacement_by_digest(album_with_tracks, tmp_pa
     newer = tmp_path / "cover2.jpg"
     newer.write_bytes(b"\xff\xd8\xff" + b"second" * 40)
     before = len(_detail())
-    tagger.update_artwork(album_dir, _release_2_tracks(), newer)
+    _update_artwork(album_dir, _release_2_tracks(), newer)
 
     replaced = _detail()[before:][0].changes[owned.ARTWORK]
     assert replaced[0] == first[1]  # what was there is what we recorded before
     assert replaced[1] != replaced[0]
 
 
-def test_tagging_without_a_cover_does_not_read_the_files_artwork(
+def test_planning_tags_alone_does_not_read_the_files_artwork(
     album_with_tracks, tmp_path, monkeypatch
 ):
-    """With no cover to embed, `write_tags` leaves existing art alone — so
-    nothing about artwork can change, and reading it would be a wasted pass over
-    every file on the path where scanning is already the slow part (#44, #74).
+    """With artwork out of scope nothing about it can change, and reading it
+    would be a wasted pass over every file — on the gardener's path, which
+    plans every album in the library (#44, #74, #448).
 
-    This used to be free: the read sat behind `cover is not None and ...` and
-    Python short-circuited it. Hoisting the digests out for #86 silently removed
-    that guard, which is the kind of regression no assertion about OUTPUT can
-    see."""
+    A TAGGING does read it now, even with no folder cover: the album's own
+    image is what a missing cover is created from (#469). This is the path
+    where that read would be pure waste."""
     from harmonist import formats
 
     reads: list[str] = []
@@ -290,7 +312,7 @@ def test_tagging_without_a_cover_does_not_read_the_files_artwork(
     monkeypatch.setattr(formats, "read_cover", counting_read_cover)
 
     album_dir = album_with_tracks(2)
-    tagger.tag_album(album_dir, _release_2_tracks())  # no cover_path
+    tagger.plan_album(album_dir, _release_2_tracks(), artwork=False)
 
     assert reads == []
 
@@ -303,7 +325,10 @@ def _cover(tmp_path, name: str, body: bytes):
 
 def test_replacing_embedded_art_keeps_a_copy_of_what_it_destroyed(album_with_tracks, tmp_path):
     """#131: embedding a cover overwrites whatever the track carried, and until
-    now that image was simply gone. The copy is what makes it undoable."""
+    now that image was simply gone. The copy is what makes it undoable.
+
+    Replacing is the artwork action's since #418 — a tagging fills gaps — so
+    that is what does the overwriting here."""
     from harmonist import activity_store, artwork_store, formats
 
     activity_store.init(tmp_path / "audit.db")
@@ -315,7 +340,7 @@ def test_replacing_embedded_art_keeps_a_copy_of_what_it_destroyed(album_with_tra
     assert original is not None
     was = artwork_store.digest(original[0])
 
-    tagger.tag_album(album_dir, _release_2_tracks(), _cover(tmp_path, "b.jpg", b"second" * 40))
+    _update_artwork(album_dir, _release_2_tracks(), _cover(tmp_path, "b.jpg", b"second" * 40))
 
     kept = artwork_store.path_for(was)
     assert kept is not None, "the overwritten image was not kept"
@@ -330,9 +355,26 @@ def test_the_shared_cover_of_an_album_is_kept_once_not_once_per_track(album_with
     album_dir = album_with_tracks(2)
 
     tagger.tag_album(album_dir, _release_2_tracks(), _cover(tmp_path, "a.jpg", b"first" * 40))
-    tagger.tag_album(album_dir, _release_2_tracks(), _cover(tmp_path, "b.jpg", b"second" * 40))
+    _update_artwork(album_dir, _release_2_tracks(), _cover(tmp_path, "b.jpg", b"second" * 40))
 
     assert len(list((tmp_path / "artwork").iterdir())) == 1
+
+
+def test_a_tagging_keeps_nothing_it_does_not_overwrite(album_with_tracks, tmp_path):
+    """The other side of the same rule. A tagging fills gaps and replaces
+    nothing (#418), so an image it leaves in place is not being destroyed and
+    has no business in the store — whose size cap it would spend, evicting the
+    backups of changes that really did happen."""
+    from harmonist import activity_store, artwork_store
+
+    activity_store.init(tmp_path / "audit.db")
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(2)
+
+    tagger.tag_album(album_dir, _release_2_tracks(), _cover(tmp_path, "a.jpg", b"first" * 40))
+    tagger.tag_album(album_dir, _release_2_tracks(), _cover(tmp_path, "b.jpg", b"second" * 40))
+
+    assert not (tmp_path / "artwork").exists() or not list((tmp_path / "artwork").iterdir())
 
 
 def test_re_tagging_with_the_same_cover_keeps_nothing(album_with_tracks, tmp_path):
@@ -908,7 +950,7 @@ def test_the_artwork_action_replaces_what_a_tagging_would_not(album_with_tracks,
     new_cover = tmp_path / "cover.jpg"
     new_cover.write_bytes(new)
 
-    changed = tagger.update_artwork(album_dir, _release_2_tracks(), new_cover)
+    changed = _update_artwork(album_dir, _release_2_tracks(), new_cover)
 
     assert changed == 2
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == new
@@ -929,7 +971,7 @@ def test_the_artwork_action_touches_no_tags(album_with_tracks, tmp_path):
     cover = tmp_path / "cover.jpg"
     cover.write_bytes(b"\xff\xd8\xff\xe0NEW\xff\xd9")
 
-    tagger.update_artwork(album_dir, _single_track_release(), cover)
+    _update_artwork(album_dir, _single_track_release(), cover)
 
     assert MP4(track)[ATOM_TITLE] == ["A title MusicBrainz disagrees with"]
 
@@ -943,8 +985,8 @@ def test_the_artwork_action_is_idempotent(album_with_tracks, tmp_path):
     cover = tmp_path / "cover.jpg"
     cover.write_bytes(b"\xff\xd8\xff\xe0ONLY\xff\xd9")
 
-    first = tagger.update_artwork(album_dir, _release_2_tracks(), cover)
-    second = tagger.update_artwork(album_dir, _release_2_tracks(), cover)
+    first = _update_artwork(album_dir, _release_2_tracks(), cover)
+    second = _update_artwork(album_dir, _release_2_tracks(), cover)
 
     assert first == 2
     assert second == 0
@@ -1226,9 +1268,7 @@ def test_restoring_artwork_puts_each_discs_image_back_on_its_own_file(tmp_path):
     cover = tmp_path / "cover.jpg"
     cover.write_bytes(_sized_jpeg(1000, 1000))
 
-    tagger.update_artwork(
-        cd1, _release_2_tracks_same_title(), cover, files=files, overwrite_art=True
-    )
+    _update_artwork(cd1, _release_2_tracks_same_title(), cover, files=files, overwrite_art=True)
     plan = tag_history.artwork_replaced(_detail())
 
     assert tagger.restore_artwork(cd1, plan, paths=[f.parent for f in files]) == 2
@@ -1857,16 +1897,15 @@ def test_every_by_value_field_has_a_rule_deciding_when_it_lowers():
     assert set(owned.BY_VALUE) == set(tagger.LOWERED_WHEN)
 
 
-def test_artwork_is_its_own_level():
+def test_artwork_is_refused_a_tag_significance():
     """Artwork arrives in a plan's changes under a key that is deliberately not
-    an owned field, and it still has to be classified — `owned.ARTWORK` is in the
-    table so the classifier can't meet a key it has no answer for.
-
-    Its own level rather than a rank among the others because "let it update my
-    cover art" is a trust decision people make separately from anything about
-    tags, and #273's setting is per level.
+    an owned field, and it has no place on the tag scale (#469): it is an
+    Addition or a Replacement, not something that reaches further or less far
+    than a retitle. Refused loudly, so it can never be ranked by accident —
+    and so no trust setting over tag levels can come to authorise an image.
     """
-    assert tagger.significance_of(owned.ARTWORK, "sha-a", "sha-b") is owned.Significance.COVER_ART
+    with pytest.raises(KeyError):
+        tagger.significance_of(owned.ARTWORK, "sha-a", "sha-b")
 
 
 def test_an_unknown_key_is_refused_rather_than_guessed():
@@ -1892,7 +1931,6 @@ def test_every_change_reaching_the_runner_still_goes_to_review():
         ("title", "Dawn  Chorus", "Dawn Chorus"),
         ("album", "A", "B"),
         ("track_num", 1, 2),
-        (owned.ARTWORK, "sha-a", "sha-b"),
     ]:
         assert owned.needs_review(tagger.significance_of(field, was, now)), field
 
@@ -1912,8 +1950,10 @@ def test_every_change_a_real_plan_produces_can_be_classified(album_with_tracks, 
     plan = tagger.plan_album(album_dir, _release_2_tracks(), cover_path=cover)
 
     seen = {f for changes in plan.changes.values() for f in changes}
-    assert owned.ARTWORK in seen  # the key most likely to be forgotten
-    for field in seen:
+    # Artwork is in a real plan — and is the one key the tag scale refuses,
+    # which is why the gardener's diff must never carry it (`plan_for`).
+    assert owned.ARTWORK in seen
+    for field in seen - {owned.ARTWORK}:
         assert isinstance(tagger.significance_of(field, None, "x"), owned.Significance)
 
 
@@ -2339,7 +2379,7 @@ def test_a_larger_embedded_image_is_promoted_to_the_folder_cover(album_with_trac
     cover = tmp_path / "cover.jpg"
     cover.write_bytes(_sized_jpeg(400, 400))
 
-    tagger.update_artwork(album_dir, _release_2_tracks(), cover)
+    _update_artwork(album_dir, _release_2_tracks(), cover)
 
     # The tracks keep the better image…
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big
@@ -2360,7 +2400,7 @@ def test_the_replaced_folder_cover_can_be_undone(album_with_tracks, tmp_path):
     small = _sized_jpeg(400, 400)
     cover.write_bytes(small)
 
-    tagger.update_artwork(album_dir, _single_track_release(), cover)
+    _update_artwork(album_dir, _single_track_release(), cover)
 
     kept = artwork_store.path_for(artwork_store.digest(small))
     assert kept is not None, "the overwritten folder cover was not kept"
@@ -2381,7 +2421,7 @@ def test_a_cover_is_not_replaced_when_its_backup_could_not_be_retained(album_wit
     small = _sized_jpeg(400, 400)
     cover.write_bytes(small)
 
-    tagger.update_artwork(album_dir, _single_track_release(), cover)
+    _update_artwork(album_dir, _single_track_release(), cover)
 
     assert cover.read_bytes() == small
 
@@ -2398,7 +2438,7 @@ def test_a_larger_folder_cover_is_still_embedded(album_with_tracks, tmp_path):
     big = _sized_jpeg(1000, 1000)
     cover.write_bytes(big)
 
-    tagger.update_artwork(album_dir, _single_track_release(), cover)
+    _update_artwork(album_dir, _single_track_release(), cover)
 
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big
     assert cover.read_bytes() == big
@@ -2417,7 +2457,7 @@ def test_per_track_artwork_never_promotes_one_track_to_the_album_cover(album_wit
     small = _sized_jpeg(400, 400)
     cover.write_bytes(small)
 
-    tagger.update_artwork(album_dir, _release_2_tracks(), cover)
+    _update_artwork(album_dir, _release_2_tracks(), cover)
 
     assert cover.read_bytes() == small
 
@@ -2435,7 +2475,7 @@ def test_a_promoted_cover_can_be_put_back(album_with_tracks, tmp_path):
     small = _sized_jpeg(400, 400)
     cover.write_bytes(small)
 
-    tagger.update_artwork(album_dir, _single_track_release(), cover)
+    _update_artwork(album_dir, _single_track_release(), cover)
     assert cover.read_bytes() == big  # promoted
 
     restored = tagger.restore_artwork(album_dir, {"cover.jpg": artwork_store.digest(small)})
@@ -2523,7 +2563,7 @@ def test_a_larger_archive_image_wins_and_is_written(album_with_tracks, tmp_path)
     release = _single_track_release()
     cover_art.cache_image(release["id"], theirs, "image/jpeg")
 
-    tagger.update_artwork(album_dir, release, cover)
+    _update_artwork(album_dir, release, cover)
 
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == theirs
     assert cover.read_bytes() == theirs
@@ -2546,7 +2586,7 @@ def test_a_smaller_archive_image_is_ignored(album_with_tracks, tmp_path):
     release = _single_track_release()
     cover_art.cache_image(release["id"], _sized_jpeg(400, 400), "image/jpeg")
 
-    tagger.update_artwork(album_dir, release, cover)
+    _update_artwork(album_dir, release, cover)
 
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == big
     assert cover.read_bytes() == big  # the album's own image still won
@@ -2593,26 +2633,27 @@ def test_a_larger_archive_image_wins_with_no_folder_cover(album_with_tracks, tmp
     release = _release_2_tracks()
     cover_art.cache_image(release["id"], theirs, "image/jpeg")
 
-    changed = tagger.update_artwork(album_dir, release, None)
+    changed = _update_artwork(album_dir, release, None)
 
-    assert changed == 2
+    assert changed == 3
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == theirs
     assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == theirs
-    # No cover.jpg is created. Writing a new file into the user's album dir is
-    # an additive behaviour of its own, and `promote_cover` asks for a strict
-    # improvement on a folder cover that is not there to be improved on.
-    assert not (album_dir / "cover.jpg").exists()
+    # …and the folder cover the album lacked is created from the same winner
+    # (#469): an addition like an artless track's, and the button's to make.
+    assert (album_dir / "cover.jpg").read_bytes() == theirs
     # What it replaced is recoverable. This album has no folder cover, so
     # everything overwritten here is EMBEDDED art — the half the store keeps —
     # which makes this the reversible case rather than #276's hazardous one.
     assert artwork_store.path_for(artwork_store.digest(mine)) is not None
     # …and pressing again finds the winner already everywhere.
-    assert tagger.update_artwork(album_dir, release, None) == 0
+    assert _update_artwork(album_dir, release, None) == 0
 
 
 def test_a_smaller_archive_image_is_ignored_with_no_folder_cover(album_with_tracks, tmp_path):
     """With no cover file the tracks' own image is the incumbent, and it keeps
-    the tie: a same-sized different picture is not an improvement."""
+    the tie: a same-sized different picture is not an improvement. It is also
+    what the missing folder cover is created from — the largest image the album
+    can offer, which here is its own."""
     from harmonist import artwork_store, cover_art
 
     artwork_store.configure(tmp_path / "artwork")
@@ -2623,8 +2664,9 @@ def test_a_smaller_archive_image_is_ignored_with_no_folder_cover(album_with_trac
     release = _single_track_release()
     cover_art.cache_image(release["id"], _sized_jpeg(1400, 1400) + b"_other", "image/jpeg")
 
-    assert tagger.update_artwork(album_dir, release, None) == 0
+    assert _update_artwork(album_dir, release, None) == 1
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == mine
+    assert (album_dir / "cover.jpg").read_bytes() == mine
 
 
 def test_per_track_artwork_survives_an_archive_cover_with_no_folder_cover(
@@ -2649,38 +2691,36 @@ def test_per_track_artwork_survives_an_archive_cover_with_no_folder_cover(
     _embed_cover(album_dir / "01 Track 1.m4a", first)
     _embed_cover(album_dir / "02 Track 2.m4a", second)
     release = _release_2_tracks()
-    cover_art.cache_image(release["id"], _sized_jpeg(3000, 3000), "image/jpeg")
+    archive = _sized_jpeg(3000, 3000)
+    cover_art.cache_image(release["id"], archive, "image/jpeg")
 
-    assert tagger.update_artwork(album_dir, release, None) == 0
+    # One write: the folder cover the album lacked, from the archive. The
+    # sleeves are user data and nothing overwrites them; a compilation's first
+    # sleeve is not the album's cover, but the archive's front cover is.
+    assert _update_artwork(album_dir, release, None) == 1
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == first
     assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == second
+    assert (album_dir / "cover.jpg").read_bytes() == archive
     # …and it is reported as the decision it is, rather than as nothing having
     # happened. This is the half the guard change actually moves.
-    plan = tagger.decide_artwork(sorted(album_dir.glob("*.m4a")), release, cover_path=None)
+    plan = tagger.decide_artwork(album_dir, sorted(album_dir.glob("*.m4a")), None)
     assert plan.preserves_per_track_art is True
 
 
-def test_a_coverless_album_with_no_candidate_still_reads_no_artwork(album_with_tracks, tmp_path):
-    """The gardener's path must not get more expensive (#442).
-
-    `plan_album` reaches `decide_artwork` for every album in the library, and
-    `_art_digests` opens every file. An album with no folder cover and no cached
-    archive image has nothing that could overwrite its tracks, so it is decided
-    without reading any of them — which is why the widened read is conditional
-    on there being a candidate rather than unconditional.
-    """
+def test_a_compilation_with_no_archive_cover_gets_no_folder_cover(album_with_tracks, tmp_path):
+    """Per-track artwork and nothing from outside: no image is the album's, so
+    none is written — not even into the folder, where the first sleeve would
+    claim to be the cover of a record it is one track of."""
     from harmonist import cover_art
 
     cover_art.configure_cache(tmp_path / "caa")  # configured, and empty
     album_dir = album_with_tracks(2)
     _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(500, 500))
+    _embed_cover(album_dir / "02 Track 2.m4a", _sized_jpeg(900, 900))
 
-    plan = tagger.decide_artwork(
-        sorted(album_dir.glob("*.m4a")), _release_2_tracks(), cover_path=None
-    )
-
-    assert plan.winner is None
-    assert plan.before == {}
+    assert _update_artwork(album_dir, _release_2_tracks(), None) == 0
+    tagger.tag_album(album_dir, _release_2_tracks())
+    assert cover_art.cached_cover(album_dir) is None
 
 
 def test_a_losing_archive_still_lets_the_albums_own_art_fill_a_gap(album_with_tracks, tmp_path):
@@ -2705,3 +2745,188 @@ def test_a_losing_archive_still_lets_the_albums_own_art_fill_a_gap(album_with_tr
 
     assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == mine
     assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == mine
+
+
+# ---------- the folder cover, created from the plan (#457, #469) ----------
+
+
+def _audit(prefix: str) -> list:
+    from harmonist import activity_store
+    from harmonist.activity_store import Source
+
+    return [
+        e for e in activity_store.recent(200, source=Source.AUDIT) if e.message.startswith(prefix)
+    ]
+
+
+def test_a_first_tagging_creates_the_folder_cover_from_the_albums_own_image(
+    album_with_tracks, tmp_path, monkeypatch
+):
+    """The shape a Bandcamp download arrives in: art embedded, no `cover.jpg`.
+    The cover is created from the winner of the size rule, like every other
+    image a tagging writes — the album's own here, with nothing from the
+    archive — and recorded as the addition it is."""
+    from harmonist import activity_store, cover_art, id_registry, images
+
+    activity_store.init(tmp_path / "audit.db")
+    monkeypatch.setattr(cover_art, "_caa_root", None)
+    album_dir = album_with_tracks(2)
+    mine = _sized_jpeg(800, 800)
+    _embed_cover(album_dir / "01 Track 1.m4a", mine)
+
+    tagger.tag_album(album_dir, _release_2_tracks())
+
+    assert (album_dir / "cover.jpg").read_bytes() == mine
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == mine  # the gap
+    digest = images.digest(mine)
+    [write] = _audit("cover.write")
+    assert "overwrote=False" in write.message
+    assert f"digest={digest}" in write.message
+    # Under the id the album answers to before any sidecar names it (#456).
+    assert write.album_id == id_registry.peek(album_dir)
+    # …and in the shape History renders and the artwork Undo reads: the image
+    # added, and the absence it was added to.
+    [line] = [e for e in _audit("tag.track") if "file=cover.jpg" in e.message]
+    detail = activity_store.tag_changes_for([line.id])[line.id]
+    assert detail.changes == {owned.ARTWORK: [None, digest]}
+
+    # A second tagging finds the cover there and writes nothing more.
+    tagger.tag_album(album_dir, _release_2_tracks())
+    assert len(_audit("cover.write")) == 1
+
+
+def test_a_larger_archive_image_becomes_the_created_cover(album_with_tracks, tmp_path, monkeypatch):
+    """What a tagging fetched from the archive is a candidate, not the folder
+    cover by right: it lands because it is the largest image on offer. The track
+    that already has art keeps it — a tagging replaces nothing (#418)."""
+    from harmonist import activity_store, cover_art
+
+    activity_store.init(tmp_path / "audit.db")
+    monkeypatch.setattr(cover_art, "_caa_root", None)
+    album_dir = album_with_tracks(2)
+    mine = _sized_jpeg(800, 800)
+    _embed_cover(album_dir / "01 Track 1.m4a", mine)
+    theirs = _sized_jpeg(3000, 3000)
+
+    tagger.tag_album(album_dir, _release_2_tracks(), archive=cover_art.Front(theirs, "image/jpeg"))
+
+    assert (album_dir / "cover.jpg").read_bytes() == theirs
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == mine
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == theirs
+
+
+def test_a_smaller_archive_image_does_not_become_the_created_cover(
+    album_with_tracks, tmp_path, monkeypatch
+):
+    """The ladder this replaced took the archive first whatever its size, and
+    gave an album with a 3000px image in its tracks a 1200px `cover.jpg` — which
+    the album page then offered to replace (#457)."""
+    from harmonist import activity_store, cover_art
+
+    activity_store.init(tmp_path / "audit.db")
+    monkeypatch.setattr(cover_art, "_caa_root", None)
+    album_dir = album_with_tracks(1)
+    mine = _sized_jpeg(3000, 3000)
+    _embed_cover(album_dir / "01 Track 1.m4a", mine)
+
+    tagger.tag_album(
+        album_dir,
+        _single_track_release(),
+        archive=cover_art.Front(_sized_jpeg(1200, 1200), "image/jpeg"),
+    )
+
+    assert (album_dir / "cover.jpg").read_bytes() == mine
+
+
+def test_a_tagging_writes_no_artwork_its_preview_did_not_show(
+    album_with_tracks, tmp_path, monkeypatch, caplog
+):
+    """Re-tag carries the page's fingerprint of what it would add. A plan that
+    no longer matches it — the album changed after the page was drawn — tags the
+    album and writes no image at all, and says so (#469)."""
+    import logging
+
+    from harmonist import activity_store, artwork, cover_art
+
+    activity_store.init(tmp_path / "audit.db")
+    monkeypatch.setattr(cover_art, "_caa_root", None)
+    album_dir = album_with_tracks(2)
+    _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(800, 800))
+    files = sorted(album_dir.glob("*.m4a"))
+    shown = tagger.decide_artwork(album_dir, files, None).fingerprint(artwork.Scope.ADDITIONS)
+    # …and then the image the page showed is swapped for another.
+    _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(900, 900))
+
+    with caplog.at_level(logging.WARNING, logger="harmonist"):
+        tagger.tag_album(album_dir, _release_2_tracks(), expected_artwork=shown)
+
+    assert not (album_dir / "cover.jpg").exists()
+    assert ATOM_COVER not in MP4(album_dir / "02 Track 2.m4a")
+    # The tags are the point, and they were written.
+    assert (
+        MP4(album_dir / "02 Track 2.m4a")[ATOM_MB_ALBUM_ID][0].decode()
+        == (_release_2_tracks()["id"])
+    )
+    assert "changed after the page showed it" in caplog.text
+
+
+def test_a_tagging_writes_the_artwork_its_preview_showed(album_with_tracks, tmp_path, monkeypatch):
+    """The same check passing — without this, a mutation that withheld every
+    page-driven tagging's artwork would go unnoticed."""
+    from harmonist import activity_store, artwork, cover_art
+
+    activity_store.init(tmp_path / "audit.db")
+    monkeypatch.setattr(cover_art, "_caa_root", None)
+    album_dir = album_with_tracks(2)
+    mine = _sized_jpeg(800, 800)
+    _embed_cover(album_dir / "01 Track 1.m4a", mine)
+    files = sorted(album_dir.glob("*.m4a"))
+    shown = tagger.decide_artwork(album_dir, files, None).fingerprint(artwork.Scope.ADDITIONS)
+
+    tagger.tag_album(album_dir, _release_2_tracks(), expected_artwork=shown)
+
+    assert (album_dir / "cover.jpg").read_bytes() == mine
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == mine
+
+
+def test_the_artwork_action_leaves_an_image_changed_since_its_plan(album_with_tracks, tmp_path):
+    """Every target is re-read before it is written. An edit made between the
+    plan and the write stands, and is named in the outcome (#469)."""
+    from harmonist import activity_store, artwork_store
+
+    activity_store.init(tmp_path / "audit.db")
+    artwork_store.configure(tmp_path / "artwork")
+    album_dir = album_with_tracks(2)
+    _embed_cover(album_dir / "01 Track 1.m4a", _sized_jpeg(400, 400))  # track 2 has none
+    cover = album_dir / "cover.jpg"
+    cover.write_bytes(_sized_jpeg(1400, 1400))
+    files = sorted(album_dir.glob("*.m4a"))
+    plan = tagger.decide_artwork(album_dir, files, cover)
+    theirs = _sized_jpeg(400, 400) + b"_edited_since"
+    _embed_cover(album_dir / "01 Track 1.m4a", theirs)
+
+    outcome = tagger.apply_artwork(album_dir, plan, files=files, cover_path=cover)
+
+    assert outcome.stale == ("01 Track 1.m4a",)
+    assert outcome.changed == 1
+    assert bytes(MP4(album_dir / "01 Track 1.m4a")[ATOM_COVER][0]) == theirs
+    assert bytes(MP4(album_dir / "02 Track 2.m4a")[ATOM_COVER][0]) == cover.read_bytes()
+
+
+def test_the_artwork_action_refuses_a_winner_that_has_moved(album_with_tracks, tmp_path):
+    """The plan names an image by digest. If the file it was found in now holds
+    something else, nothing is written — the preview described the old one."""
+    from harmonist import activity_store
+
+    activity_store.init(tmp_path / "audit.db")
+    album_dir = album_with_tracks(1)
+    cover = album_dir / "cover.jpg"
+    cover.write_bytes(_sized_jpeg(1400, 1400))
+    files = sorted(album_dir.glob("*.m4a"))
+    plan = tagger.decide_artwork(album_dir, files, cover)
+    cover.write_bytes(_sized_jpeg(1400, 1400) + b"_swapped")
+
+    with pytest.raises(tagger.ArtworkChangedError):
+        tagger.apply_artwork(album_dir, plan, files=files, cover_path=cover)
+
+    assert ATOM_COVER not in MP4(files[0])

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -1774,7 +1774,7 @@ def test_manual_assign_with_full_url(client, cfg, monkeypatch):
         return _release_for_match(mbid, n_tracks=1)
 
     monkeypatch.setattr("harmonist.mb_lookup.fetch_release", fake_fetch)
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     r = client.post(
         f"/manual/{aid}/assign",
@@ -1795,7 +1795,7 @@ def test_manual_assign_with_bare_mbid(client, cfg, monkeypatch):
         "harmonist.mb_lookup.fetch_release",
         lambda mbid: _release_for_match(mbid, n_tracks=1),
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     r = client.post(
         f"/manual/{aid}/assign",
@@ -1828,7 +1828,7 @@ def test_manual_assign_derives_store_url_from_embedded_comment(client, cfg, monk
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda m: _release_for_match(m, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     def no_urls(_m):
         raise AssertionError("MB url-rels must not be queried when ©cmt has a precise URL")
@@ -1850,7 +1850,7 @@ def test_manual_assign_falls_back_to_mb_url_when_comment_is_root(client, cfg, mo
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda m: _release_for_match(m, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release_urls",
         lambda _m: ["https://artist.bandcamp.com/album/canonical"],
@@ -1872,7 +1872,7 @@ def test_manual_assign_uses_artist_root_placeholder_when_no_mb_url(client, cfg, 
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda m: _release_for_match(m, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     monkeypatch.setattr("harmonist.mb_lookup.fetch_release_urls", lambda _m: [])
 
     r = client.post(f"/manual/{aid}/assign", data={"mbid": _ASSIGN_MBID})
@@ -1888,7 +1888,7 @@ def test_manual_assign_store_url_derivation_error_is_swallowed(client, cfg, monk
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda m: _release_for_match(m, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     def boom(*a, **kw):
         raise RuntimeError("derivation failed")
@@ -3307,7 +3307,7 @@ def test_retag_re_runs_tagger(client, cfg, monkeypatch):
         "harmonist.mb_lookup.fetch_release",
         lambda mbid: _release_for_match(mbid, n_tracks=1),
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     aid = _id_for(cfg, d)
     r = client.post(f"/retag/{aid}")
@@ -3340,7 +3340,7 @@ def test_retag_proceeds_when_the_cover_art_archive_is_unreachable(client, cfg, m
     def down(*a, **kw):
         raise CoverArtError("CAA returned status 503 for https://coverartarchive.org/…/front")
 
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", down)
+    monkeypatch.setattr("harmonist.cover_art.front_image", down)
 
     r = client.post(f"/retag/{_id_for(cfg, d)}")
     assert r.status_code == 200
@@ -3360,7 +3360,7 @@ def test_retag_proceeds_when_the_cover_art_archive_is_unreachable(client, cfg, m
     # entry used to arrive beside an automatic copy of the `log.exception` —
     # carrying a raw absolute path and no album, which is the one of the two a
     # reader would have found least useful.
-    unavailable = [e for e in activity.recent(20) if "over art unavailable" in e.message]
+    unavailable = [e for e in activity.recent(20) if "Archive unavailable" in e.message]
     assert len(unavailable) == 1, [e.message for e in unavailable]
     assert unavailable[0].level == "warning"
     assert unavailable[0].album_id, "attributed, so it reaches the album's History"
@@ -3386,7 +3386,7 @@ def test_retagging_with_the_archive_down_stays_a_no_op_the_second_time(client, c
     def down(*a, **kw):
         raise CoverArtError("CAA returned status 503")
 
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", down)
+    monkeypatch.setattr("harmonist.cover_art.front_image", down)
 
     def track_writes() -> int:
         return len(
@@ -3411,7 +3411,7 @@ def test_retag_works_on_an_album_confirmed_as_incomplete(client, cfg, monkeypatc
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=4)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     r = client.post(f"/retag/{_id_for(cfg, d)}")
     assert r.status_code == 200
@@ -3433,7 +3433,7 @@ def test_retag_still_refuses_an_unconfirmed_short_album(client, cfg, monkeypatch
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=4)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     r = client.post(f"/retag/{_id_for(cfg, d)}")
     assert "Re-tagged" not in r.text
@@ -3460,7 +3460,7 @@ def test_retag_offers_incomplete_when_mb_has_grown_tracks(client, cfg, monkeypat
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=3)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     aid = _id_for(cfg, d)
 
     r = client.post(f"/retag/{aid}")
@@ -3494,7 +3494,7 @@ def test_retag_as_incomplete_takes_the_grown_releases_tags(client, cfg, monkeypa
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=3)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     r = client.post(f"/retag/{_id_for(cfg, d)}", data={"accept_short": "true"})
     assert r.status_code == 200
@@ -3524,7 +3524,7 @@ def test_retag_reports_extra_files_as_a_failure_with_no_way_out(client, cfg, mon
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     r = client.post(f"/retag/{_id_for(cfg, d)}")
     assert "Re-tag failed" in r.text
@@ -3544,7 +3544,7 @@ def test_album_action_records_activity_against_that_album(client, cfg, monkeypat
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     activity_store.clear()
 
     r = client.post(f"/retag/{aid}")
@@ -3601,7 +3601,7 @@ def test_status_bar_payload_carries_the_album_name(client, cfg, monkeypatch):
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     r = client.post(f"/retag/{aid}")
     payload = _json.loads(r.headers["HX-Trigger"])["harmonist-status"]
@@ -3723,20 +3723,19 @@ def test_activity_shows_album_label_even_when_link_is_dead(client, cfg):
     assert 'href="/album/' not in body  # ...but not a link
 
 
-def test_a_cover_written_before_tagging_reaches_the_albums_history(client, cfg, monkeypatch):
+def test_a_cover_created_by_a_first_tagging_reaches_the_albums_history(client, cfg, monkeypatch):
     """#456, end to end and in the order it really happens.
 
-    The cover is fetched BEFORE the tagging that renames the album, so the row is
-    written under the temp_uid and the album answers to the MBID by the time
-    anyone looks. Both halves have to hold for the user to find it: the record
-    must carry an id at all, and the alias chain must carry that id forward.
+    The cover is created by the same tagging that renames the album (#469), and
+    its record is written under the id the album had when that tagging started —
+    the temp_uid — while the album answers to the MBID by the time anyone looks.
+    Both halves have to hold for the user to find it: the record must carry an
+    id at all, and the alias chain must carry that id forward.
 
     The identity genuinely moves here — asserted, because a fixture whose id
     never changed would pass this with the fix reverted, which is exactly how
     #65's first regression test managed to prove nothing.
     """
-    import httpx
-
     from harmonist import cover_art
 
     d = _make_album(cfg, "CoverThenTag")
@@ -3752,26 +3751,21 @@ def test_a_cover_written_before_tagging_reaches_the_albums_history(client, cfg, 
     old_id = _id_for(cfg, d)
     activity_store.clear()
 
-    # The cover lands first, under whatever the album is called right now.
-    cover_art.ensure_cover(
-        d,
-        "rel-cover",
-        client=httpx.Client(
-            transport=httpx.MockTransport(
-                lambda req: httpx.Response(
-                    200, content=b"COVERBYTES", headers={"content-type": "image/jpeg"}
-                )
-            ),
-            follow_redirects=True,
-        ),
+    # The archive has a cover for the release, and the album has no folder
+    # cover — so the tagging creates one, under whatever the album is called
+    # at the moment it starts.
+    monkeypatch.setattr(
+        "harmonist.cover_art.front_image",
+        lambda *a, **kw: cover_art.Front(data=b"COVERBYTES", mime="image/jpeg"),
     )
-    assert (d / "cover.jpg").exists()
+    assert not (d / "cover.jpg").exists()
 
     # Confirming tags it: temp_uid is dropped for the MBID and the old id dies.
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
     )
     assert client.post(f"/confirm/{old_id}").status_code == 200
+    assert (d / "cover.jpg").read_bytes() == b"COVERBYTES"
     new_id = _id_for(cfg, d)
     assert new_id != old_id, "the identity has to move, or this proves nothing"
 
@@ -4522,7 +4516,7 @@ def test_action_records_an_id_that_still_resolves_after_tagging(client, cfg, mon
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     activity.clear()
 
     # Confirming TAGS it: temp_uid is dropped, the id becomes the MBID.
@@ -4615,7 +4609,7 @@ def test_post_sync_auto_tag_entry_links_to_the_album(cfg, monkeypatch):
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     activity.clear()
 
     assert _resolve_by_store_url(d, cfg, PicardCompatibleTagger()) == "tagged"
@@ -4641,7 +4635,7 @@ def test_a_download_matching_two_editions_equally_is_not_tagged_as_either(cfg, m
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     tagged_as = []
     for order in (["rel-ed-a", "rel-ed-b"], ["rel-ed-b", "rel-ed-a"]):
@@ -4744,7 +4738,7 @@ def test_retag_emits_album_retagged_trigger(client, cfg, monkeypatch):
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     r = client.post(f"/retag/{_id_for(cfg, d)}")
     assert r.status_code == 200
     assert "album-retagged" in r.headers.get("HX-Trigger", "")
@@ -4870,7 +4864,7 @@ def test_retag_recomputes_count_and_promotes_incomplete_to_complete(client, cfg,
         "harmonist.mb_lookup.fetch_release",
         lambda mbid: _release_for_match(mbid, n_tracks=1),
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     r = client.post(f"/retag/{_id_for(cfg, d)}")
     assert r.status_code == 200
@@ -5107,7 +5101,7 @@ def test_confirm_incomplete_tags_and_persists_expected_count(client, cfg, monkey
         }
 
     monkeypatch.setattr("harmonist.mb_lookup.fetch_release", fake_release)
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     aid = _id_for(cfg, d)
     r = client.post(f"/confirm/{aid}/incomplete")
@@ -5154,7 +5148,7 @@ def test_confirm_mistag_adopts_owned_store_url(client, cfg, monkeypatch):
         "harmonist.mb_lookup.fetch_release",
         lambda mbid: _release_for_match(mbid, n_tracks=1),
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     aid = _id_for(cfg, d)
     r = client.post(f"/confirm/{aid}")
@@ -5185,7 +5179,7 @@ def test_confirm_normal_candidate_keeps_store_url(client, cfg, monkeypatch):
         "harmonist.mb_lookup.fetch_release",
         lambda mbid: _release_for_match(mbid, n_tracks=1),
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     aid = _id_for(cfg, d)
     client.post(f"/confirm/{aid}")
     assert sc.read(d).store_url == "https://x.bandcamp.com/album/keep-me"
@@ -5306,7 +5300,7 @@ def test_canonical_id_change_mid_transaction(client, cfg, monkeypatch):
         "harmonist.mb_lookup.fetch_release",
         lambda mbid: _release_for_match(mbid, n_tracks=1),
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
     # POST at the temp_uid URL — runs the handler, returns 200
     r = client.post(f"/manual/{temp_uid}/assign", data={"mbid": mbid})
@@ -5584,7 +5578,6 @@ def test_settings_save_persists_and_applies_live(client, cfg):
             "download_format": "alac",
             "max_downloads_per_sync": "12",
             "user_agent": "Harmonist/9.9 ( me@example.com )",
-            "cover_art_size": "500",
             "gardener_level": "review",
             "log_level": "warning",
         },
@@ -5595,7 +5588,6 @@ def test_settings_save_persists_and_applies_live(client, cfg):
     live = client.app.state.cfg
     assert live.bandcamp.download_format == "alac"
     assert live.bandcamp.max_downloads_per_sync == 12
-    assert live.cover_art.size == "500"
     assert live.gardener.level == "review"
     assert live.log_level == "warning"
     # Persisted to harmonist.toml (round-trips on next load)
@@ -5603,24 +5595,6 @@ def test_settings_save_persists_and_applies_live(client, cfg):
     assert "alac" in toml
     assert "max_downloads_per_sync = 12" in toml
     assert 'level = "review"' in toml
-
-
-def test_settings_save_rejects_invalid_cover_size(client, cfg):
-    r = client.post(
-        "/settings",
-        data={
-            "download_format": "flac",
-            "max_downloads_per_sync": "5",
-            "user_agent": "Harmonist/0.1 ( x@y.z )",
-            "cover_art_size": "999",  # not a valid Literal
-            "gardener_level": "off",
-            "log_level": "info",
-        },
-    )
-    assert r.status_code == 200
-    assert "Couldn't save" in r.text
-    # nothing persisted
-    assert not (cfg.paths.config_dir / "harmonist.toml").exists()
 
 
 def test_settings_save_rejects_an_unknown_gardener_level(client, cfg):
@@ -5634,7 +5608,6 @@ def test_settings_save_rejects_an_unknown_gardener_level(client, cfg):
             "download_format": "flac",
             "max_downloads_per_sync": "5",
             "user_agent": "Harmonist/0.1 ( x@y.z )",
-            "cover_art_size": "original",
             "gardener_level": "enrich",  # #273's level, not implemented yet
             "log_level": "info",
         },
@@ -7602,7 +7575,7 @@ def test_request_scope_correlates_the_action_with_its_audit_records(client, cfg,
     monkeypatch.setattr(
         "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=1)
     )
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
     activity.clear()
 
     assert client.post(f"/confirm/{aid}").status_code == 200
@@ -8567,7 +8540,7 @@ def test_a_replacement_musicbrainz_cannot_match_lands_in_the_inbox_not_the_libra
 def no_cover_fetch(monkeypatch):
     """Tagging embeds cover art, which would otherwise reach the real Cover Art
     Archive over the network for every release id these tests invent."""
-    monkeypatch.setattr("harmonist.cover_art.ensure_cover", lambda *a, **kw: None)
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
 
 
 def _resolve_the_download(cfg, album_dir: Path) -> str:
@@ -8996,28 +8969,31 @@ def test_artwork_section_names_the_tracks_missing_art(client, cfg):
     rendered = " ".join(r.text.split())
     # The incoming half names its source and dates itself, so "replaced" cannot
     # be read as something that already happened (#413).
-    assert "After a re-tag" in rendered
+    assert "After Apply" in rendered
     assert "the album&#39;s own artwork" in rendered
 
 
-def test_artwork_section_says_a_folder_cover_is_about_to_be_created(client, cfg):
-    """#457: a re-tag writes a cover.jpg into an album that hasn't got one —
-    mandatory for Navidrome, so it happens whether or not anyone pressed
-    anything about artwork. The section said nothing, and a 3 MB image appearing
-    in a music folder read as Harmonist acting unasked."""
+def test_artwork_section_shows_the_folder_cover_it_would_create(client, cfg):
+    """#457: a cover file gets written into an album that hasn't got one, and
+    the section said nothing — a 3 MB image appearing in a music folder read as
+    Harmonist acting unasked.
+
+    It is a ROW now (#467): an empty frame for the file that is not there, and
+    beside it the image that will be. And the section's own button creates it
+    (#469), so the button is offered — it used to be withheld because it could
+    not make the file its row would have promised."""
     art = _png(1)
     d = _album_with_art(cfg, "NoFolderCover", covers=[art, art])  # no `folder=`
 
     rendered = " ".join(client.get(f"/album/{_id_for(cfg, d)}/artwork").text.split())
 
-    # Attributed to RE-TAGGING, not to the artwork button beside it, which
-    # cannot create this file at all.
-    assert "This album has no" in rendered
-    assert "Re-tagging creates one from" in rendered
-    # ...and that button stays off: nothing about the album's existing images
-    # changes, so offering the control would promise the sentence's outcome from
-    # a button that does not produce it.
-    assert "Update artwork" not in rendered
+    # Named for the image it will hold: the tracks' own art is a PNG.
+    assert "not in the folder yet" in rendered
+    assert "There is no cover.png." in rendered
+    assert "the album&#39;s own artwork" in rendered
+    assert "Apply artwork" in rendered
+    # An addition, and labelled as one.
+    assert "Addition" in rendered
 
 
 def test_artwork_section_does_not_announce_a_cover_the_album_already_has(client, cfg):
@@ -9044,7 +9020,7 @@ def test_artwork_section_promises_no_overwrite_where_art_is_preserved(client, cf
     assert "Track 1" in r.text
     assert "Replaced" not in r.text
     assert "Left as is" not in r.text
-    assert "After a re-tag" not in r.text
+    assert "After Apply" not in r.text
 
 
 def test_artwork_images_are_served_by_digest(client, cfg):
@@ -9097,8 +9073,125 @@ def test_the_artwork_action_is_offered_only_when_something_would_change(client, 
     quiet = client.get(f"/album/{_id_for(cfg, settled)}/artwork")
     offered = client.get(f"/album/{_id_for(cfg, improvable)}/artwork")
 
-    assert "Update artwork" not in quiet.text
-    assert "Update artwork" in offered.text
+    assert "Apply artwork" not in quiet.text
+    assert "Apply artwork" in offered.text
+
+
+# ---------- one plan for the page and the writers (#469) ----------
+
+
+def _form_value(html: str, name: str) -> str:
+    """The value of the hidden input named `name` — a fingerprint."""
+    import re
+
+    match = re.search(rf'name="{name}"\s+value="([0-9a-f]*)"', html)
+    assert match, f"no {name} input in the response"
+    return match.group(1)
+
+
+def _release_backed_album_with_art(cfg, name: str, mbid: str, **kw) -> Path:
+    """`_album_with_art`, with a sidecar naming a release so it can be re-tagged."""
+    from harmonist.models import Sidecar
+
+    d = _album_with_art(cfg, name, **kw)
+    sc.write(d, Sidecar(mb_release_id=mbid))
+    return d
+
+
+def test_the_page_and_the_tagger_fingerprint_one_plan_alike(client, cfg):
+    """Re-tag carries the page's fingerprint back, and the tagger compares it
+    with its own. The two must spell one plan identically — read through the
+    album on one side and through the file list on the other — or every re-tag
+    pressed from a page would withhold its artwork."""
+    from harmonist import artwork, tagger
+
+    d = _album_with_art(cfg, "Agreed", covers=[_png(1), None])
+
+    html = client.get(f"/album/{_id_for(cfg, d)}/artwork").text
+
+    plan = tagger.decide_artwork(d, sorted(d.glob("*.m4a")), None)
+    assert _form_value(html, "art_plan") == plan.fingerprint(artwork.Scope.ADDITIONS)
+    assert _form_value(html, "plan") == plan.fingerprint(artwork.Scope.ALL)
+
+
+def test_retag_writes_the_artwork_the_page_showed(client, cfg, monkeypatch):
+    from harmonist import formats
+
+    art = _png(1)
+    d = _release_backed_album_with_art(cfg, "Shown", "rel-shown", covers=[art, None])
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=2)
+    )
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
+    aid = _id_for(cfg, d)
+    shown = _form_value(client.get(f"/album/{aid}/artwork").text, "art_plan")
+
+    r = client.post(f"/retag/{aid}", data={"art_plan": shown})
+
+    assert "Re-tagged" in r.text
+    assert (d / "cover.png").read_bytes() == art
+    cover = formats.read_cover(d / "02 Track.m4a")
+    assert cover is not None and cover[0] == art
+
+
+def test_retag_writes_no_artwork_the_page_did_not_show(client, cfg, monkeypatch):
+    """The page was drawn from an album that has changed since: tags go on,
+    no image does, and the album's History says why (#469)."""
+    from harmonist import formats
+
+    d = _release_backed_album_with_art(cfg, "Unshown", "rel-unshown", covers=[_png(1), None])
+    monkeypatch.setattr(
+        "harmonist.mb_lookup.fetch_release", lambda mbid: _release_for_match(mbid, n_tracks=2)
+    )
+    monkeypatch.setattr("harmonist.cover_art.front_image", lambda *a, **kw: None)
+
+    r = client.post(f"/retag/{_id_for(cfg, d)}", data={"art_plan": "0" * 64})
+
+    assert "Re-tagged" in r.text
+    assert not list(d.glob("cover.*"))
+    assert formats.read_cover(d / "02 Track.m4a") is None
+    assert any("changed after the page showed it" in e.message for e in activity.recent(20))
+
+
+def test_apply_artwork_writes_only_what_the_page_showed(client, cfg):
+    """The button carries the fingerprint of the column it sits under. A
+    mismatch — or none at all — writes nothing and re-draws the section; the
+    fingerprint the page really showed writes exactly that."""
+    from harmonist import formats
+
+    art = _png(1)
+    d = _album_with_art(cfg, "Button", covers=[art, None])
+    aid = _id_for(cfg, d)
+
+    stale = client.post(f"/album/{aid}/artwork/update", data={"plan": "0" * 64})
+    assert "changed after the page showed it" in " ".join(stale.text.split())
+    client.post(f"/album/{aid}/artwork/update")
+    assert not list(d.glob("cover.*"))
+    assert formats.read_cover(d / "02 Track.m4a") is None
+
+    shown = _form_value(client.get(f"/album/{aid}/artwork").text, "plan")
+    client.post(f"/album/{aid}/artwork/update", data={"plan": shown})
+
+    assert (d / "cover.png").read_bytes() == art
+    cover = formats.read_cover(d / "02 Track.m4a")
+    assert cover is not None and cover[0] == art
+
+
+def test_the_archive_check_downloads_any_cover_for_an_album_with_no_art(client, cfg, monkeypatch):
+    """A preview of an addition has to show the picture it adds (#469). The
+    check downloads only an image wider than the album's widest — and an album
+    with no image has no width, so it used to download nothing."""
+    d = _release_backed_album_with_art(cfg, "Artless", "rel-artless", covers=[None, None])
+    seen: list[int | None] = []
+
+    def front(mbid, **kw):
+        seen.append(kw.get("keep_if_wider_than"))
+
+    monkeypatch.setattr("harmonist.caa_cache.front", front)
+
+    client.get(f"/album/{_id_for(cfg, d)}/artwork?check=1")
+
+    assert seen == [0]
 
 
 def test_the_artwork_action_writes_artwork_and_not_tags(client, cfg):
@@ -9221,11 +9314,11 @@ def test_a_losing_archive_cover_sits_in_the_incoming_column(client, cfg):
     rendered = " ".join(client.get(f"/album/{_id_for(cfg, d)}/artwork").text.split())
     muted = rendered[rendered.index("art-rows--muted") :]
 
-    # The incoming column, under a heading that is not the promise "After a
-    # re-tag" makes.
+    # The incoming column, under a heading that is not the promise "After
+    # Apply" makes.
     assert "art-row__side--after" in muted
     assert "Also considered" in muted
-    assert "After a re-tag" not in muted
+    assert "After Apply" not in muted
     # Neither mark: both say "this is what would be put on your files", and a
     # winning archive cover carries both — see
     # `test_a_winning_archive_cover_is_marked_as_the_one_being_written`.
@@ -9268,7 +9361,7 @@ def test_a_winning_archive_cover_is_marked_as_the_one_being_written(client, cfg)
     assert "art-rows--muted" not in rendered  # it won, so it is not an also-ran
     assert "art-row__facts--mb" in rendered
     assert "From the Cover Art Archive" in rendered  # the hexagon's label
-    assert "Update artwork" in rendered
+    assert "Apply artwork" in rendered
 
 
 def test_an_archive_with_nothing_gets_its_own_placeholder(client, cfg):
@@ -9507,7 +9600,7 @@ def test_loading_the_archives_cover_does_not_make_it_the_winner(client, cfg, mon
 
     assert "art-rows--muted" in rendered  # still an also-ran
     assert "mb-mark" not in rendered  # and still unmarked
-    assert "Update artwork" not in rendered  # nothing to write
+    assert "Apply artwork" not in rendered  # nothing to write
 
 
 def test_a_failed_load_of_the_archives_cover_says_so(client, cfg, monkeypatch):


### PR DESCRIPTION
First slice of #468: the shared artwork plan (#469) and the display that reads it (#467).

One artwork plan now names every write that puts the winning image in place — each target, what it holds now (or that it holds nothing), and what it will hold. The album page draws its Artwork rows from it; a tagging and the section's button execute it. The page used to carry its own copy of the size rule, and the two had drifted.

## Changes

- **Folder-cover creation moves inside the plan.** `cover_art.ensure_cover` wrote into the album before tagging had decided anything. The archive's image is now a candidate fetched into the cache (`front_image`), and a missing cover is created from whichever image wins on size.
- **A missing cover is a row**, and **Apply artwork** (was *Update artwork*) creates it. Artwork is labelled **Addition / Replacement**; only a Replacement confirms. `Significance.COVER_ART` is retired from the tag scale.
- **Writes only what the page showed.** Forms carry a fingerprint of the plan; Apply artwork writes nothing on a mismatch, and a re-tag writes its tags and no artwork (with a History warning). Each target is re-read before it is written.
- A created cover is recorded as an artwork change `[None, digest]` (groundwork for #471); History names `cover.jpg` instead of counting it as a track.
- The page's archive check downloads any cover for an album with no art, so the preview can show it.
- The `[cover_art] size` setting (and its Settings control) is removed; the original is always used.
- A tagging no longer backs up images it does not overwrite.
- `tagger.update_artwork` removed — no production caller once the button applies the page's plan.

## Judgment calls

- A compilation (per-track art) gets a folder cover only from the archive; with no archive image, none is created.
- Addition undo is not offered yet (#471).

## Verification

- `make check` green; full e2e suite run locally (36 passed) — CI does not run it.
- New tests mutation-checked, including two new browser tests (`test/e2e/test_artwork_apply.py`) for the `hx-include`d fingerprint and the Apply form.
- Also fixes `test_every_row_reaches_its_own_image`, which was already failing on `main`.

Fixes #469
Fixes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)